### PR TITLE
Tweak Justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,11 +12,11 @@ bench:
   cargo bench --benches -- --nocapture
 
 test *ARGS:
-  cargo nextest run --test-threads $(nproc) {{ARGS}}
+  cargo nextest run {{ARGS}}
   @if [ "{{ARGS}}" == "" ]; then cargo test --doc; fi
 
 test_ci *ARGS:
-  RUST_LOG=sailfish=debug,tests=debug cargo nextest run --workspace --retries 3 --test-threads $(nproc) {{ARGS}}
+  RUST_LOG=sailfish=debug,tests=debug cargo nextest run --workspace --retries 3 {{ARGS}}
   RUST_LOG=sailfish=debug,tests=debug cargo test --doc {{ARGS}}
 
 run *ARGS:


### PR DESCRIPTION
Removes `RUSTFLAGS` and `--test-threads $(nproc)`. The latter is the default of nextest and not having it set makes it easier to run with tests `--no-capture`.