### PR TITLE
Make tests time-based

### DIFF
--- a/tests/src/tests/network/external/test_simple_network.rs
+++ b/tests/src/tests/network/external/test_simple_network.rs
@@ -41,7 +41,7 @@ async fn test_simple_network_genesis() {
         })
         .collect();
 
-    NetworkTest::<Libp2pNetworkTest>::new(group, node_outcomes)
+    NetworkTest::<Libp2pNetworkTest>::new(group, node_outcomes, None)
         .run()
         .await;
 }

--- a/tests/src/tests/network/internal/test_simple_network.rs
+++ b/tests/src/tests/network/internal/test_simple_network.rs
@@ -41,7 +41,7 @@ async fn test_simple_network_genesis() {
         })
         .collect();
 
-    NetworkTest::<MemoryNetworkTest>::new(group, node_outcomes)
+    NetworkTest::<MemoryNetworkTest>::new(group, node_outcomes, None)
         .run()
         .await;
 }


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>
<!-- See here for keywords in Github -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### This PR:
Adds a configurable timeout for tests so that way we aren't arbitrarily setting it for each test run. The default timeout is 4 seconds per test, so each test *must* complete within 4 seconds (all conditions are `Passed`).

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable.  Leave this section blank if it's not applicable -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4   -->

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR can be tested through CI there is no need to add this section -->
<!-- * E.g. `just async_std test` -->

<!-- Complete the following items before creating this PR
* Are the proper people tagged to review it?
* Have you linked an issue to this PR?   -->
