### PR TITLE
Rename `gc` to `cleanup` and add buffered vertices.

### DIFF
--- a/sailfish/src/consensus.rs
+++ b/sailfish/src/consensus.rs
@@ -753,7 +753,7 @@ impl Consensus {
                 self.delivered.insert((r, s));
             }
         }
-        self.gc();
+        self.cleanup();
         actions
     }
 
@@ -763,15 +763,28 @@ impl Consensus {
         r = %self.round,
         c = %self.committed_round)
     )]
-    fn gc(&mut self) {
-        if *self.committed_round < self.committee.size().get() as u64 {
+    fn cleanup(&mut self) {
+        let len = self.committee.size().get() as u64;
+
+        if *self.committed_round < len {
             return;
         }
 
-        let r = self.committed_round - self.committee.size().get() as u64;
+        let r = self.committed_round - len;
+
         self.dag.remove(r);
         self.buffer.remove(r);
         self.delivered.retain(|(x, _)| *x >= r);
+
+        // Now add buffered vertices of the lowest round to the DAG. This is assumed to be safe
+        // because we are at this point at least `len` rounds ahead of `r` and in each round we
+        // have > 2f vertices in our DAG.
+
+        debug_assert!(self.buffer.vertex_count(r) <= self.committee.threshold().get());
+
+        for v in self.buffer.drain_round(r) {
+            self.dag.add(v)
+        }
 
         self.metrics.dag_depth.set(self.dag.depth());
         self.metrics.vertex_buffer.set(self.buffer.depth());

--- a/sailfish/src/consensus/dag.rs
+++ b/sailfish/src/consensus/dag.rs
@@ -40,7 +40,7 @@ impl Dag {
         m.insert(*s, v);
     }
 
-    /// Removes all rounds up to (and including) the specified round number from the DAG
+    /// Removes all rounds up to the specified round number from the DAG
     pub fn remove(&mut self, r: RoundNumber) {
         self.elements = self.elements.split_off(&r);
     }

--- a/tests/src/tests/consensus/test_traffic_patterns.rs
+++ b/tests/src/tests/consensus/test_traffic_patterns.rs
@@ -64,14 +64,13 @@ fn delayed_delivery() {
     ]);
     sim.goto(500);
 
-    assert_eq!(135, sim.events().iter().filter(|e| e.is_timeout()).count());
+    assert_eq!(10, sim.events().iter().filter(|e| e.is_timeout()).count());
 
-    assert_eq!(8, sim.consensus("A").buffer_depth());
-    assert_eq!(8, sim.consensus("B").buffer_depth());
-    assert_eq!(8, sim.consensus("C").buffer_depth());
-    assert_eq!(8, sim.consensus("E").buffer_depth());
-
+    assert_eq!(0, sim.consensus("A").buffer_depth());
+    assert_eq!(0, sim.consensus("B").buffer_depth());
+    assert_eq!(0, sim.consensus("C").buffer_depth());
     assert_eq!(0, sim.consensus("D").buffer_depth());
+    assert_eq!(0, sim.consensus("E").buffer_depth());
 
     assert!(is_valid_delivery(&sim));
 }


### PR DESCRIPTION
After we pruned the DAG and the buffer we add vertices from the lowest buffer round to the DAG. This should help with cases where we are unable to add vertices to the DAG because of varying delays before GST where we end up in a situation that vertices arrive after we GC'd the DAG and are unable to fully resolve vertex edges.

The change is assumed to be sage because we are at this point several rounds ahead of the lowest buffer round and have at least a quorum of vertices in our DAG in each of those rounds.