### PR TITLE
Update some comments.

### DIFF
--- a/multisig/src/committee.rs
+++ b/multisig/src/committee.rs
@@ -24,29 +24,17 @@ impl Committee {
     }
 
     /// Returns the size of the committee as a non-zero unsigned integer.
-    ///
-    /// # Panics
-    ///
-    /// - If the committee is empty, though this should be impossible due to the `new` method's check.
     pub fn size(&self) -> NonZeroUsize {
         NonZeroUsize::new(self.parties.len()).expect("committee is not empty")
     }
 
-    /// Calculates and returns the threshold for consensus, which is `ceil(n/3)` where `n` is the committee size.
-    ///
-    /// # Panics
-    ///
-    /// - If the calculation results in zero, which is theoretically impossible since `n > 0`.
+    /// Returns the threshold for consensus, which is `ceil(n/3)` where `n` is the committee size.
     pub fn threshold(&self) -> NonZeroUsize {
         let t = self.parties.len().div_ceil(3);
         NonZeroUsize::new(t).expect("ceil(n/3) with n > 0 never gives 0")
     }
 
     /// Computes the quorum size
-    ///
-    /// # Panics
-    ///
-    /// - If the calculation results in zero, which is impossible since `n + 1 > 0`.
     pub fn quorum_size(&self) -> NonZeroUsize {
         let q = self.parties.len() * 2 / 3 + 1;
         NonZeroUsize::new(q).expect("n + 1 > 0")
@@ -67,7 +55,7 @@ impl Committee {
         self.parties.contains_right(k)
     }
 
-    /// Returns an iterator over all entries in the committee, providing both key IDs and public keys.
+    /// Returns an iterator over all entries in the committee.
     pub fn entries(&self) -> impl Iterator<Item = (KeyId, &PublicKey)> {
         self.parties.iter().map(|e| (*e.0, e.1))
     }
@@ -78,10 +66,6 @@ impl Committee {
     }
 
     /// Determines the leader for a given round number using a round-robin method.
-    ///
-    /// # Panics
-    ///
-    /// - If the calculation results in an index out of bounds, which should not occur if `parties` is not empty.
     pub fn leader(&self, round: usize) -> PublicKey {
         let i = round % self.parties.len();
         self.parties
@@ -92,9 +76,6 @@ impl Committee {
     }
 
     /// Returns the key ID of the leader for a given round number.
-    /// /// # Panics
-    ///
-    /// - If the calculation results in an index out of bounds, which should not occur if `parties` is not empty.
     pub fn leader_index(&self, round: usize) -> KeyId {
         let i = round % self.parties.len();
         self.parties

--- a/multisig/src/lib.rs
+++ b/multisig/src/lib.rs
@@ -82,7 +82,7 @@ impl Keypair {
         this
     }
 
-    /// Generate keypair from a seed
+    /// Generate keypair from a seed.
     pub fn from_seed(seed: [u8; 32]) -> Self {
         let this = Self {
             pair: ed25519::KeyPair::from_seed(ed25519::Seed::new(seed)),
@@ -91,23 +91,19 @@ impl Keypair {
         this
     }
 
-    /// Returns ed25519 Public key
+    /// Returns ed25519 Public key.
     pub fn public_key(&self) -> PublicKey {
         PublicKey { key: self.pair.pk }
     }
 
-    /// Return ed25519 Secret key
-    ///
-    /// Note:
-    /// - This contains both private and public key
-    /// - The first 32 bytes being private key and the latter 32 bytes are public key
+    /// Return ed25519 secret key.
     pub fn secret_key(&self) -> SecretKey {
         SecretKey {
             key: self.pair.sk.clone(),
         }
     }
 
-    /// Sign data with our ed25519 private key
+    /// Sign data with our ed25519 secret key.
     pub fn sign(&self, data: &[u8], deterministic: bool) -> Signature {
         Signature {
             sig: self

--- a/multisig/src/votes.rs
+++ b/multisig/src/votes.rs
@@ -41,12 +41,12 @@ impl<D: Committable + Clone> VoteAccumulator<D> {
         self.votes.is_empty()
     }
 
-    /// Return the amount of signatures for a given commmitment
+    /// Return the amount of signatures for a given commmitment.
     pub fn votes(&self, c: &Commitment<D>) -> usize {
         self.votes.get(c).map(|e| e.sigs.len()).unwrap_or(0)
     }
 
-    /// Return iterator for each public key for a given committment
+    /// Return iterator for each public key for a given committment.
     pub fn voters(&self, c: &Commitment<D>) -> impl Iterator<Item = &PublicKey> {
         if let Some(e) = self.votes.get(c) {
             Either::Right(e.sigs.keys().filter_map(|i| self.committee.get_key(*i)))
@@ -55,17 +55,17 @@ impl<D: Committable + Clone> VoteAccumulator<D> {
         }
     }
 
-    /// Returns an optional reference to the certificate
+    /// Returns a reference to the certificate, if available.
     pub fn certificate(&self) -> Option<&Certificate<D>> {
         self.cert.as_ref()
     }
 
-    /// Returns an optional certificate
+    /// Consumes this vote accumulator and returns the certificate, if available.
     pub fn into_certificate(self) -> Option<Certificate<D>> {
         self.cert
     }
 
-    /// Set the certificate
+    /// Set the certificate.
     pub fn set_certificate(&mut self, c: Certificate<D>) {
         self.clear();
         self.votes.insert(
@@ -78,12 +78,13 @@ impl<D: Committable + Clone> VoteAccumulator<D> {
         self.cert = Some(c)
     }
 
+    /// Clear all accumulated votes and the certificate.
     pub fn clear(&mut self) {
         self.votes.clear();
         self.cert = None
     }
 
-    /// Adds a signed data into the vote accumulator
+    /// Adds a signed data into the vote accumulator.
     ///
     /// This function will:
     /// - Validate the public key of sender

--- a/sailfish/src/consensus.rs
+++ b/sailfish/src/consensus.rs
@@ -289,13 +289,15 @@ impl Consensus {
         actions
     }
 
-    /// Handle a no vote message received
+    /// Handle a no-vote message received.
     ///
     /// Upon receiving a no vote message we:
-    /// - Verify that we are the leader for round `r + 1` from timeout round `r`
-    /// - Check if we have a timeout certificate for the round, or set it
-    /// - Add the `no_vote` to our `VoteAccumulator` upon  receiving `2f + 1` `no_votes` a certificate will be created
-    /// - Advance round by broadcasting the vertex with the attached `no_vote` and `timeout_certificate`
+    /// - Verify that we are the leader for round `r + 1` from timeout round `r`.
+    /// - Check if we have a timeout certificate for the round, or else set it.
+    /// - Add the `no_vote` to our `VoteAccumulator`. Upon receiving `2f + 1`
+    ///   `no_votes` a certificate will be created.
+    /// - If a no-vote certificate has been created, advance to the next round with
+    ///   the `no_vote` and `timeout_certificate`.
     pub fn handle_no_vote(&mut self, e: Envelope<NoVoteMessage, Validated>) -> Vec<Action> {
         trace!(
             node    = %self.public_key(),
@@ -543,10 +545,11 @@ impl Consensus {
         actions
     }
 
-    /// Advances the leader from timeout round r
+    /// Advances the leader from timeout round `r`.
     ///
-    /// This function advances a leader by createing a vertex and attaches a timeout certicate and no vote certificate for a round
-    /// The leader is for round r + 1 where r is the round we timed out in
+    /// This function advances the leader of `r + 1`. The required timeout and
+    /// no-vote certificates will be attached to the newly created vertex this
+    /// node will broadcast.
     fn advance_leader_with_no_vote_certificate(
         &mut self,
         round: RoundNumber,
@@ -878,12 +881,12 @@ impl Consensus {
         true
     }
 
-    /// Retrieve leader vertex for a given round
+    /// Retrieve leader vertex for a given round.
     fn leader_vertex(&self, r: RoundNumber) -> Option<&Vertex> {
         self.dag.vertex(r, &self.committee.leader(*r as usize))
     }
 
-    /// Do we have a `Evidence` that a message is valid for a given round
+    /// Do we have `Evidence` that a message is valid for a given round?
     fn evidence(&self, r: RoundNumber) -> Option<Evidence> {
         if let Some(cert) = self.rounds.get(&r).and_then(|a| a.certificate()) {
             return Some(Evidence::Regular(cert.clone()));
@@ -894,7 +897,7 @@ impl Consensus {
         None
     }
 
-    /// Do we have a given timeout certificate for a given round
+    /// Do we have a given timeout certificate for a given round?
     fn has_timeout_cert(&self, r: RoundNumber) -> bool {
         self.timeouts
             .get(&r)
@@ -902,14 +905,17 @@ impl Consensus {
             .unwrap_or(false)
     }
 
-    /// Find the first round in our buffer that we have a quorum of vertices for
+    /// Find the first round in our buffer that we have a quorum of vertices for.
     fn first_available_round(&self) -> Option<RoundNumber> {
         self.buffer
             .rounds()
             .find(|r| self.buffer.vertex_count(*r) >= self.committee.quorum_size().get())
     }
 
-    /// Lowest round that a quorum of nodes has committed
+    /// Cutoff round for cleanup and catch-up logic.
+    ///
+    /// It is defined as the quorum of committed round numbers of the committee
+    /// minus an extra margin to avoid overly aggressive cleanup.
     fn lower_round_bound(&self) -> RoundNumber {
         self.nodes
             .committed_round_quorum()

--- a/sailfish/src/consensus/info.rs
+++ b/sailfish/src/consensus/info.rs
@@ -18,7 +18,7 @@ impl NodeInfo {
         }
     }
 
-    /// Sets the committed round for the quorum of nodes
+    /// Sets the committed round of a committee member.
     pub fn set_committed_round(&mut self, k: &PublicKey, new: RoundNumber) -> bool {
         let Some(i) = self.nodes.iter().position(|(p, _)| p == k) else {
             return false;
@@ -46,7 +46,7 @@ impl NodeInfo {
         true
     }
 
-    /// Gets the lowest committed round for the quorum of nodes
+    /// Gets the smallest round number the quorum of nodes has committed.
     pub fn committed_round_quorum(&self) -> RoundNumber {
         debug_assert!(self.quorum <= self.nodes.len());
         self.nodes[self.quorum - 1].1

--- a/sailfish/src/coordinator.rs
+++ b/sailfish/src/coordinator.rs
@@ -26,7 +26,7 @@ pub struct Coordinator<C> {
     /// The instance of Sailfish consensus for this coordinator.
     consensus: Consensus,
 
-    /// The timeout timer for a sailfish consensus round
+    /// The timeout timer for a sailfish consensus round.
     timer: BoxFuture<'static, RoundNumber>,
 
     /// Have we started consensus?
@@ -51,14 +51,15 @@ impl<C: Comm> Coordinator<C> {
         self.id
     }
 
-    /// Starts Sailfish consesnsus
+    /// Starts Sailfish consensus.
     ///
-    /// This function creates `Evidence` for the Genesis round and starts consensus sending these out
-    /// Then returning the list of actions that need to be executed
+    /// This function initializes and starts consensus. The sequence of
+    /// consensus actions is returned and `Coordinator::execute` should be applied
+    /// to each one.
     ///
     /// # Panics
-    /// This function panics if:
-    /// - We have called `start` twice in the same lifetime of the app.
+    ///
+    /// `Coordinator::start` must only be invoked once, otherwise it will panic.
     pub async fn start(&mut self) -> Result<Vec<Action>, C::Err> {
         if !self.init {
             self.init = true;
@@ -69,15 +70,12 @@ impl<C: Comm> Coordinator<C> {
         panic!("Cannot call start twice");
     }
 
-    /// Handles the `next` event for Sailfish consensus
+    /// Await the next sequence of consensus actions.
     ///
     /// This function will either:
-    /// - Timeout a sailfish round if no progress was made and multicast the timeout messages to members in the committee
-    /// - Process a validated consensus `Message` received from a member in the committee
     ///
-    /// # Panics
-    /// This function panics if:
-    /// - We have called `start` twice in the same lifetime of the app.
+    /// - timeout a sailfish round if no progress was made, or
+    /// - process a validated consensus `Message` that was RBC-delivered over the network.
     pub async fn next(&mut self) -> Result<Vec<Action>, C::Err> {
         tokio::select! { biased;
             r = &mut self.timer => Ok(self.consensus.timeout(r)),
@@ -85,22 +83,23 @@ impl<C: Comm> Coordinator<C> {
         }
     }
 
-    /// Appends a list of transactions to the consensus transaction queue
+    /// Appends a list of transactions to the consensus transaction queue.
     pub fn handle_transactions(&mut self, transactions: Vec<Transaction>) {
         for t in transactions {
             self.consensus.enqueue_transaction(t);
         }
     }
 
-    /// Handles a given consensus `Action`
+    /// Execute a given consensus `Action`.
     ///
     /// This function will handle one of the following actions:
-    /// - `ResetTimer` - Reset timeout timer
-    /// - `Deliver` - Return a Sailfish consensus block to the caller
-    /// - `SendProposal` - Reliable broadcast a vertex to the members in the committee
-    /// - `SendTimeout` - Multicast a timeout message to the members in the committee
-    /// - `SendTimeoutCert` - Multicast a timeout certificate upon receiving `2f + 1` timeouts for a given round
-    /// - `SendNoVote` - Send a no vote to the leader in `r + 1` for a timeout in round `r`
+    ///
+    /// - `ResetTimer` - Reset timeout timer.
+    /// - `Deliver` - Return a Sailfish consensus block to the caller.
+    /// - `SendProposal` - Reliably broadcast a vertex to the members in the committee.
+    /// - `SendTimeout` - Multicast a timeout message to the members in the committee.
+    /// - `SendTimeoutCert` - Multicast a timeout certificate to the members in the committee.
+    /// - `SendNoVote` - Send a no-vote to the leader in `r + 1` for a timeout in round `r`.
     pub async fn execute(&mut self, action: Action) -> Result<Option<SailfishStatusEvent>, C::Err> {
         match action {
             Action::ResetTimer(r) => {

--- a/sailfish/src/sailfish.rs
+++ b/sailfish/src/sailfish.rs
@@ -56,7 +56,7 @@ pub struct Sailfish<N: Comm + Send + 'static> {
 /// Implementation of the `HasInitializer` trait for `Sailfish<N>`, defining how to initialize
 /// a `Sailfish` instance from an `SailfishInitializer`.
 ///
-/// This trait provides an asynchronous method to construct a `Sailfish` from its initializer,
+/// This impl provides an asynchronous method to construct a `Sailfish` from its initializer,
 /// allowing for setup and configuration before the main structure is used.
 ///
 /// # Type Parameters

--- a/tests/src/tests/consensus/helpers/key_manager.rs
+++ b/tests/src/tests/consensus/helpers/key_manager.rs
@@ -24,7 +24,7 @@ pub struct KeyManager {
     committee: Committee,
 }
 
-/// Helper for all the keys in a committeee for testing purposes
+/// Helper for all the keys in a committeee for testing purposes.
 impl KeyManager {
     pub(crate) fn new(num_nodes: u8) -> Self {
         let key_pairs = (0..num_nodes).map(|i| (i, unsafe_zero_keypair(i as u64)));
@@ -35,7 +35,7 @@ impl KeyManager {
         }
     }
 
-    /// Create test helpers for all the nodes
+    /// Create test helpers for all the nodes.
     pub(crate) fn create_node_instruments(&self) -> Vec<TestNodeInstrument> {
         self.keys
             .iter()
@@ -49,7 +49,7 @@ impl KeyManager {
             .collect()
     }
 
-    /// For a given round create vertex message for each node in committee
+    /// For a given round create vertex message for each node in committee.
     pub(crate) fn create_vertex_msgs(&self, round: u64, edges: Vec<PublicKey>) -> Vec<Message> {
         self.keys
             .keys()
@@ -57,7 +57,8 @@ impl KeyManager {
             .collect()
     }
 
-    /// For a given round create vertex message for a given node in the committee, add the strong edges to public keys
+    /// For a given round create vertex message for a given node in the committee
+    /// and add the edges to public keys.
     pub(crate) fn create_vertex_msg_for_node_id(
         &self,
         id: u8,
@@ -71,7 +72,7 @@ impl KeyManager {
         Message::Vertex(e)
     }
 
-    /// For a given round, create a timeout message for all nodes in committee
+    /// For a given round, create a timeout message for all nodes in committee.
     pub(crate) fn create_timeout_msgs(&self, round: u64) -> Vec<Message> {
         self.keys
             .keys()
@@ -79,7 +80,7 @@ impl KeyManager {
             .collect()
     }
 
-    /// For a given round, create a timeout message for specified node id in committee
+    /// For a given round, create a timeout message for specified node id in committee.
     pub(crate) fn create_timeout_msg_for_node_id(&self, id: u8, round: u64) -> Message {
         let kpair = &self.keys[&id];
         let t = TimeoutMessage::new(self.gen_round_cert(round - 1).into(), kpair, true);
@@ -87,7 +88,7 @@ impl KeyManager {
         Message::Timeout(e)
     }
 
-    /// Get vertex edges for a round
+    /// Get vertex edges for a round.
     pub(crate) fn edges_for_round(
         &self,
         round: RoundNumber,
@@ -105,7 +106,7 @@ impl KeyManager {
             .collect()
     }
 
-    /// Create an envelope with signers for given type
+    /// Create an envelope with signers for given type.
     pub(crate) fn signers<T>(&self, value: T, count: usize) -> Vec<Envelope<T, Validated>>
     where
         T: Committable + Clone,
@@ -117,7 +118,7 @@ impl KeyManager {
         envs
     }
 
-    /// Setup dag for testing
+    /// Setup dag for testing.
     pub(crate) fn prepare_dag(
         &self,
         round: u64,
@@ -137,7 +138,7 @@ impl KeyManager {
         (dag, evidence, edges)
     }
 
-    /// Craft a vertex message for a given round and keypair
+    /// Craft a vertex message for a given round and keypair.
     pub(crate) fn create_vertex_proposal_msg(
         &self,
         round: RoundNumber,
@@ -148,7 +149,7 @@ impl KeyManager {
         Message::Vertex(e)
     }
 
-    /// Craft a timeout certificate with signers from committee
+    /// Craft a timeout certificate with signers from committee.
     pub(crate) fn gen_timeout_cert<N: Into<RoundNumber>>(&self, r: N) -> Certificate<Timeout> {
         let mut va = VoteAccumulator::new(self.committee.clone());
         let r = r.into();
@@ -158,7 +159,7 @@ impl KeyManager {
         va.into_certificate().unwrap()
     }
 
-    /// Craft a timeout certificate with signers from committee
+    /// Craft a timeout certificate with signers from committee.
     pub(crate) fn gen_round_cert<N: Into<RoundNumber>>(&self, r: N) -> Certificate<RoundNumber> {
         let mut va = VoteAccumulator::new(self.committee.clone());
         let r = r.into();

--- a/timeboost-core/src/types/vertex.rs
+++ b/timeboost-core/src/types/vertex.rs
@@ -40,7 +40,7 @@ impl Vertex {
         }
     }
 
-    /// Is the vertex from genesis round
+    /// Is this vertex from the genesis round?
     pub fn is_genesis(&self) -> bool {
         *self.round.data() == RoundNumber::genesis()
             && *self.round.data() == self.evidence.round()

--- a/timeboost-networking/src/lib.rs
+++ b/timeboost-networking/src/lib.rs
@@ -228,17 +228,13 @@ impl Network {
 }
 
 impl Server {
-    /// Handles the main loop for a the nodes network, this will last the lifetime of the app
+    /// Runs the main loop of this network node.
     ///
     /// This function:
-    /// - Tries to connect to each remote peer in the committee
-    /// - Handles tasks that have been completed or terminated
-    /// - Processes new messages we received on the network
     ///
-    /// # Panics
-    ///
-    /// This function panics if:
-    /// - We are unable to get the x25519 public key from ed25519 public key
+    /// - Tries to connect to each remote peer in the committee.
+    /// - Handles tasks that have been completed or terminated.
+    /// - Processes new messages we received on the network.
     async fn run(mut self, listener: TcpListener) -> Result<Empty> {
         self.handshake_tasks.spawn(pending());
         self.io_tasks.spawn(pending());
@@ -384,10 +380,11 @@ impl Server {
         }
     }
 
-    /// Handles when I/O task has been completed
+    /// Handles a completed I/O task.
     ///
-    /// This function will get the Public Key of the task that was terminated
-    /// Then cleanly remove the active I/O task and call `spawn_connect` to recreate the connection
+    /// This function will get the public key of the task that was terminated
+    /// and then cleanly removes the associated I/O task data and re-connects
+    /// to the peer node it was interacting with.
     fn on_io_task_end(&mut self, id: task::Id) {
         let Some(k) = self.task2key.remove(&id) else {
             error!(n = %self.key, "no key for task");
@@ -409,15 +406,10 @@ impl Server {
         }
     }
 
-    /// Spawns a new connection task to a peer identified by public key
+    /// Spawns a new connection task to a peer identified by public key.
     ///
-    /// This function will look up the x25519 Public Key from ed25519 key and the remote address then spawn a connection task
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if:
-    /// - If we do not have a mapping from remote peers ed25519 public key to x25519 public key
-    /// - If we do not have a mapping from remote peers ed25519 public key to remote peer address
+    /// This function will look up the x25519 public key of the ed25519 key
+    /// and the remote address and then spawn a connection task.
     fn spawn_connect(&mut self, k: PublicKey) {
         let x = self.index.get_by_left(&k).expect("known public key");
         let a = self.peers.get(&k).expect("known address");
@@ -425,17 +417,11 @@ impl Server {
             .spawn(connect(self.keypair.clone(), *x, *a));
     }
 
-    /// Spawns a new `Noise` responder handshake task, this is using `Noise` IK Handshake
+    /// Spawns a new `Noise` responder handshake task using the IK pattern.
     ///
-    /// This function will create the responders handshake machine using its own private key
-    /// Then spawn a task that listens for incoming initiator handshakes and responds
-    ///
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if:
-    /// - If the `NOISE_PARAMS` are invalid
-    /// - If we are unable to initialize our `HandshakeState` machine
+    /// This function will create the responder handshake machine using its
+    /// own private key and then spawn a task that awaits an initiator handshake
+    /// to which it will respond.
     fn spawn_handshake(&mut self, s: TcpStream) {
         let h = Builder::new(NOISE_PARAMS.parse().expect("valid noise params"))
             .local_private_key(&self.keypair.secret_key().as_bytes())
@@ -444,10 +430,9 @@ impl Server {
         self.handshake_tasks.spawn(on_handshake(h, s));
     }
 
-    /// Spawns a new I/O task for handling communication with a remote peer over a TCP connection
-    /// That is also using `Noise` for encryption and decryption
-    ///
-    /// This function will split the TCP stream into read and write halves for a TCP connection and spawn a task for each
+    /// Spawns a new I/O task for handling communication with a remote peer over
+    /// a TCP connection using the noise framework to create an authenticated
+    /// secure link.
     fn spawn_io(&mut self, k: PublicKey, s: TcpStream, t: TransportState) {
         debug!(n = %self.key, a = ?s.peer_addr().ok(), "starting i/o tasks");
         let (to_remote, from_remote) = mpsc::channel(256);

--- a/timeboost/src/api/endpoints.rs
+++ b/timeboost/src/api/endpoints.rs
@@ -27,7 +27,7 @@ impl TimeboostApiState {
         Self { app_tx }
     }
 
-    /// Run the timeboost api
+    /// Run the timeboost API.
     pub async fn run(self, url: Url) -> io::Result<()> {
         let api = define_api::<StaticVersion<0, 1>>()
             .map_err(|e| io::Error::new(ErrorKind::Other, e.to_string()))?;
@@ -41,7 +41,7 @@ impl TimeboostApiState {
 
 #[async_trait]
 impl TimeboostApi for TimeboostApiState {
-    /// Submit a transaction to timeboost layer
+    /// Submit a transaction to timeboost layer.
     async fn submit(&self, tx: Transaction) -> Result<(), ServerError> {
         let status = TimeboostStatusEvent {
             event: TimeboostEventType::Transactions {

--- a/timeboost/src/binaries/builder.rs
+++ b/timeboost/src/binaries/builder.rs
@@ -67,7 +67,7 @@ struct Cli {
     #[clap(long, short, default_value_t = 100)]
     tps: u32,
 
-    /// The ip address of the nitro node for gas estimations
+    /// The ip address of the nitro node for gas estimations.
     #[clap(long, default_value = "http://172.20.0.12:8547")]
     nitro_node_url: reqwest::Url,
 }


### PR DESCRIPTION
Some panic sections are removed if the panic is not expected. In accordance with the recommendation of `Option::expect`, expect messages should state why a panic should not or can not happen. An informal proof is ideal, but anything that convinces the reader that the `Option` is not or should not be a `None` is fine too. If stated this way, I do not think we should mention them in panic sections of doc comments. We also do not do this for various other expressions that can panic, e.g. indexing with the subscript operator.