### PR TITLE
`is_valid` only requires the leader vertex ID.

### DIFF
--- a/sailfish/src/consensus.rs
+++ b/sailfish/src/consensus.rs
@@ -3,6 +3,7 @@ use std::mem;
 
 use timeboost_core::types::block::Block;
 use timeboost_core::types::round_number::RoundNumber;
+use timeboost_core::types::vertex::VertexId;
 use tracing::{debug, instrument, trace, warn};
 use vote::VoteAccumulator;
 
@@ -643,10 +644,8 @@ impl Consensus {
             return false;
         }
 
-        if let Some(l) = self.leader_vertex(v.round() - 1) {
-            if v.has_strong_edge(l.id()) {
-                return true;
-            }
+        if v.has_strong_edge(&self.leader_vertex_id(v.round() - 1)) {
+            return true;
         }
 
         let Some(tcert) = v.timeout_cert() else {
@@ -655,6 +654,7 @@ impl Consensus {
                 round  = %self.round,
                 vround = %v.round(),
                 vsrc   = %v.source(),
+                leader = %self.leader_vertex(v.round() - 1).is_some(),
                 "vertex has no strong path to leader vertex and no timeout certificate"
             );
             return false;
@@ -724,5 +724,9 @@ impl Consensus {
 
     fn leader_vertex(&self, r: RoundNumber) -> Option<&Vertex> {
         self.dag.vertex(r, &self.committee.leader(r))
+    }
+
+    fn leader_vertex_id(&self, r: RoundNumber) -> VertexId {
+        VertexId::new(r, self.committee.leader(r))
     }
 }

--- a/timeboost-core/src/types/vertex.rs
+++ b/timeboost-core/src/types/vertex.rs
@@ -18,6 +18,13 @@ pub struct VertexId {
 }
 
 impl VertexId {
+    pub fn new(r: RoundNumber, s: PublicKey) -> Self {
+        Self {
+            round: r,
+            source: s,
+        }
+    }
+
     pub fn round(&self) -> RoundNumber {
         self.round
     }


### PR DESCRIPTION
Currently the node checking the validity of a vertex proposal requires the leader vertex to be present in its local DAG in order to accept the proposal with a strong edge to the leader vertex. This may cause issues in case the node is falling behind by multiple rounds and upon resuming regular traffic receives vertex proposals of rounds for which is has yet to receive the leader vertex.

This changes checks that the proposed vertex has a strong path to the ID of the leader vertex of the previous round without consulting its local DAG, i.e. the proposal is accepted without the leader vertex itself being known to the node.

NB that this will cause the proposed vertex to be buffered. Until the node has received all vertices of the vertex edges, the proposal will not be added to the local DAG.

This change is also meant to clarify the situation w.r.t. vertex IDs which can be freely created by anyone. In any case we need to improve defence against malicious IDs, e.g. by checking that the source key is a member of the committee and by limiting the buffer size.