### PR TITLE
Remove `lazy_static` dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ jf-signature = { git = "https://github.com/EspressoSystems/jellyfish", tag = "jf
     "bls",
 ] }
 jf-utils = { version = "0.4.4", git = "https://github.com/espressosystems/jellyfish", tag = "0.4.5" }
-lazy_static = "1"
 libp2p-identity = { version = "0.2.9", features = ["ed25519"] }
 multiaddr = "0.18.2"
 nimue = { git = "https://github.com/arkworks-rs/nimue.git", features = ["ark"] }

--- a/sailfish/Cargo.toml
+++ b/sailfish/Cargo.toml
@@ -23,7 +23,6 @@ committable = { workspace = true }
 criterion = "0.5"
 derive_builder = { workspace = true }
 futures = { workspace = true }
-lazy_static = { workspace = true }
 libp2p-identity = { workspace = true }
 multiaddr = { workspace = true }
 multisig = { path = "../multisig" }

--- a/sailfish/benches/consensus_single.rs
+++ b/sailfish/benches/consensus_single.rs
@@ -1,8 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use lazy_static::lazy_static;
 use multisig::{Committee, Keypair, PublicKey, Validated};
 use sailfish::consensus::{Consensus, Dag};
-use std::{collections::HashMap, num::NonZeroUsize};
+use std::{collections::HashMap, num::NonZeroUsize, sync::LazyLock};
 use timeboost_core::types::{
     message::{Action, Evidence, Message},
     NodeId,
@@ -13,19 +12,17 @@ const SEED: [u8; 32] = [
     1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 ];
 
-lazy_static! {
-    static ref TEST_DATA: HashMap<u64, Vec<Message>> = {
-        let mut m = HashMap::new();
-        m.insert(
-            10,
-            generate_quorum_data(MultiRoundTestSpec {
-                rounds: 10,
-                ..Default::default()
-            }),
-        );
-        m
-    };
-}
+static TEST_DATA: LazyLock<HashMap<u64, Vec<Message>>> = LazyLock::new(|| {
+    let mut m = HashMap::new();
+    m.insert(
+        10,
+        generate_quorum_data(MultiRoundTestSpec {
+            rounds: 10,
+            ..Default::default()
+        }),
+    );
+    m
+});
 
 #[derive(Debug, Clone, Copy)]
 struct MultiRoundTestSpec {

--- a/timeboost-networking/Cargo.toml
+++ b/timeboost-networking/Cargo.toml
@@ -14,7 +14,6 @@ custom_debug = "0.6.2"
 delegate = "0.13"
 derive_builder = { workspace = true }
 futures = { workspace = true }
-lazy_static = { workspace = true }
 libp2p = { package = "libp2p", version = "0.53", default-features = false, features = [
     "macros",
     "autonat",

--- a/timeboost-networking/src/p2p/behaviours/dht/mod.rs
+++ b/timeboost-networking/src/p2p/behaviours/dht/mod.rs
@@ -18,7 +18,6 @@ use futures::{
     channel::{mpsc, oneshot::Sender},
     SinkExt,
 };
-use lazy_static::lazy_static;
 use libp2p::kad::{
     /* handler::KademliaHandlerIn, */ store::MemoryStore, BootstrapOk, GetClosestPeersOk,
     GetRecordOk, GetRecordResult, ProgressStep, PutRecordResult, QueryId, QueryResult, Record,
@@ -42,10 +41,8 @@ pub mod store;
 /// in order to trust that the answer is correct when retrieving from the DHT
 pub(crate) const NUM_REPLICATED_TO_TRUST: usize = 2;
 
-lazy_static! {
-    /// the maximum number of nodes to query in the DHT at any one time
-    static ref MAX_DHT_QUERY_SIZE: NonZeroUsize = NonZeroUsize::new(50).unwrap();
-}
+/// the maximum number of nodes to query in the DHT at any one time
+const MAX_DHT_QUERY_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(50) };
 
 use super::exponential_backoff::ExponentialBackoff;
 use crate::p2p::{ClientRequest, NetworkEvent};
@@ -345,7 +342,7 @@ impl<K: SignatureKey + 'static> DHTBehaviour<K> {
                         warn!("Get DHT: Internal disagreement for get dht request {:?}! requerying with more nodes. {:?} retries left", progress, new_retry_count);
                         let new_factor = NonZeroUsize::max(
                             NonZeroUsize::new(num_replicas.get() + 1).unwrap_or(num_replicas),
-                            *MAX_DHT_QUERY_SIZE,
+                            MAX_DHT_QUERY_SIZE,
                         );
                         self.retry_get(KadGetQuery {
                             backoff,


### PR DESCRIPTION
Rust 1.80.0 added `std::sync::LazyLock`.
