### PR TITLE
Make edge delay a function of message.

### DIFF
--- a/sailfish/src/consensus.rs
+++ b/sailfish/src/consensus.rs
@@ -295,7 +295,12 @@ impl Consensus {
         actions
     }
 
-    #[instrument(level = "trace", skip_all, fields(n = %self.public_key(), r = %self.round()))]
+    #[instrument(level = "trace", skip_all, fields(
+        n = %self.public_key(),
+        r = %self.round(),
+        s = %e.signing_key(),
+        t = %e.data().no_vote().data().round())
+    )]
     pub fn handle_no_vote(&mut self, e: Envelope<NoVoteMessage, Validated>) -> Vec<Action> {
         let mut actions = Vec::new();
 

--- a/timeboost-core/src/types/message.rs
+++ b/timeboost-core/src/types/message.rs
@@ -35,6 +35,22 @@ impl<S> Message<S> {
             Self::TimeoutCert(c) => c.data().round(),
         }
     }
+
+    pub fn is_vertex(&self) -> bool {
+        matches!(self, Self::Vertex(_))
+    }
+
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, Self::Timeout(_))
+    }
+
+    pub fn is_no_vote(&self) -> bool {
+        matches!(self, Self::NoVote(_))
+    }
+
+    pub fn is_timeout_cert(&self) -> bool {
+        matches!(self, Self::TimeoutCert(_))
+    }
 }
 
 impl Message<Unchecked> {


### PR DESCRIPTION
Instead of a single delay per edge, allow tests to specify a delay for a specific message.

Also support an optional precondition for rules so they can assert facts before being applied.