### PR TITLE
Use `Message` in `Comm` methods.

### DIFF
--- a/tests/src/tests/network/internal.rs
+++ b/tests/src/tests/network/internal.rs
@@ -10,6 +10,7 @@ use sailfish::{
 };
 use timeboost_core::types::{
     event::{SailfishStatusEvent, TimeboostStatusEvent},
+    message::Message,
     test::net::{Conn, Star},
 };
 use tokio::{
@@ -35,8 +36,8 @@ pub struct MemoryNetworkTest {
 }
 
 impl TestableNetwork for MemoryNetworkTest {
-    type Node = Coordinator<Conn<Vec<u8>>>;
-    type Network = Star<Vec<u8>>;
+    type Node = Coordinator<Conn<Message>>;
+    type Network = Star<Message>;
     type Shutdown = ShutdownToken;
 
     fn new(group: Group, outcomes: HashMap<usize, Vec<TestCondition>>) -> Self {

--- a/timeboost-core/src/traits/comm.rs
+++ b/timeboost-core/src/traits/comm.rs
@@ -4,32 +4,33 @@ use async_trait::async_trait;
 use hotshot::traits::{implementations::Libp2pNetwork, NetworkError};
 use hotshot_types::traits::network::{BroadcastDelay, ConnectedNetwork, Topic};
 
+use crate::types::message::Message;
 use crate::types::PublicKey;
 
 #[async_trait]
 pub trait Comm {
     type Err: Error + Send + Sync + 'static;
 
-    async fn broadcast(&mut self, msg: Vec<u8>) -> Result<(), Self::Err>;
+    async fn broadcast(&mut self, msg: Message) -> Result<(), Self::Err>;
 
-    async fn send(&mut self, to: PublicKey, msg: Vec<u8>) -> Result<(), Self::Err>;
+    async fn send(&mut self, to: PublicKey, msg: Message) -> Result<(), Self::Err>;
 
-    async fn receive(&mut self) -> Result<Vec<u8>, Self::Err>;
+    async fn receive(&mut self) -> Result<Message, Self::Err>;
 }
 
 #[async_trait]
 impl<T: Comm + Send> Comm for Box<T> {
     type Err = T::Err;
 
-    async fn broadcast(&mut self, msg: Vec<u8>) -> Result<(), Self::Err> {
+    async fn broadcast(&mut self, msg: Message) -> Result<(), Self::Err> {
         (**self).broadcast(msg).await
     }
 
-    async fn send(&mut self, to: PublicKey, msg: Vec<u8>) -> Result<(), Self::Err> {
+    async fn send(&mut self, to: PublicKey, msg: Message) -> Result<(), Self::Err> {
         (**self).send(to, msg).await
     }
 
-    async fn receive(&mut self) -> Result<Vec<u8>, Self::Err> {
+    async fn receive(&mut self) -> Result<Message, Self::Err> {
         (**self).receive().await
     }
 }
@@ -38,16 +39,24 @@ impl<T: Comm + Send> Comm for Box<T> {
 impl Comm for Libp2pNetwork<PublicKey> {
     type Err = NetworkError;
 
-    async fn broadcast(&mut self, msg: Vec<u8>) -> Result<(), Self::Err> {
-        self.broadcast_message(msg, Topic::Global, BroadcastDelay::None)
+    async fn broadcast(&mut self, msg: Message) -> Result<(), Self::Err> {
+        let bytes =
+            bincode::serialize(&msg).map_err(|e| NetworkError::FailedToSerialize(e.to_string()))?;
+
+        self.broadcast_message(bytes, Topic::Global, BroadcastDelay::None)
             .await
     }
 
-    async fn send(&mut self, to: PublicKey, msg: Vec<u8>) -> Result<(), Self::Err> {
-        self.direct_message(msg, to).await
+    async fn send(&mut self, to: PublicKey, msg: Message) -> Result<(), Self::Err> {
+        let bytes =
+            bincode::serialize(&msg).map_err(|e| NetworkError::FailedToSerialize(e.to_string()))?;
+
+        self.direct_message(bytes, to).await
     }
 
-    async fn receive(&mut self) -> Result<Vec<u8>, Self::Err> {
-        self.recv_message().await
+    async fn receive(&mut self) -> Result<Message, Self::Err> {
+        let bytes = self.recv_message().await?;
+
+        bincode::deserialize(&bytes).map_err(|e| NetworkError::FailedToDeserialize(e.to_string()))
     }
 }


### PR DESCRIPTION
This allows implementers of `Comm` to inspect the data that is sent and received more easily.