### PR TITLE
Make `Coordinator` generic over `Comm`.

### DIFF
--- a/sailfish/src/sailfish.rs
+++ b/sailfish/src/sailfish.rs
@@ -11,7 +11,7 @@ use hotshot::{
             derive_libp2p_keypair, derive_libp2p_multiaddr, derive_libp2p_peer_id,
             Libp2pMetricsValue, Libp2pNetwork,
         },
-        NetworkError, NetworkNodeConfigBuilder,
+        NetworkNodeConfigBuilder,
     },
     types::SignatureKey,
 };
@@ -165,9 +165,9 @@ impl Sailfish {
         staked_nodes: Vec<PeerConfig<PublicKey>>,
         shutdown_rx: oneshot::Receiver<ShutdownToken>,
         #[cfg(feature = "test")] event_log: Option<Arc<RwLock<Vec<CoordinatorAuditEvent>>>>,
-    ) -> Coordinator
+    ) -> Coordinator<C>
     where
-        C: Comm<Err = NetworkError> + Send + 'static,
+        C: Comm + Send + 'static,
     {
         let committee = StaticCommittee::new(
             staked_nodes

--- a/tests/src/tests/network.rs
+++ b/tests/src/tests/network.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use hotshot::traits::NetworkError;
 use sailfish::coordinator::CoordinatorAuditEvent;
 use timeboost_core::{logging, traits::comm::Comm};
 use tokio::{task::JoinSet, time::timeout};
@@ -54,7 +53,7 @@ impl TestCondition {
 
 pub trait TestableNetwork {
     type Node: Send;
-    type Network: Comm<Err = NetworkError> + Send;
+    type Network: Comm + Send;
     type Shutdown: Send;
     fn new(group: Group, outcomes: HashMap<usize, Vec<TestCondition>>) -> Self;
     async fn init(&mut self) -> (Vec<Self::Node>, Vec<Self::Network>);

--- a/tests/src/tests/network/internal.rs
+++ b/tests/src/tests/network/internal.rs
@@ -8,7 +8,7 @@ use sailfish::{
     coordinator::{Coordinator, CoordinatorAuditEvent},
     sailfish::ShutdownToken,
 };
-use timeboost_core::types::test::net::Star;
+use timeboost_core::types::test::net::{Conn, Star};
 use tokio::{
     sync::oneshot::{self, Receiver, Sender},
     task::JoinSet,
@@ -27,7 +27,7 @@ pub struct MemoryNetworkTest {
 }
 
 impl TestableNetwork for MemoryNetworkTest {
-    type Node = Coordinator;
+    type Node = Coordinator<Conn<Vec<u8>>>;
     type Network = Star<Vec<u8>>;
     type Shutdown = ShutdownToken;
 


### PR DESCRIPTION
Instead of using dynamic dispatch which requires specifying the associated error type, be completely generic over `Comm`.
