### PR TITLE
Consider views to self.

### DIFF
--- a/sailfish/benches/consensus_single.rs
+++ b/sailfish/benches/consensus_single.rs
@@ -55,12 +55,12 @@ impl Net {
     }
 
     pub fn run(&mut self) {
-        let d = Dag::new(NonZeroUsize::new(self.nodes.len()).unwrap());
-
         let mut actions = Vec::new();
 
+        let size = NonZeroUsize::new(self.nodes.len()).unwrap();
         for node in self.nodes.values_mut() {
-            actions.extend(node.go(d.clone(), Evidence::Genesis));
+            let d = Dag::new(node.public_key(), size);
+            actions.extend(node.go(d, Evidence::Genesis));
         }
 
         let mut messages: Vec<Message> = actions.drain(..).filter_map(action_to_msg).collect();

--- a/sailfish/src/coordinator.rs
+++ b/sailfish/src/coordinator.rs
@@ -53,7 +53,7 @@ impl<C: Comm> Coordinator<C> {
         if !self.init {
             self.init = true;
             let e = Evidence::Genesis;
-            let d = Dag::new(self.consensus.committee_size());
+            let d = Dag::new(self.consensus.public_key(), self.consensus.committee_size());
             return Ok(self.consensus.go(d, e));
         }
         panic!("Cannot call start twice");

--- a/tests/src/tests/consensus/helpers/fake_network.rs
+++ b/tests/src/tests/consensus/helpers/fake_network.rs
@@ -35,7 +35,10 @@ impl FakeNetwork {
         let committee_size = NonZeroUsize::new(self.nodes.len()).unwrap();
         for node_instrument in self.nodes.values_mut() {
             let node = node_instrument.node_mut();
-            for a in node.go(Dag::new(committee_size), Evidence::Genesis) {
+            for a in node.go(
+                Dag::new(node.public_key(), committee_size),
+                Evidence::Genesis,
+            ) {
                 Self::handle_action(node.id(), a, &mut next)
             }
         }

--- a/tests/src/tests/consensus/helpers/key_manager.rs
+++ b/tests/src/tests/consensus/helpers/key_manager.rs
@@ -120,10 +120,11 @@ impl KeyManager {
 
     pub(crate) fn prepare_dag(
         &self,
+        key: PublicKey,
         round: u64,
         committee: &Committee,
     ) -> (Dag, Evidence, Vec<PublicKey>) {
-        let mut dag = Dag::new(committee.size());
+        let mut dag = Dag::new(key, committee.size());
         let edges = self
             .keys
             .values()

--- a/tests/src/tests/consensus/helpers/shaping.rs
+++ b/tests/src/tests/consensus/helpers/shaping.rs
@@ -344,12 +344,12 @@ impl Simulator {
 
         assert!(!parties.is_empty());
 
-        let dag = Dag::new(NonZeroUsize::new(parties.len()).unwrap());
-
         let mut actions = Vec::new();
 
         for (name, party) in &mut parties {
-            actions.push((*name, party.logic.go(dag.clone(), Evidence::Genesis)));
+            let key = party.logic.public_key();
+            let dag = Dag::new(key, NonZeroUsize::new(committee.size().get()).unwrap());
+            actions.push((*name, party.logic.go(dag, Evidence::Genesis)));
         }
 
         Self {

--- a/tests/src/tests/consensus/test_consensus_actions.rs
+++ b/tests/src/tests/consensus/test_consensus_actions.rs
@@ -26,7 +26,8 @@ async fn test_single_node_advance() {
     // Setup up consensus state
     let mut round = 7;
     let node = node_handle.node_mut();
-    let (dag, evidence, vertices_for_round) = manager.prepare_dag(round, &committee);
+    let (dag, evidence, vertices_for_round) =
+        manager.prepare_dag(node.public_key(), round, &committee);
     node.go(dag, evidence);
 
     // Craft messages
@@ -69,7 +70,8 @@ async fn test_single_node_timeout() {
     // Setup up consensus state
     let mut round = 4;
     let node = node_handle.node_mut();
-    let (dag, evidence, _vertices_for_round) = manager.prepare_dag(round, &committee);
+    let (dag, evidence, _vertices_for_round) =
+        manager.prepare_dag(node.public_key(), round, &committee);
     node.go(dag, evidence);
 
     // Craft messages
@@ -131,7 +133,8 @@ async fn test_single_node_timeout_cert() {
 
     // Setup up consensus state
     let node = node_handle.node_mut();
-    let (dag, evidence, vertices_for_round) = manager.prepare_dag(*expected_round - 1, &committee);
+    let (dag, evidence, vertices_for_round) =
+        manager.prepare_dag(node.public_key(), *expected_round - 1, &committee);
     node.go(dag, evidence);
 
     // Craft messages, skip leader vertex

--- a/tests/src/tests/consensus/test_consensus_fake_network.rs
+++ b/tests/src/tests/consensus/test_consensus_fake_network.rs
@@ -209,7 +209,10 @@ fn basic_liveness() {
             let node = node_handle.node_mut();
             (
                 (i as u64).into(),
-                node.go(Dag::new(node.committee_size()), Evidence::Genesis),
+                node.go(
+                    Dag::new(node.public_key(), node.committee_size()),
+                    Evidence::Genesis,
+                ),
             )
         })
         .collect();


### PR DESCRIPTION
To help with cases where long enough delays (across GC points) prevent parties from adding proposals from a delayed party, we count the number of views by external parties and if 0 we skip a reference to self in a proposal to allow others to include that proposal and subsequent ones.