### PR TITLE
Small changes.

### DIFF
--- a/sailfish/src/consensus.rs
+++ b/sailfish/src/consensus.rs
@@ -97,7 +97,7 @@ impl Consensus {
     }
 
     #[cfg(feature = "test")]
-    pub fn committe(&self) -> &StaticCommittee {
+    pub fn committee(&self) -> &StaticCommittee {
         &self.committee
     }
 
@@ -148,7 +148,8 @@ impl Consensus {
         buffered  = %self.buffer.len(),
         delivered = %self.delivered.len(),
         leaders   = %self.leader_stack.len(),
-        timeouts  = %self.timeouts.len())
+        timeouts  = %self.timeouts.len(),
+        dag       = %self.dag.depth())
     )]
     pub fn handle_message(&mut self, m: Message) -> Vec<Action> {
         match m {
@@ -287,7 +288,7 @@ impl Consensus {
         }
 
         // certificate is formed when we have 2f + 1 votes added to accumulator
-        if self.no_votes.certificate().is_some() {
+        if let Some(nc) = self.no_votes.certificate().cloned() {
             // we need to reset round timer and broadcast vertex with timeout certificate and no vote certificate
             let Some(tc) = self
                 .timeouts
@@ -304,7 +305,7 @@ impl Consensus {
                 return actions;
             };
 
-            actions.extend(self.advance_leader_with_no_vote_certificate(round, tc));
+            actions.extend(self.advance_leader_with_no_vote_certificate(round, tc, nc));
         }
 
         actions
@@ -447,20 +448,22 @@ impl Consensus {
 
         // As leader of the next round we need to wait for > 2f no-votes of the current round
         // since we have no leader vertex.
-        actions.extend(self.advance_leader_with_no_vote_certificate(round, tc));
-        actions
-    }
-
-    fn advance_leader_with_no_vote_certificate(
-        &mut self,
-        round: RoundNumber,
-        tc: Certificate<Timeout>,
-    ) -> Vec<Action> {
-        let mut actions = Vec::new();
         let Some(nc) = self.no_votes.certificate().cloned() else {
             return actions;
         };
 
+        actions.extend(self.advance_leader_with_no_vote_certificate(round, tc, nc));
+        actions
+    }
+
+    #[instrument(level = "trace", skip(self, tc, nc), fields(node = %self.id, round = %self.round))]
+    fn advance_leader_with_no_vote_certificate(
+        &mut self,
+        round: RoundNumber,
+        tc: Certificate<Timeout>,
+        nc: Certificate<NoVote>,
+    ) -> Vec<Action> {
+        let mut actions = Vec::new();
         self.round = round + 1;
         actions.push(Action::ResetTimer(self.round));
         let NewVertex(mut v) = self.create_new_vertex(self.round);
@@ -471,7 +474,7 @@ impl Consensus {
     }
 
     /// Add a new vertex to the DAG and send it as a proposal to nodes.
-    #[instrument(level = "trace", skip(self), fields(node = %self.id, round = %self.round))]
+    #[instrument(level = "trace", skip_all, fields(node = %self.id, round = %self.round, vround = %v.round()))]
     fn add_and_broadcast_vertex(&mut self, v: Vertex) -> Vec<Action> {
         self.dag.add(v.clone());
         let mut actions = Vec::new();
@@ -535,7 +538,7 @@ impl Consensus {
             return Ok(Vec::new());
         }
 
-        if self.dag.vertices(v.round()).count() as u64 >= self.committee.success_threshold().get() {
+        if self.dag.vertex_count(v.round()) as u64 >= self.committee.success_threshold().get() {
             // We have enough edges => try to commit the leader vertex:
             let Some(l) = self.leader_vertex(v.round() - 1).cloned() else {
                 debug!(

--- a/sailfish/src/consensus/dag.rs
+++ b/sailfish/src/consensus/dag.rs
@@ -26,6 +26,10 @@ impl Dag {
         self.elements.entry(r).or_default().insert(*s, v);
     }
 
+    pub fn depth(&self) -> usize {
+        self.elements.len()
+    }
+
     pub fn max_round(&self) -> Option<RoundNumber> {
         self.elements.keys().max().cloned()
     }

--- a/tests/src/tests/consensus/helpers/fake_network.rs
+++ b/tests/src/tests/consensus/helpers/fake_network.rs
@@ -47,7 +47,7 @@ impl FakeNetwork {
     pub(crate) fn leader_for_round(&self, round: RoundNumber) -> PublicKey {
         self.nodes
             .values()
-            .map(|(node, _)| node.committe().leader(round))
+            .map(|(node, _)| node.committee().leader(round))
             .max()
             .unwrap()
     }
@@ -87,7 +87,7 @@ impl FakeNetwork {
                     // To simulate a timeout we just drop the message with the leader vertex
                     // We still keep the other vertices from non leader nodes so we will have 2f + 1 vertices
                     // And be able to propose a vertex with timeout cert
-                    if *v.signing_key() == node.committe().leader(v.data().round()) {
+                    if *v.signing_key() == node.committee().leader(v.data().round()) {
                         continue;
                     }
                 }
@@ -114,7 +114,7 @@ impl FakeNetwork {
         msg: Message,
         interceptor: &Interceptor,
     ) -> Vec<Action> {
-        let msgs = interceptor.intercept_message(msg, node.committe());
+        let msgs = interceptor.intercept_message(msg, node.committee());
         let mut actions = Vec::new();
         for msg in msgs {
             actions.extend(node.handle_message(msg));


### PR DESCRIPTION
In particular, have `advance_leader_with_no_vote_certificate` take the no-vote certificate as parameter as proof that the caller is the round leader.