### PR TITLE
Some small improvements.

### DIFF
--- a/sailfish/src/consensus/dag.rs
+++ b/sailfish/src/consensus/dag.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, num::NonZeroUsize};
+use std::{collections::BTreeMap, num::NonZeroUsize, ops::RangeBounds};
 
 use timeboost_core::types::{round_number::RoundNumber, vertex::Vertex, PublicKey};
 
@@ -48,16 +48,19 @@ impl Dag {
             .unwrap_or(false)
     }
 
-    pub fn vertices_from(&self, r: RoundNumber) -> impl Iterator<Item = &Vertex> + Clone {
-        self.elements.range(r..).flat_map(|(_, m)| m.values())
-    }
-
     pub fn vertices(&self, r: RoundNumber) -> impl Iterator<Item = &Vertex> + Clone {
         self.elements.get(&r).into_iter().flat_map(|m| m.values())
     }
 
     pub fn vertex(&self, r: RoundNumber, s: &PublicKey) -> Option<&Vertex> {
         self.elements.get(&r)?.get(s)
+    }
+
+    pub fn vertex_range<R>(&self, r: R) -> impl Iterator<Item = &Vertex> + Clone
+    where
+        R: RangeBounds<RoundNumber>,
+    {
+        self.elements.range(r).flat_map(|(_, m)| m.values())
     }
 
     pub fn vertex_count(&self, r: RoundNumber) -> usize {

--- a/sailfish/src/consensus/vote.rs
+++ b/sailfish/src/consensus/vote.rs
@@ -40,7 +40,7 @@ impl<D: Committable + Eq + Clone> VoteAccumulator<D> {
         self.cert = None
     }
 
-    pub fn certificate(&mut self) -> Option<&Certificate<D>> {
+    pub fn certificate(&self) -> Option<&Certificate<D>> {
         self.cert.as_ref()
     }
 

--- a/tests/src/tests/consensus/test_consensus.rs
+++ b/tests/src/tests/consensus/test_consensus.rs
@@ -327,6 +327,7 @@ fn basic_liveness() {
 
     // Every node should have delivered the same output:
     for (a, b) in delivered.values().zip(delivered.values().skip(1)) {
+        assert!(!a.is_empty());
         assert_eq!(a, b)
     }
 }


### PR DESCRIPTION
- `VoteAggregator::certificate` does not require a unique reference to self
- The half-open `Dag::vertices_from` is replaces with `Dag::vertex_range` to allow closed intervals.
- Removed "strong" in `Consensus` since we olny have strong edges.
- Simplified `Dag::try_to_add_to_dag` to look only for edges to the leader of r - 1 when deciding if the leader can be committed, instead of asking `Dag::is_connected`.
- Add a test assertion.