### PR TITLE
network: Fix max. message size handling.

### DIFF
--- a/timeboost-networking/Cargo.toml
+++ b/timeboost-networking/Cargo.toml
@@ -15,4 +15,5 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+portpicker = { workspace = true }
 quickcheck = { workspace = true }

--- a/timeboost-networking/src/lib.rs
+++ b/timeboost-networking/src/lib.rs
@@ -430,7 +430,7 @@ async fn connect(
         .chain(repeat(30_000))
     {
         sleep(Duration::from_millis(d)).await;
-        debug!(%to, a = %addr, "connecting");
+        debug!(a = %addr, "connecting");
         match TcpStream::connect(addr).await {
             Ok(s) => {
                 if let Err(e) = s.set_nodelay(true) {

--- a/timeboost-networking/tests/frame-handling.rs
+++ b/timeboost-networking/tests/frame-handling.rs
@@ -1,0 +1,69 @@
+use std::net::{Ipv4Addr, SocketAddr};
+
+use multisig::{Keypair, PublicKey};
+use portpicker::pick_unused_port;
+use rand::{Rng, RngCore};
+use timeboost_networking::Network;
+use tokio::time::{timeout, Duration};
+
+/// Send and receive messages of various sizes between 1 byte and 5 MiB.
+#[tokio::test]
+async fn multiple_frames() {
+    let party_a = Keypair::generate();
+    let party_b = Keypair::generate();
+
+    let all_parties: [(PublicKey, SocketAddr); 2] = [
+        (
+            party_a.public_key(),
+            (Ipv4Addr::LOCALHOST, pick_unused_port().unwrap()).into(),
+        ),
+        (
+            party_b.public_key(),
+            (Ipv4Addr::LOCALHOST, pick_unused_port().unwrap()).into(),
+        ),
+    ];
+
+    let mut net_a = Network::create(all_parties[0].1, party_a, all_parties)
+        .await
+        .unwrap();
+    let mut net_b = Network::create(all_parties[1].1, party_b, all_parties)
+        .await
+        .unwrap();
+
+    let sender = all_parties[0].0;
+
+    for _ in 0..100 {
+        send_recv(sender, &mut net_a, &mut net_b, gen_message()).await
+    }
+}
+
+/// Generate a vector with random data and random length (within bounds).
+fn gen_message() -> Vec<u8> {
+    let mut g = rand::thread_rng();
+    let mut v = vec![0; g.gen_range(1..5 * 1024 * 1024)];
+    g.fill_bytes(&mut v);
+    v
+}
+
+/// Multicast a message and receive them in both networks.
+///
+/// Since `Network` is essentially unreliable, this will retry multicasting
+/// until the expected message has been received by both parties.
+async fn send_recv(sender: PublicKey, net_a: &mut Network, net_b: &mut Network, data: Vec<u8>) {
+    'main: loop {
+        net_a.multicast(data.clone()).await.unwrap();
+
+        for net in [&mut *net_a, net_b] {
+            if let Ok(Ok((k, x))) = timeout(Duration::from_millis(5), net.receive()).await {
+                assert_eq!(k, sender);
+                if x != data {
+                    continue 'main;
+                }
+            } else {
+                continue 'main;
+            }
+        }
+
+        return;
+    }
+}


### PR DESCRIPTION
In a weak moment with the help of auto-completion I selected the `MAX_PAYLOAD_SIZE` constant as the limit for a message consisting of potentially multiple frames. It makes no sense of course to limit multiple frames to the payload size of a single noise payload.

This commit adds a constant `MAX_TOTAL_SIZE` (= 5MiB) to allow for messages up to that value.

Thanks to @lukeiannucci for pointing out this mistake.