### PR TITLE
Add `Label` for logs.

### DIFF
--- a/sailfish/src/consensus/dag.rs
+++ b/sailfish/src/consensus/dag.rs
@@ -70,12 +70,7 @@ impl Dag {
     /// Is there a connection between two vertices?
     pub fn is_connected(&self, from: &Vertex, to: &Vertex) -> bool {
         let mut current = vec![from];
-        for nodes in self
-            .elements
-            .range(RoundNumber::genesis()..from.round())
-            .rev()
-            .map(|e| e.1)
-        {
+        for nodes in self.elements.range(..from.round()).rev().map(|e| e.1) {
             current = nodes
                 .iter()
                 .filter_map(|(_, v)| current.iter().any(|x| x.has_edge(v.source())).then_some(v))
@@ -90,6 +85,17 @@ impl Dag {
             }
         }
         false
+    }
+
+    pub fn dbg_dag(&self) {
+        for (r, e) in &self.elements {
+            println!("{r} -> {{");
+            for v in e.values() {
+                print!("  ");
+                v.dbg_edges();
+            }
+            println!("}}")
+        }
     }
 }
 

--- a/timeboost-core/src/types.rs
+++ b/timeboost-core/src/types.rs
@@ -93,3 +93,27 @@ impl Keypair {
         &self.public
     }
 }
+
+#[derive(Clone, Copy)]
+pub struct Label(u64);
+
+impl Label {
+    pub fn new<H: std::hash::Hash>(x: H) -> Self {
+        use std::hash::Hasher;
+        let mut h = std::hash::DefaultHasher::new();
+        x.hash(&mut h);
+        Self(h.finish())
+    }
+}
+
+impl fmt::Debug for Label {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "L{:X}", self.0)
+    }
+}
+
+impl fmt::Display for Label {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as fmt::Debug>::fmt(self, f)
+    }
+}

--- a/timeboost-core/src/types/vertex.rs
+++ b/timeboost-core/src/types/vertex.rs
@@ -9,6 +9,7 @@ use super::{
     message::{NoVote, Timeout},
     PublicKey,
 };
+use crate::types::Label;
 use crate::types::{block::Block, round_number::RoundNumber};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -91,6 +92,14 @@ impl Vertex {
     pub fn set_timeout(&mut self, t: Certificate<Timeout>) -> &mut Self {
         self.timeout = Some(t);
         self
+    }
+
+    pub fn dbg_edges(&self) {
+        println! { "{} -> {} -> {:?}",
+            Label::new(self.source()),
+            self.round(),
+            self.edges().map(Label::new).collect::<Vec<_>>()
+        }
     }
 }
 


### PR DESCRIPTION
Vertex edges use the public key of a node, as this uniquely identifies the node itself. Our `NodeId`s on the other hand are separately assigned numerical IDs. To help with associating nodes and DAG vertices this commit adds a `Label` type which is the hash of the public key. The hash implementation is not collision resistant, but for debug logs of small sets this should not be a concern.

Based on the `Label` this commit also introduces `Dag::dbg_dag` to print the DAG to stdout and `Vertex::dbg_edges` to print a vertex' round number, source and parent vertices.