### PR TITLE
Add vertex newtype that implements `Ord`.

### DIFF
--- a/sailfish/src/consensus/ord.rs
+++ b/sailfish/src/consensus/ord.rs
@@ -1,0 +1,48 @@
+use std::cmp::Ordering;
+use std::ops::Deref;
+
+use timeboost_core::types::vertex::Vertex;
+
+/// Newtype for `Vertex` that implements `Ord` by round number.
+#[derive(Debug)]
+pub struct OrderedVertex(pub Vertex);
+
+impl From<Vertex> for OrderedVertex {
+    fn from(value: Vertex) -> Self {
+        Self(value)
+    }
+}
+
+impl From<OrderedVertex> for Vertex {
+    fn from(value: OrderedVertex) -> Self {
+        value.0
+    }
+}
+
+impl Deref for OrderedVertex {
+    type Target = Vertex;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl PartialEq for OrderedVertex {
+    fn eq(&self, other: &Self) -> bool {
+        self.round().eq(&other.round())
+    }
+}
+
+impl Eq for OrderedVertex {}
+
+impl Ord for OrderedVertex {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.round().cmp(&other.round())
+    }
+}
+
+impl PartialOrd for OrderedVertex {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/tests/src/tests/consensus/test_consensus_fake_network.rs
+++ b/tests/src/tests/consensus/test_consensus_fake_network.rs
@@ -329,7 +329,7 @@ fn basic_liveness() {
                 assert!(n.dag().max_round().unwrap() >= n.committed_round() - 2);
             }
             // No one is late => buffer should always be empty:
-            assert!(n.buffer().is_empty());
+            assert_eq!(0, n.buffer().count());
         }
         actions = next
     }


### PR DESCRIPTION
Currently `Vertex` does not implement `Ord` because certificate signatures do not implement it. Since we want to keep vertices in a set ordered by round number, this commit adds a newtype that implements the necessary `Ord` logic.
