### PR TITLE
Use multiple no-vote accumulators.

### DIFF
--- a/tests/src/tests/consensus/test_consensus_actions.rs
+++ b/tests/src/tests/consensus/test_consensus_actions.rs
@@ -189,8 +189,6 @@ async fn test_single_node_timeout_cert() {
     // Handle certificate msg (send no vote, advance round, reset timer, propose for r + 1)
     node_handle.handle_message_and_verify_actions(Message::TimeoutCert(send_cert));
 
-    // Ensure we went through all expected actions
-    node_handle.assert_timeout_accumulator(expected_round, 0);
     assert!(
         node_handle.expected_actions_is_empty(),
         "Test is done but there are still remaining actions."

--- a/tests/src/tests/consensus/test_consensus_fake_network.rs
+++ b/tests/src/tests/consensus/test_consensus_fake_network.rs
@@ -93,20 +93,6 @@ async fn test_timeout_round_and_no_vote() {
     // Leader send vertex with no vote certificate and timeout certificate
     network.process();
 
-    // After the NVC has been created, the no-vote accumulator is empty.
-    assert!(
-        network
-            .leader(timeout_at_round)
-            .no_vote_accumulator()
-            .votes()
-            == 0
-    );
-
-    // Everyone moved to the next round, so timeout accumulators should be empty again.
-    assert!(network
-        .consensus()
-        .all(|c| c.timeout_accumulators().is_empty()));
-
     let nodes_msgs = network.msgs_in_queue();
 
     // Ensure we have messages from all nodes


### PR DESCRIPTION
We may receive no-votes from multiple rounds when we were leader.