### PR TITLE
Initial decryption phase

### DIFF
--- a/cliquenet/src/addr.rs
+++ b/cliquenet/src/addr.rs
@@ -19,12 +19,20 @@ impl Address {
         }
     }
 
-    /// We need to be able to set the port to something else.
+    /// Set the address port.
     pub fn set_port(&mut self, p: u16) {
         match self {
-            Self::Inet(ip, _) => *self = Self::Inet(*ip, p),
-            Self::Name(hn, _) => *self = Self::Name(hn.clone(), p),
+            Self::Inet(_, o) => *o = p,
+            Self::Name(_, o) => *o = p,
         }
+    }
+
+    pub fn with_port(mut self, p: u16) -> Self {
+        match self {
+            Self::Inet(ip, _) => self = Self::Inet(ip, p),
+            Self::Name(hn, _) => self = Self::Name(hn, p),
+        }
+        self
     }
 
     pub fn is_ip(&self) -> bool {

--- a/timeboost-crypto/benches/decryption.rs
+++ b/timeboost-crypto/benches/decryption.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_std::rand::RngCore;
@@ -36,7 +38,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("encrypt"));
         grp.throughput(Throughput::Bytes(len as u64));
         for size in committee_sizes {
-            let committee = Keyset::new(size, 0);
+            let committee = Keyset::new(0, NonZeroUsize::new(size).unwrap());
             let (pk, _, _) =
                 ShoupGennaro::<G, H, D>::keygen(rng, &committee).expect("generate key material");
             let plaintext = Plaintext::new(payload_bytes.to_vec());
@@ -54,7 +56,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("decrypt"));
         grp.throughput(Throughput::Bytes(len as u64));
         for size in committee_sizes {
-            let committee = Keyset::new(size, 0);
+            let committee = Keyset::new(0, NonZeroUsize::new(size).unwrap());
             let (pk, _, key_shares) =
                 ShoupGennaro::<G, H, D>::keygen(rng, &committee).expect("generate key material");
             let plaintext = Plaintext::new(payload_bytes.to_vec());
@@ -73,7 +75,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("combine"));
         grp.throughput(Throughput::Bytes(len as u64));
         for size in committee_sizes {
-            let committee = Keyset::new(size, 0);
+            let committee = Keyset::new(0, NonZeroUsize::new(size).unwrap());
             let (pk, comb_key, key_shares) =
                 ShoupGennaro::<G, H, D>::keygen(rng, &committee).expect("generate key material");
             let plaintext = Plaintext::new(payload_bytes.to_vec());

--- a/timeboost-crypto/benches/decryption.rs
+++ b/timeboost-crypto/benches/decryption.rs
@@ -7,7 +7,7 @@ use digest::{DynDigest, FixedOutputReset};
 use nimue::{DigestBridge, DuplexHash};
 use sha2::{Digest, Sha256};
 use timeboost_crypto::{
-    sg_encryption::ShoupGennaro, traits::threshold_enc::ThresholdEncScheme, Committee, Plaintext,
+    sg_encryption::ShoupGennaro, traits::threshold_enc::ThresholdEncScheme, Keyset, Plaintext,
 };
 
 const KB: usize = 1 << 10;
@@ -36,7 +36,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("encrypt"));
         grp.throughput(Throughput::Bytes(len as u64));
         for size in committee_sizes {
-            let committee = Committee { size, id: 0 };
+            let committee = Keyset::new(size, 0);
             let (pk, _, _) =
                 ShoupGennaro::<G, H, D>::keygen(rng, &committee).expect("generate key material");
             let plaintext = Plaintext::new(payload_bytes.to_vec());
@@ -54,7 +54,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("decrypt"));
         grp.throughput(Throughput::Bytes(len as u64));
         for size in committee_sizes {
-            let committee = Committee { size, id: 0 };
+            let committee = Keyset::new(size, 0);
             let (pk, _, key_shares) =
                 ShoupGennaro::<G, H, D>::keygen(rng, &committee).expect("generate key material");
             let plaintext = Plaintext::new(payload_bytes.to_vec());
@@ -73,7 +73,7 @@ where
         let mut grp = c.benchmark_group(benchmark_group_name("combine"));
         grp.throughput(Throughput::Bytes(len as u64));
         for size in committee_sizes {
-            let committee = Committee { size, id: 0 };
+            let committee = Keyset::new(size, 0);
             let (pk, comb_key, key_shares) =
                 ShoupGennaro::<G, H, D>::keygen(rng, &committee).expect("generate key material");
             let plaintext = Plaintext::new(payload_bytes.to_vec());

--- a/timeboost-crypto/src/cp_proof.rs
+++ b/timeboost-crypto/src/cp_proof.rs
@@ -8,6 +8,7 @@ use nimue::{
     },
     Arthur, DuplexHash, IOPattern,
 };
+use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
 use crate::traits::dleq_proof::{DleqProofError, DleqProofScheme};
@@ -62,7 +63,7 @@ impl<C: CurveGroup> DleqTuple<C> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct Proof {
     pub(crate) transcript: Vec<u8>,
 }

--- a/timeboost-crypto/src/lib.rs
+++ b/timeboost-crypto/src/lib.rs
@@ -249,10 +249,10 @@ impl DecryptionScheme {
     /// - A single public key for clients to encrypt their transaction bundles.
     /// - A single combination key to all nodes for combining partially decrypted ciphertexts.
     /// - One distinct private key share per node for partial decryption.
-    pub fn trusted_keygen(size: usize) -> TrustedKeyMaterial {
+    pub fn trusted_keygen(size: NonZeroUsize) -> TrustedKeyMaterial {
         // TODO: fix committee id when dynamic keysets
         let mut rng = ark_std::rand::thread_rng();
-        let keyset = Keyset::new(1, NonZeroUsize::new(size).expect("no non-zero keyset size"));
+        let keyset = Keyset::new(1, size);
         <DecryptionScheme as ThresholdEncScheme>::keygen(&mut rng, &keyset).unwrap()
     }
 }

--- a/timeboost-crypto/src/lib.rs
+++ b/timeboost-crypto/src/lib.rs
@@ -218,9 +218,11 @@ impl Plaintext {
     pub fn new(data: Vec<u8>) -> Self {
         Plaintext(data)
     }
+}
 
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
+impl From<Plaintext> for Vec<u8> {
+    fn from(plaintext: Plaintext) -> Self {
+        plaintext.0
     }
 }
 

--- a/timeboost-crypto/src/lib.rs
+++ b/timeboost-crypto/src/lib.rs
@@ -62,7 +62,7 @@ impl Keyset {
     }
 
     pub fn threshold(&self) -> NonZeroUsize {
-        NonZeroUsize::new(self.size.get().div_ceil(3)).expect("ceil(n/3) with n > 0 never gives 0")
+        NonZeroUsize::new(self.size.get() / 3).expect("ceil(n/3) with n > 0 never gives 0")
     }
 }
 

--- a/timeboost-crypto/src/lib.rs
+++ b/timeboost-crypto/src/lib.rs
@@ -35,9 +35,9 @@ impl From<u64> for KeysetId {
     }
 }
 
-impl Into<u64> for KeysetId {
-    fn into(self) -> u64 {
-        self.0
+impl From<KeysetId> for u64 {
+    fn from(val: KeysetId) -> Self {
+        val.0
     }
 }
 

--- a/timeboost-crypto/src/sg_encryption.rs
+++ b/timeboost-crypto/src/sg_encryption.rs
@@ -60,7 +60,7 @@ where
         rng: &mut R,
         committee: &Keyset,
     ) -> Result<(Self::PublicKey, Self::CombKey, Vec<Self::KeyShare>), ThresholdEncError> {
-        let committee_size = committee.size.get() as usize;
+        let committee_size = committee.size.get();
         let degree = committee_size / CORR_RATIO;
         let gen = C::generator();
         let poly: DensePolynomial<_> = DensePolynomial::rand(degree, rng);
@@ -177,7 +177,7 @@ where
         dec_shares: Vec<&Self::DecShare>,
         ciphertext: &Self::Ciphertext,
     ) -> Result<Self::Plaintext, ThresholdEncError> {
-        let committee_size: usize = committee.size.get() as usize;
+        let committee_size: usize = committee.size.get();
         let threshold = committee_size / CORR_RATIO + 1;
         let gen = C::generator();
 
@@ -359,7 +359,7 @@ mod test {
         let ciphertext =
             ShoupGennaro::<G, H, D>::encrypt(rng, &committee, &pk, &plaintext).unwrap();
 
-        let threshold = committee.threshold().get() as usize;
+        let threshold = committee.threshold().get();
         let dec_shares: Vec<_> = key_shares
             .iter()
             .map(|s| ShoupGennaro::<G, H, D>::decrypt(s, &ciphertext))
@@ -411,7 +411,7 @@ mod test {
         );
 
         // 2. Invalidate n - t shares
-        let committee_size = committee.size.get() as usize;
+        let committee_size = committee.size.get();
         let threshold = committee_size / 3;
         let first_correct_share = dec_shares[0].clone();
         // modify n - t shares

--- a/timeboost-crypto/src/sg_encryption.rs
+++ b/timeboost-crypto/src/sg_encryption.rs
@@ -411,11 +411,11 @@ mod test {
         );
 
         // 2. Invalidate n - t shares
-        let committee_size = committee.size.get();
-        let threshold = committee_size / 3;
+        let c_size = committee.size().get();
+        let c_threshold = committee.threshold().get();
         let first_correct_share = dec_shares[0].clone();
         // modify n - t shares
-        (0..(committee_size - threshold)).for_each(|i| {
+        (0..(c_size - c_threshold)).for_each(|i| {
             let mut share: DecShare<_> = dec_shares[i].clone();
             share.phi = Proof { transcript: vec![] };
             dec_shares[i] = share;

--- a/timeboost-crypto/src/traits/threshold_enc.rs
+++ b/timeboost-crypto/src/traits/threshold_enc.rs
@@ -1,7 +1,7 @@
 use ark_std::rand::Rng;
 use thiserror::Error;
 
-use crate::Committee;
+use crate::Keyset;
 
 /// A Threshold Encryption Scheme.
 pub trait ThresholdEncScheme {
@@ -17,13 +17,13 @@ pub trait ThresholdEncScheme {
     #[allow(clippy::type_complexity)]
     fn keygen<R: Rng>(
         rng: &mut R,
-        committee: &Committee,
+        committee: &Keyset,
     ) -> Result<(Self::PublicKey, Self::CombKey, Vec<Self::KeyShare>), ThresholdEncError>;
 
     /// Encrypt a `message` using the encryption key `pk`.
     fn encrypt<R: Rng>(
         rng: &mut R,
-        committee: &Committee,
+        committee: &Keyset,
         pk: &Self::PublicKey,
         message: &Self::Plaintext,
     ) -> Result<Self::Ciphertext, ThresholdEncError>;
@@ -36,7 +36,7 @@ pub trait ThresholdEncScheme {
 
     /// Combine a set of `dec_shares` using `comb_key` into a plaintext message.
     fn combine(
-        committee: &Committee,
+        committee: &Keyset,
         comb_key: &Self::CombKey,
         dec_shares: Vec<&Self::DecShare>,
         ciphertext: &Self::Ciphertext,
@@ -54,4 +54,6 @@ pub enum ThresholdEncError {
     Internal(anyhow::Error),
     #[error(transparent)]
     IOError(#[from] std::io::Error),
+    #[error(transparent)]
+    SerializationError(#[from] ark_serialize::SerializationError),
 }

--- a/timeboost-sequencer/Cargo.toml
+++ b/timeboost-sequencer/Cargo.toml
@@ -6,6 +6,8 @@ description.workspace = true
 
 [dependencies]
 blake3 = { workspace = true }
+bincode = { workspace = true }
+bimap = { workspace = true }
 cliquenet = { path = "../cliquenet" }
 committable = { workspace = true }
 metrics = { path = "../metrics" }
@@ -14,8 +16,8 @@ parking_lot = { workspace = true }
 sailfish = { path = "../sailfish" }
 serde = { workspace = true }
 thiserror = { workspace = true }
+timeboost-crypto = { path = "../timeboost-crypto" }
 timeboost-types = { path = "../timeboost-types" }
 timeboost-utils = { path = "../timeboost-utils" }
 tokio = { workspace = true }
 tracing = { workspace = true }
-

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -375,7 +375,7 @@ impl Worker {
             .lock()
             .iter()
             .filter(|(k, _)| k.round() == round)
-            .all(|(_, v)| usize::from(self.committee.threshold().get()) < v.len());
+            .all(|(_, v)| self.committee.threshold().get() < v.len());
 
         if !hatched {
             // ciphertexts are not ready to be decrypted.

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -107,7 +107,7 @@ impl Decrypter {
 
                 let (mut ptxs, mut txs) = incl.into_transactions();
                 for (i, m) in modified_ptxs.into_iter().enumerate() {
-                    ptxs[m] = PriorityBundle::new_compute_hash(
+                    ptxs[m] = PriorityBundle::new_with_hash(
                         ptxs[m].epoch(),
                         ptxs[m].seqno(),
                         dec[i].clone(),

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -1,37 +1,354 @@
-use std::collections::VecDeque;
-use std::future::{pending, Pending};
+use std::collections::BTreeMap;
 
-use timeboost_types::InclusionList;
+use std::sync::Arc;
 
-#[derive(Debug)]
+use bimap::BiMap;
+use cliquenet::Network;
+use multisig::Committee;
+use parking_lot::Mutex;
+use sailfish::types::RoundNumber;
+use timeboost_crypto::traits::threshold_enc::ThresholdEncScheme;
+use timeboost_crypto::{DecryptionScheme, Nonce};
+use timeboost_types::{
+    DecShareKey, DecryptionKey, InclusionList, KeysetId, PriorityBundle, ShareInfo, Transaction,
+};
+use tokio::spawn;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::task::JoinHandle;
+use tracing::{error, warn};
+
+type DecShare = <DecryptionScheme as ThresholdEncScheme>::DecShare;
+type Ciphertext = <DecryptionScheme as ThresholdEncScheme>::Ciphertext;
+type EncryptedData = Vec<(KeysetId, Vec<u8>)>;
+type DecryptedData = Vec<Vec<u8>>;
+
+const MAX_ROUNDS: usize = 100;
+
 pub struct Decrypter {
-    queue: VecDeque<InclusionList>,
-    forever: Pending<InclusionList>,
+    ready: BTreeMap<RoundNumber, Option<InclusionList>>,
+    incls: BTreeMap<RoundNumber, InclusionList>,
+    modified: BTreeMap<RoundNumber, (Vec<usize>, Vec<usize>)>,
+    enc_tx: Sender<(RoundNumber, EncryptedData)>,
+    dec_rx: Receiver<(RoundNumber, DecryptedData)>,
+    jh: JoinHandle<()>,
 }
 
 impl Decrypter {
-    pub fn new() -> Self {
+    pub fn new(net: Network, committee: Committee, dec_sk: DecryptionKey) -> Self {
+        let (enc_tx, enc_rx) = channel(MAX_ROUNDS);
+        let (dec_tx, dec_rx) = channel(MAX_ROUNDS);
+        let decrypter = Worker::new(net, committee, dec_sk);
+
         Self {
-            queue: VecDeque::new(),
-            forever: pending(),
+            ready: BTreeMap::new(),
+            incls: BTreeMap::new(),
+            modified: BTreeMap::new(),
+            enc_tx,
+            dec_rx,
+            jh: spawn(decrypter.go(enc_rx, dec_tx)),
         }
     }
 
-    pub fn enqueue<I>(&mut self, incl: I)
+    pub async fn enqueue<I>(&mut self, incls: I)
     where
         I: IntoIterator<Item = InclusionList>,
     {
-        self.queue.extend(incl);
+        // 1. extract encrypted txns from each inclusion list.
+        // 2. send the encrypted data to the worker.
+        for incl in incls {
+            let mut encrypted_data = Vec::new();
+            let round = incl.round();
+            self.incls.insert(round, incl.clone());
+            let (ptxs, txs) = incl.into_transactions();
+            let txs: Vec<_> = txs.into_iter().collect();
+            let mut modified_ptxs = Vec::new();
+            let mut modified_txs = Vec::new();
+            for (i, ptx) in ptxs.iter().enumerate() {
+                if ptx.encrypted() {
+                    encrypted_data.push((ptx.kid(), ptx.data().to_vec()));
+                    modified_ptxs.push(i);
+                }
+            }
+            for (i, tx) in txs.iter().enumerate() {
+                if tx.encrypted() {
+                    encrypted_data.push((tx.kid(), tx.data().to_vec()));
+                    modified_txs.push(i);
+                }
+            }
+            self.modified.insert(round, (modified_ptxs, modified_txs));
+            self.ready.insert(round, None);
+            if let Err(e) = self.enc_tx.send((round, encrypted_data)).await {
+                error!("failed to send encrypted data: {:?}", e);
+            }
+        }
     }
 
     pub async fn next(&mut self) -> Result<InclusionList, DecryptError> {
-        if let Some(i) = self.queue.pop_front() {
-            return Ok(i);
+        // 1. receive decrypted data for some round r.
+        // 2. reassemble incl list and mark round r as "ready".
+        // 3. if r is next round, then return list, otherwise, goto (1).
+        while let Some((r, dec)) = self.dec_rx.recv().await {
+            self.incls
+                .remove(&r)
+                .map(|incl| {
+                    let ptxs_len = incl.priority_bundles().len();
+                    let modified = self
+                        .modified
+                        .remove(&r)
+                        .expect("worker has incl list => was enqueued");
+
+                    let (mut ptxs, txs) = incl.clone().into_transactions();
+                    let mut txs = Vec::from_iter(txs);
+
+                    for (i, m) in modified.0.into_iter().enumerate() {
+                        ptxs[m] = PriorityBundle::new(
+                            ptxs[m].epoch(),
+                            ptxs[m].seqno(),
+                            dec[i].clone(),
+                            *ptxs[m].digest(),
+                            ptxs[m].kid(),
+                        );
+                    }
+
+                    for (i, m) in modified.1.into_iter().enumerate() {
+                        txs[m] = Transaction::new(
+                            txs[m].nonce(),
+                            txs[m].to(),
+                            dec[ptxs_len + i].clone(),
+                            txs[m].kid(),
+                        );
+                    }
+                    Some(incl)
+                })
+                .map(|incl| self.ready.insert(r, incl));
+
+            if let Some(entry) = self.ready.first_entry() {
+                if let Some(incl) = entry.get() {
+                    return Ok(incl.clone());
+                } else {
+                    warn!(
+                        "received decrypted txns for r={} but the next round is r={}",
+                        r,
+                        entry.key()
+                    );
+                }
+            }
         }
-        Ok(self.forever.clone().await)
+        Err(DecryptError::Unknown)
+    }
+}
+
+impl Drop for Decrypter {
+    fn drop(&mut self) {
+        self.jh.abort()
+    }
+}
+
+struct Worker {
+    net: Network,
+    committee: Committee,
+    dec_sk: DecryptionKey,
+    idx2nonce: BiMap<usize, Nonce>,
+    nonce2ct: BiMap<Nonce, Ciphertext>,
+    shares: Arc<Mutex<BTreeMap<DecShareKey, Vec<DecShare>>>>,
+}
+
+impl Worker {
+    pub fn new(net: Network, committee: Committee, dec_sk: DecryptionKey) -> Self {
+        Self {
+            net,
+            committee,
+            dec_sk,
+            idx2nonce: BiMap::new(),
+            nonce2ct: BiMap::new(),
+            shares: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    pub async fn go(
+        mut self,
+        mut enc_rx: Receiver<(RoundNumber, EncryptedData)>,
+        dec_tx: Sender<(RoundNumber, DecryptedData)>,
+    ) {
+        loop {
+            tokio::select! {
+                Ok((pubkey, bytes)) = self.net.receive() => {
+                    if let Ok(s) = bincode::deserialize::<ShareInfo>(&bytes) {
+                        if let Some((dec_round, dec_items)) = self.handle_shares(s).await {
+                            let _ = dec_tx.send((dec_round, dec_items)).await;
+                        } else {
+                            continue;
+                        }
+                    } else {
+                        warn!("failed to deserialize share from: {}", pubkey);
+                        continue;
+                    }
+                },
+                enc_txns = enc_rx.recv() => {
+                    if let Some(enc_txns) = enc_txns {
+                        if let Err(e) = self.submit_decrypt(enc_txns.0, enc_txns.1).await {
+                            warn!("failed to submit decrypt: {:?}", e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn submit_decrypt(
+        &mut self,
+        round: RoundNumber,
+        encrypted_item: Vec<(KeysetId, Vec<u8>)>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut cids = vec![];
+        let mut kids = vec![];
+        let mut dec_shares = vec![];
+        for (idx, item) in encrypted_item.iter().enumerate() {
+            let (kid, item) = item;
+            let ciphertext = match bincode::deserialize::<Ciphertext>(item) {
+                Ok(ciphertext) => ciphertext,
+                Err(_) => {
+                    warn!("failed to deserialize ciphertext");
+                    continue;
+                }
+            };
+            // mappings
+            let nonce = ciphertext.nonce();
+            self.nonce2ct.insert(nonce, ciphertext.clone());
+            self.idx2nonce.insert(idx, nonce);
+
+            match <DecryptionScheme as ThresholdEncScheme>::decrypt(
+                self.dec_sk.privkey(),
+                &ciphertext,
+            ) {
+                Ok(dec_share) => {
+                    let k = DecShareKey::new(round, nonce, *kid);
+                    self.shares
+                        .lock()
+                        .entry(k)
+                        .or_default()
+                        .push(dec_share.clone());
+
+                    cids.push(nonce);
+                    kids.push(*kid);
+                    dec_shares.push(dec_share);
+                }
+                Err(_) => {
+                    warn!("failed to create decryption share");
+                    continue;
+                }
+            }
+        }
+
+        let share_info = ShareInfo::new(round, kids, cids, dec_shares);
+        let _ = self.send(&share_info).await;
+
+        Ok(())
+    }
+
+    async fn send(&self, share: &ShareInfo) -> Result<(), Box<dyn std::error::Error>> {
+        let share_bytes = bincode::serialize(&share)?;
+        self.net
+            .multicast(share_bytes.into())
+            .await
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+    }
+
+    async fn handle_shares(&mut self, share: ShareInfo) -> Option<(RoundNumber, Vec<Vec<u8>>)> {
+        let round = share.round();
+        self.insert_shares(share);
+        self.check_shares(round).await
+    }
+
+    fn insert_shares(&self, share_info: ShareInfo) {
+        let cids = share_info.cids();
+        let shares = share_info.dec_shares();
+        let kids = share_info.kids();
+
+        if cids.len() != shares.len() || cids.len() != kids.len() {
+            error!("invalid share info format");
+        }
+        // add the shares to the map using round, keyset id and nonce as key.
+        for i in 0..cids.len() {
+            let cid = cids[i];
+            let s = shares[i].clone();
+
+            let k = DecShareKey::new(share_info.round(), cid, kids[i]);
+            self.shares.lock().entry(k).or_default().push(s);
+        }
+    }
+
+    async fn check_shares(&mut self, round: RoundNumber) -> Option<(RoundNumber, Vec<Vec<u8>>)> {
+        let ready = self
+            .shares
+            .lock()
+            .iter()
+            .filter(|(k, _)| k.round() == round)
+            .all(|(_, v)| usize::from(self.committee.threshold()) < v.len());
+
+        if ready {
+            let mut shares = self.shares.lock();
+            let mut to_remove = vec![];
+            let round_entries: Vec<_> = shares.iter().filter(|(k, _)| k.round() == round).collect();
+            let mut decrypted: Vec<Vec<u8>> = Vec::with_capacity(round_entries.len());
+            let committee = timeboost_crypto::Committee {
+                id: 0,
+                size: self.committee.size().get() as u64,
+            };
+            // combine decryption shares for each ciphertext
+            for (k, shares) in round_entries {
+                let cid = k.cid();
+                // TODO: make sure that the correct keyset is used for combining.
+                let ciphertext = match self.nonce2ct.get_by_left(cid) {
+                    Some(c) => c,
+                    None => {
+                        warn!("received sufficient shares but not the actual ciphertext");
+                        return None;
+                    }
+                };
+
+                let idx = match self.idx2nonce.get_by_right(cid) {
+                    Some(idx) => idx,
+                    None => {
+                        error!("cipertext is present but corresponding id is missing");
+                        return None;
+                    }
+                };
+
+                let decrypted_data = match DecryptionScheme::combine(
+                    &committee,
+                    self.dec_sk.combkey(),
+                    shares.iter().collect::<Vec<_>>(),
+                    ciphertext,
+                ) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        error!("unable to combine received shares {:?}", e);
+                        return None;
+                    }
+                };
+                to_remove.push(*cid);
+                decrypted[*idx] = decrypted_data.as_bytes().to_vec();
+            }
+
+            // clean up
+            shares.retain(|k, _| k.round() != round);
+            for cid in to_remove {
+                self.idx2nonce.remove_by_right(&cid);
+                self.nonce2ct.remove_by_left(&cid);
+            }
+
+            Some((round, decrypted))
+        } else {
+            // ciphertexts are not ready to be decrypted.
+            None
+        }
     }
 }
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
-pub enum DecryptError {}
+pub enum DecryptError {
+    #[error("unknown decryption error")]
+    Unknown,
+}

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -375,7 +375,7 @@ impl Worker {
             .lock()
             .iter()
             .filter(|(k, _)| k.round() == round)
-            .all(|(_, v)| usize::from(self.committee.threshold()) < v.len());
+            .all(|(_, v)| usize::from(self.committee.threshold().get()) < v.len());
 
         if !hatched {
             // ciphertexts are not ready to be decrypted.

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -409,7 +409,7 @@ impl Worker {
                     &ciphertext,
                 )
                 .map_err(DecryptError::Decryption)?;
-                Ok((idx, DecryptedItem(decrypted_data.as_bytes().to_vec())))
+                Ok((idx, DecryptedItem(decrypted_data.into())))
             })
             .collect::<Result<_, DecryptError>>()?;
 

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -17,7 +17,6 @@ use sailfish::Coordinator;
 use timeboost_crypto::Keyset;
 use timeboost_types::{Address, CandidateList, DelayedInboxIndex};
 use timeboost_types::{DecryptionKey, Transaction};
-use timeboost_utils::dec_addr;
 use timeboost_utils::types::prometheus::PrometheusMetrics;
 use tokio::select;
 use tracing::error;
@@ -80,8 +79,13 @@ impl Sequencer {
         let coordinator = Coordinator::new(rbc, consensus);
 
         let dec_keyset = Keyset::new(1, cons_keyset.size());
-        let dec_peers: Vec<_> = cfg.peers.iter().map(|(k, a)| (*k, dec_addr(a))).collect();
-        let dec_addr = dec_addr(&net::Address::from(cfg.bind));
+        let dec_peers: Vec<_> = cfg
+            .peers
+            .iter()
+            .map(|(k, a)| (*k, a.clone().with_port(a.port() + 250)))
+            .collect();
+        let dec_addr = net::Address::from(cfg.bind).with_port(cfg.bind.port() + 250);
+
         let dec_net = Network::create(
             dec_addr,
             cfg.keypair, // same auth

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -14,8 +14,8 @@ use sailfish::consensus::{Consensus, ConsensusMetrics};
 use sailfish::rbc::{Rbc, RbcConfig, RbcError, RbcMetrics};
 use sailfish::types::{Action, RoundNumber};
 use sailfish::Coordinator;
-use timeboost_types::{Address, Transaction};
-use timeboost_types::{CandidateList, DelayedInboxIndex};
+use timeboost_types::{Address, CandidateList, DelayedInboxIndex};
+use timeboost_types::{DecryptionKey, Transaction};
 use timeboost_utils::types::prometheus::PrometheusMetrics;
 use tokio::select;
 use tracing::error;
@@ -34,6 +34,7 @@ pub struct SequencerConfig {
     peers: Vec<(PublicKey, net::Address)>,
     bind: SocketAddr,
     index: DelayedInboxIndex,
+    dec_sk: DecryptionKey,
 }
 
 pub struct Sequencer {
@@ -52,7 +53,7 @@ impl Sequencer {
         let rbc_metrics = RbcMetrics::new(prom.as_ref());
         let net_metrics = NetworkMetrics::new(prom.as_ref(), cfg.peers.iter().map(|(k, _)| *k));
 
-        let committee = Committee::new(
+        let cons_keyset = Committee::new(
             cfg.peers
                 .iter()
                 .map(|(k, _)| *k)
@@ -60,19 +61,30 @@ impl Sequencer {
                 .map(|(i, key)| (i as u8, key)),
         );
 
-        let network =
-            Network::create(cfg.bind, cfg.keypair.clone(), cfg.peers, net_metrics).await?;
+        let cons_net = Network::create(
+            cfg.bind,
+            cfg.keypair.clone(),
+            cfg.peers.clone(),
+            net_metrics,
+        )
+        .await?;
 
-        let rcf = RbcConfig::new(cfg.keypair.clone(), committee.clone());
-        let rbc = Rbc::new(network, rcf.with_metrics(rbc_metrics));
+        let rcf = RbcConfig::new(cfg.keypair.clone(), cons_keyset.clone());
+        let rbc = Rbc::new(cons_net, rcf.with_metrics(rbc_metrics));
 
         let queue = TransactionQueue::new(cfg.priority_addr, cfg.index);
-        let consensus = Consensus::new(cfg.keypair, committee.clone(), queue.clone())
+        let consensus = Consensus::new(cfg.keypair.clone(), cons_keyset.clone(), queue.clone())
             .with_metrics(cons_metrics);
         let coordinator = Coordinator::new(rbc, consensus);
 
-        let includer = Includer::new(committee, cfg.index);
-        let decrypter = Decrypter::new();
+        let dec_peers: Vec<_> = cfg.peers.iter().map(|(k, a)| (*k, dec_addr(a))).collect();
+        let dec_addr = dec_addr(&net::Address::from(cfg.bind));
+        // decryption network uses the same auth keys
+        let dec_net =
+            Network::create(dec_addr, cfg.keypair, dec_peers, NetworkMetrics::default()).await?;
+
+        let includer = Includer::new(cons_keyset.clone(), cfg.index);
+        let decrypter = Decrypter::new(dec_net, cons_keyset, cfg.dec_sk);
         let sorter = Sorter::new();
 
         Ok(Self {
@@ -121,7 +133,7 @@ impl Sequencer {
                             self.transactions.update_transactions(&i, r);
                             inclusions.push(i)
                         }
-                        self.decrypter.enqueue(inclusions)
+                        self.decrypter.enqueue(inclusions).await;
                     },
                     Err(e) => {
                         error!("coordinator error: {}", e);
@@ -140,6 +152,12 @@ impl Sequencer {
             }
         }
     }
+}
+
+fn dec_addr(addr: &net::Address) -> net::Address {
+    let mut dec_addr = addr.clone();
+    dec_addr.set_port(addr.port() + 250);
+    dec_addr
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -14,6 +14,7 @@ use sailfish::consensus::{Consensus, ConsensusMetrics};
 use sailfish::rbc::{Rbc, RbcConfig, RbcError, RbcMetrics};
 use sailfish::types::{Action, RoundNumber};
 use sailfish::Coordinator;
+use timeboost_crypto::Keyset;
 use timeboost_types::{Address, CandidateList, DelayedInboxIndex};
 use timeboost_types::{DecryptionKey, Transaction};
 use timeboost_utils::dec_addr;
@@ -78,7 +79,7 @@ impl Sequencer {
             .with_metrics(cons_metrics);
         let coordinator = Coordinator::new(rbc, consensus);
 
-        let dec_keyset = timeboost_crypto::Keyset::new(1, cons_keyset.size().get() as u16);
+        let dec_keyset = Keyset::new(1, cons_keyset.size());
         let dec_peers: Vec<_> = cfg.peers.iter().map(|(k, a)| (*k, dec_addr(a))).collect();
         let dec_addr = dec_addr(&net::Address::from(cfg.bind));
         let dec_net = Network::create(

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -77,6 +77,7 @@ impl Sequencer {
             .with_metrics(cons_metrics);
         let coordinator = Coordinator::new(rbc, consensus);
 
+        let dec_keyset = timeboost_crypto::Keyset::new(1, cons_keyset.size().get() as u16);
         let dec_peers: Vec<_> = cfg.peers.iter().map(|(k, a)| (*k, dec_addr(a))).collect();
         let dec_addr = dec_addr(&net::Address::from(cfg.bind));
         // decryption network uses the same auth keys
@@ -84,7 +85,7 @@ impl Sequencer {
             Network::create(dec_addr, cfg.keypair, dec_peers, NetworkMetrics::default()).await?;
 
         let includer = Includer::new(cons_keyset.clone(), cfg.index);
-        let decrypter = Decrypter::new(dec_net, cons_keyset, cfg.dec_sk);
+        let decrypter = Decrypter::new(dec_net, dec_keyset, cfg.dec_sk);
         let sorter = Sorter::new();
 
         Ok(Self {

--- a/timeboost-sequencer/src/queue.rs
+++ b/timeboost-sequencer/src/queue.rs
@@ -61,7 +61,10 @@ impl TransactionQueue {
         inner.set_time(time);
 
         for mut t in it.into_iter() {
-            let kid = KeysetId::try_from(t.data()).expect("first 8 data bytes are keyset id");
+            let kid = match KeysetId::try_from(t.data()) {
+                Ok(kid) => kid,
+                Err(_) => continue,
+            };
             t.set_keyset(kid);
 
             if t.to() != inner.priority_addr {

--- a/timeboost-sequencer/src/queue.rs
+++ b/timeboost-sequencer/src/queue.rs
@@ -61,11 +61,11 @@ impl TransactionQueue {
         inner.set_time(time);
 
         for mut t in it.into_iter() {
-            let kid = match KeysetId::try_from(t.data()) {
-                Ok(kid) => kid,
-                Err(_) => continue,
-            };
-            t.set_keyset(kid);
+            if let Ok(kid) = KeysetId::try_from(t.data()) {
+                t.set_keyset(kid);
+            } else {
+                continue;
+            }
 
             if t.to() != inner.priority_addr {
                 inner.transactions.push_back((now, t));

--- a/timeboost-sequencer/src/queue.rs
+++ b/timeboost-sequencer/src/queue.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
 use sailfish::types::{DataSource, RoundNumber};
-use timeboost_types::{Address, Epoch, PriorityBundle, RetryList, Transaction};
+use timeboost_types::{Address, Epoch, KeysetId, PriorityBundle, RetryList, Transaction};
 use timeboost_types::{CandidateList, DelayedInboxIndex, InclusionList, Timestamp};
 
 const MIN_WAIT_TIME: Duration = Duration::from_millis(250);
@@ -59,8 +59,9 @@ impl TransactionQueue {
 
         inner.set_time(time);
 
-        for t in it.into_iter() {
-            // TODO: initial validity checks on data (mininum length, etc.)
+        for mut t in it.into_iter() {
+            let kid = KeysetId::parse_from(t.data());
+            t.set_keyset(kid);
             if t.to() != inner.priority_addr {
                 inner.transactions.push_back((now, t));
                 continue;

--- a/timeboost-sequencer/src/queue.rs
+++ b/timeboost-sequencer/src/queue.rs
@@ -4,7 +4,8 @@ use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
 use sailfish::types::{DataSource, RoundNumber};
-use timeboost_types::{Address, Epoch, KeysetId, PriorityBundle, RetryList, Transaction};
+use timeboost_crypto::KeysetId;
+use timeboost_types::{Address, Epoch, PriorityBundle, RetryList, Transaction};
 use timeboost_types::{CandidateList, DelayedInboxIndex, InclusionList, Timestamp};
 
 const MIN_WAIT_TIME: Duration = Duration::from_millis(250);
@@ -60,8 +61,9 @@ impl TransactionQueue {
         inner.set_time(time);
 
         for mut t in it.into_iter() {
-            let kid = KeysetId::parse_from(t.data());
+            let kid = KeysetId::try_from(t.data()).expect("first 8 data bytes are keyset id");
             t.set_keyset(kid);
+
             if t.to() != inner.priority_addr {
                 inner.transactions.push_back((now, t));
                 continue;

--- a/timeboost-sequencer/src/queue.rs
+++ b/timeboost-sequencer/src/queue.rs
@@ -60,6 +60,7 @@ impl TransactionQueue {
         inner.set_time(time);
 
         for t in it.into_iter() {
+            // TODO: initial validity checks on data (mininum length, etc.)
             if t.to() != inner.priority_addr {
                 inner.transactions.push_back((now, t));
                 continue;

--- a/timeboost-types/Cargo.toml
+++ b/timeboost-types/Cargo.toml
@@ -10,6 +10,7 @@ committable = { workspace = true }
 multisig = { path = "../multisig" }
 serde = { workspace = true }
 sailfish-types = { path = "../sailfish-types" }
+timeboost-crypto = { path = "../timeboost-crypto" }
 
 [dev-dependencies]
 quickcheck = "1"

--- a/timeboost-types/src/decryption.rs
+++ b/timeboost-types/src/decryption.rs
@@ -1,0 +1,108 @@
+use sailfish_types::RoundNumber;
+use serde::{Deserialize, Serialize};
+use timeboost_crypto::{traits::threshold_enc::ThresholdEncScheme, DecryptionScheme, Nonce};
+
+use crate::KeysetId;
+
+type KeyShare = <DecryptionScheme as ThresholdEncScheme>::KeyShare;
+
+type PublicKey = <DecryptionScheme as ThresholdEncScheme>::PublicKey;
+type CombKey = <DecryptionScheme as ThresholdEncScheme>::CombKey;
+type DecShare = <DecryptionScheme as ThresholdEncScheme>::DecShare;
+
+#[derive(Debug)]
+pub struct DecryptionKey {
+    pubkey: PublicKey,
+    combkey: CombKey,
+    privkey: KeyShare,
+}
+
+impl DecryptionKey {
+    pub fn new(pubkey: PublicKey, combkey: CombKey, privkey: KeyShare) -> Self {
+        DecryptionKey {
+            pubkey,
+            combkey,
+            privkey,
+        }
+    }
+
+    pub fn pubkey(&self) -> &PublicKey {
+        &self.pubkey
+    }
+
+    pub fn combkey(&self) -> &CombKey {
+        &self.combkey
+    }
+
+    pub fn privkey(&self) -> &KeyShare {
+        &self.privkey
+    }
+}
+
+/// Representing a set of shares from a single Timeboost node.
+/// If a round has multiple encrypted items (ciphertexts),
+/// they are "batched" in `ciphertexts` and `decryption_shares`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ShareInfo {
+    round: RoundNumber,
+    kids: Vec<KeysetId>,
+    cids: Vec<Nonce>,
+    dec_shares: Vec<DecShare>,
+}
+
+impl ShareInfo {
+    pub fn new(
+        round: RoundNumber,
+        kids: Vec<KeysetId>,
+        cids: Vec<Nonce>,
+        dec_shares: Vec<DecShare>,
+    ) -> Self {
+        ShareInfo {
+            round,
+            kids,
+            cids,
+            dec_shares,
+        }
+    }
+
+    pub fn round(&self) -> RoundNumber {
+        self.round
+    }
+
+    pub fn kids(&self) -> &[KeysetId] {
+        &self.kids
+    }
+
+    pub fn cids(&self) -> &[Nonce] {
+        &self.cids
+    }
+
+    pub fn dec_shares(&self) -> &[DecShare] {
+        &self.dec_shares
+    }
+}
+
+#[derive(Clone, Debug, Hash, Serialize, Deserialize, Ord, PartialEq, Eq, PartialOrd)]
+pub struct DecShareKey {
+    round: RoundNumber,
+    cid: Nonce,
+    kid: KeysetId,
+}
+
+impl DecShareKey {
+    pub fn new(round: RoundNumber, cid: Nonce, kid: KeysetId) -> Self {
+        DecShareKey { round, cid, kid }
+    }
+
+    pub fn round(&self) -> RoundNumber {
+        self.round
+    }
+
+    pub fn cid(&self) -> &Nonce {
+        &self.cid
+    }
+
+    pub fn kid(&self) -> &KeysetId {
+        &self.kid
+    }
+}

--- a/timeboost-types/src/decryption.rs
+++ b/timeboost-types/src/decryption.rs
@@ -1,8 +1,8 @@
 use sailfish_types::RoundNumber;
 use serde::{Deserialize, Serialize};
-use timeboost_crypto::{traits::threshold_enc::ThresholdEncScheme, DecryptionScheme, Nonce};
-
-use crate::KeysetId;
+use timeboost_crypto::{
+    traits::threshold_enc::ThresholdEncScheme, DecryptionScheme, KeysetId, Nonce,
+};
 
 type KeyShare = <DecryptionScheme as ThresholdEncScheme>::KeyShare;
 type PublicKey = <DecryptionScheme as ThresholdEncScheme>::PublicKey;

--- a/timeboost-types/src/decryption.rs
+++ b/timeboost-types/src/decryption.rs
@@ -38,9 +38,6 @@ impl DecryptionKey {
     }
 }
 
-/// Representing a set of shares from a single Timeboost node.
-/// If a round has multiple encrypted items (ciphertexts),
-/// they are "batched" in `ciphertexts` and `decryption_shares`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ShareInfo {
     round: RoundNumber,

--- a/timeboost-types/src/decryption.rs
+++ b/timeboost-types/src/decryption.rs
@@ -5,7 +5,6 @@ use timeboost_crypto::{traits::threshold_enc::ThresholdEncScheme, DecryptionSche
 use crate::KeysetId;
 
 type KeyShare = <DecryptionScheme as ThresholdEncScheme>::KeyShare;
-
 type PublicKey = <DecryptionScheme as ThresholdEncScheme>::PublicKey;
 type CombKey = <DecryptionScheme as ThresholdEncScheme>::CombKey;
 type DecShare = <DecryptionScheme as ThresholdEncScheme>::DecShare;

--- a/timeboost-types/src/inclusion_list.rs
+++ b/timeboost-types/src/inclusion_list.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{DelayedInboxIndex, Epoch, PriorityBundle, Timestamp, Transaction};
 use sailfish_types::RoundNumber;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct InclusionList {
     round: RoundNumber,
     time: Timestamp,

--- a/timeboost-types/src/inclusion_list.rs
+++ b/timeboost-types/src/inclusion_list.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{DelayedInboxIndex, Epoch, PriorityBundle, Timestamp, Transaction};
 use sailfish_types::RoundNumber;
 
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct InclusionList {
     round: RoundNumber,
     time: Timestamp,
@@ -53,6 +53,10 @@ impl InclusionList {
 
     pub fn timestamp(&self) -> Timestamp {
         self.time
+    }
+
+    pub fn round(&self) -> RoundNumber {
+        self.round
     }
 
     pub fn len(&self) -> usize {

--- a/timeboost-types/src/lib.rs
+++ b/timeboost-types/src/lib.rs
@@ -18,4 +18,4 @@ pub use inclusion_list::InclusionList;
 pub use retry_list::RetryList;
 pub use seqno::SeqNo;
 pub use time::{Epoch, Timestamp};
-pub use transaction::{KeysetId, PriorityBundle, Transaction};
+pub use transaction::{PriorityBundle, Transaction};

--- a/timeboost-types/src/lib.rs
+++ b/timeboost-types/src/lib.rs
@@ -1,5 +1,6 @@
 mod address;
 mod candidate_list;
+mod decryption;
 mod delayed_inbox;
 mod inclusion_list;
 mod retry_list;
@@ -11,9 +12,10 @@ pub mod math;
 
 pub use address::Address;
 pub use candidate_list::CandidateList;
+pub use decryption::{DecShareKey, DecryptionKey, ShareInfo};
 pub use delayed_inbox::DelayedInboxIndex;
 pub use inclusion_list::InclusionList;
 pub use retry_list::RetryList;
 pub use seqno::SeqNo;
 pub use time::{Epoch, Timestamp};
-pub use transaction::{PriorityBundle, Transaction};
+pub use transaction::{KeysetId, PriorityBundle, Transaction};

--- a/timeboost-types/src/transaction.rs
+++ b/timeboost-types/src/transaction.rs
@@ -1,5 +1,6 @@
 use committable::{Commitment, Committable, RawCommitmentBuilder};
 use serde::{Deserialize, Serialize};
+use timeboost_crypto::KeysetId;
 
 use crate::{Address, Epoch, SeqNo};
 
@@ -38,32 +39,6 @@ impl Committable for Nonce {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct KeysetId(u32);
-
-impl From<u32> for KeysetId {
-    fn from(value: u32) -> Self {
-        KeysetId(value)
-    }
-}
-
-impl From<&[u8]> for KeysetId {
-    fn from(v: &[u8]) -> Self {
-        Self(u32::from_be_bytes(
-            v[0..4].try_into().expect("4 bytes is always u32"),
-        ))
-    }
-}
-
-impl KeysetId {
-    pub fn parse_from(data: &[u8]) -> KeysetId {
-        if data.len() >= 4 {
-            return KeysetId::from(&data[..4]);
-        }
-        KeysetId(0)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Transaction {
     to: Address,
@@ -94,7 +69,7 @@ impl Transaction {
     }
 
     pub fn encrypted(&self) -> bool {
-        self.kid != KeysetId(0)
+        self.kid != KeysetId::from(0u64)
     }
 
     pub fn kid(&self) -> KeysetId {
@@ -166,7 +141,7 @@ impl PriorityBundle {
     }
 
     pub fn encrypted(&self) -> bool {
-        self.kid != KeysetId(0)
+        self.kid != KeysetId::from(0)
     }
 
     pub fn kid(&self) -> KeysetId {
@@ -189,7 +164,7 @@ impl From<Transaction> for PriorityBundle {
             seqno: t.nonce.to_seqno(),
             data: t.data,
             hash: t.hash,
-            kid: KeysetId(0),
+            kid: KeysetId::from(0),
         }
     }
 }

--- a/timeboost-types/src/transaction.rs
+++ b/timeboost-types/src/transaction.rs
@@ -123,7 +123,7 @@ impl PriorityBundle {
         }
     }
 
-    pub fn new_compute_hash(epoch: Epoch, seqno: SeqNo, data: Vec<u8>, kid: KeysetId) -> Self {
+    pub fn new_with_hash(epoch: Epoch, seqno: SeqNo, data: Vec<u8>, kid: KeysetId) -> Self {
         let h = blake3::hash(&data);
         Self::new(epoch, seqno, data, h.into(), kid)
     }

--- a/timeboost-utils/Cargo.toml
+++ b/timeboost-utils/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bs58 = { workspace = true }
 blake3 = { workspace = true }
+cliquenet = { path = "../cliquenet" }
 futures = { workspace = true }
 metrics = { path = "../metrics" }
 multisig = { path = "../multisig" }

--- a/timeboost-utils/Cargo.toml
+++ b/timeboost-utils/Cargo.toml
@@ -9,7 +9,6 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bs58 = { workspace = true }
 blake3 = { workspace = true }
-cliquenet = { path = "../cliquenet" }
 futures = { workspace = true }
 metrics = { path = "../metrics" }
 multisig = { path = "../multisig" }

--- a/timeboost-utils/src/lib.rs
+++ b/timeboost-utils/src/lib.rs
@@ -1,3 +1,5 @@
+use cliquenet::Address;
+
 pub mod types;
 
 pub fn unsafe_zero_keypair<N: Into<u64>>(i: N) -> multisig::Keypair {
@@ -14,4 +16,10 @@ pub fn sig_keypair_from_seed_indexed(seed: [u8; 32], index: u64) -> multisig::Ke
 
 pub fn bs58_encode(b: &[u8]) -> String {
     bs58::encode(b).into_string()
+}
+
+pub fn dec_addr(addr: &Address) -> Address {
+    let mut dec_addr = addr.clone();
+    dec_addr.set_port(addr.port() + 250);
+    dec_addr
 }

--- a/timeboost-utils/src/lib.rs
+++ b/timeboost-utils/src/lib.rs
@@ -1,5 +1,3 @@
-use cliquenet::Address;
-
 pub mod types;
 
 pub fn unsafe_zero_keypair<N: Into<u64>>(i: N) -> multisig::Keypair {
@@ -16,10 +14,4 @@ pub fn sig_keypair_from_seed_indexed(seed: [u8; 32], index: u64) -> multisig::Ke
 
 pub fn bs58_encode(b: &[u8]) -> String {
     bs58::encode(b).into_string()
-}
-
-pub fn dec_addr(addr: &Address) -> Address {
-    let mut dec_addr = addr.clone();
-    dec_addr.set_port(addr.port() + 250);
-    dec_addr
 }

--- a/timeboost/Cargo.toml
+++ b/timeboost/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = { workspace = true }
 tide-disco = { workspace = true }
 timeboost-core = { path = "../timeboost-core" }
 timeboost-crypto = { path = "../timeboost-crypto" }
+timeboost-types = { path = "../timeboost-types" }
 timeboost-utils = { path = "../timeboost-utils" }
 tokio = { workspace = true }
 toml = { workspace = true }

--- a/timeboost/src/binaries/builder.rs
+++ b/timeboost/src/binaries/builder.rs
@@ -140,7 +140,7 @@ async fn main() -> Result<()> {
 
     // Now, fetch the signature private key and decryption private key, preference toward the JSON config.
     // Note that the clone of the two fields explicitly avoids cloning the entire `PublicNodeInfo`.
-    let (sig_key, dec_key) = match (my_keyset.sig_pk.clone(), my_keyset.dec_pk.clone()) {
+    let (sig_key, dec_sk) = match (my_keyset.sig_pk.clone(), my_keyset.dec_pk.clone()) {
         // We found both in the JSON, we're good to go.
         (Some(sig_pk), Some(dec_pk)) => {
             let sig_key = multisig::SecretKey::try_from(sig_pk.as_str())
@@ -166,8 +166,8 @@ async fn main() -> Result<()> {
     };
 
     let keypair = Keypair::from(sig_key);
-    let deckey = keyset
-        .build_decryption_material(dec_key)
+    let dec_sk = keyset
+        .build_decryption_material(dec_sk)
         .expect("parse keyset");
 
     let (tb_app_tx, tb_app_rx) = channel(100);
@@ -245,7 +245,7 @@ async fn main() -> Result<()> {
         metrics_port: cli.metrics_port,
         peers: peer_hosts_and_keys,
         keypair,
-        deckey,
+        dec_sk,
         bind_address,
         nitro_url: cli.nitro_node_url,
         app_tx: tb_app_tx,

--- a/timeboost/src/binaries/builder.rs
+++ b/timeboost/src/binaries/builder.rs
@@ -6,7 +6,7 @@ use std::{
     path::PathBuf,
 };
 use timeboost::{
-    keyset::{private_keys, wait_for_live_peer, Keyset},
+    keyset::{private_keys, wait_for_live_peer, KeysetConfig},
     start_rpc_api, Timeboost, TimeboostInitializer,
 };
 use timeboost_core::traits::has_initializer::HasInitializer;
@@ -130,7 +130,7 @@ async fn main() -> Result<()> {
     ensure!(num < 20, "number of nodes must be less 20");
 
     // Read public key material
-    let keyset = Keyset::read_keyset(cli.keyset_file).expect("keyfile to exist and be valid");
+    let keyset = KeysetConfig::read_keyset(cli.keyset_file).expect("keyfile to exist and be valid");
 
     // Ensure the config exists for this keyset
     let my_keyset = keyset

--- a/timeboost/src/binaries/keygen.rs
+++ b/timeboost/src/binaries/keygen.rs
@@ -42,7 +42,7 @@ impl Scheme {
                 }
             }
             Self::Decryption => {
-                let (pub_key, comb_key, key_shares) = DecryptionScheme::trusted_keygen(num as u64);
+                let (pub_key, comb_key, key_shares) = DecryptionScheme::trusted_keygen(num as u16);
                 debug!("generating new threshold encryption keyset");
                 let pub_key = bs58_encode(&pub_key.as_bytes());
                 let comb_key = bs58_encode(&comb_key.as_bytes());

--- a/timeboost/src/binaries/keygen.rs
+++ b/timeboost/src/binaries/keygen.rs
@@ -42,7 +42,7 @@ impl Scheme {
                 }
             }
             Self::Decryption => {
-                let (pub_key, comb_key, key_shares) = DecryptionScheme::trusted_keygen(num as u16);
+                let (pub_key, comb_key, key_shares) = DecryptionScheme::trusted_keygen(num);
                 debug!("generating new threshold encryption keyset");
                 let pub_key = bs58_encode(&pub_key.as_bytes());
                 let comb_key = bs58_encode(&comb_key.as_bytes());

--- a/timeboost/src/binaries/sailfish.rs
+++ b/timeboost/src/binaries/sailfish.rs
@@ -17,7 +17,7 @@ use std::{
     time::Duration,
 };
 use timeboost::{
-    keyset::{private_keys, wait_for_live_peer, Keyset},
+    keyset::{private_keys, wait_for_live_peer, KeysetConfig},
     start_metrics_api, start_rpc_api, TransactionQueue,
 };
 use timeboost_core::{
@@ -213,7 +213,8 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     let num = cli.nodes.unwrap_or(4);
 
-    let keyset = Keyset::read_keyset(cli.keyset_file).context("Failed to read keyset file")?;
+    let keyset =
+        KeysetConfig::read_keyset(cli.keyset_file).context("Failed to read keyset file")?;
 
     let (app_tx, mut app_rx) = mpsc::channel(1024);
 

--- a/timeboost/src/keyset.rs
+++ b/timeboost/src/keyset.rs
@@ -12,7 +12,7 @@ type PublicKey = <DecryptionScheme as ThresholdEncScheme>::PublicKey;
 type CombKey = <DecryptionScheme as ThresholdEncScheme>::CombKey;
 
 #[derive(Deserialize)]
-pub struct Keyset {
+pub struct KeysetConfig {
     keyset: Vec<PublicNodeInfo>,
     dec_keyset: PublicDecInfo,
 }
@@ -37,11 +37,11 @@ pub struct PublicDecInfo {
     combkey: String,
 }
 
-impl Keyset {
+impl KeysetConfig {
     pub fn read_keyset(path: PathBuf) -> Result<Self> {
         ensure!(path.exists(), "File not found: {:?}", path);
         let data = fs::read_to_string(&path).context("Failed to read file")?;
-        let keyset: Keyset = from_str(&data).context("Failed to parse JSON")?;
+        let keyset: KeysetConfig = from_str(&data).context("Failed to parse JSON")?;
         Ok(keyset)
     }
 

--- a/timeboost/src/keyset.rs
+++ b/timeboost/src/keyset.rs
@@ -6,7 +6,7 @@ use multisig::SecretKey;
 use serde::Deserialize;
 use serde_json::from_str;
 use timeboost_crypto::{traits::threshold_enc::ThresholdEncScheme, DecryptionScheme};
-
+use timeboost_types::DecryptionKey;
 type KeyShare = <DecryptionScheme as ThresholdEncScheme>::KeyShare;
 type PublicKey = <DecryptionScheme as ThresholdEncScheme>::PublicKey;
 type CombKey = <DecryptionScheme as ThresholdEncScheme>::CombKey;
@@ -37,13 +37,6 @@ pub struct PublicDecInfo {
     combkey: String,
 }
 
-#[allow(dead_code)]
-pub struct DecryptionInfo {
-    pub pubkey: PublicKey,
-    pub combkey: CombKey,
-    pub privkey: KeyShare,
-}
-
 impl Keyset {
     pub fn read_keyset(path: PathBuf) -> Result<Self> {
         ensure!(path.exists(), "File not found: {:?}", path);
@@ -52,16 +45,12 @@ impl Keyset {
         Ok(keyset)
     }
 
-    pub fn build_decryption_material(&self, deckey: KeyShare) -> Result<DecryptionInfo> {
+    pub fn build_decryption_material(&self, deckey: KeyShare) -> Result<DecryptionKey> {
         let pubkey = PublicKey::try_from(self.dec_keyset.pubkey.as_str())
             .context("Failed to parse public key from keyset")?;
         let combkey = CombKey::try_from(self.dec_keyset.combkey.as_str())
             .context("Failed to parse combination key from keyset")?;
-        Ok(DecryptionInfo {
-            pubkey,
-            combkey,
-            privkey: deckey,
-        })
+        Ok(DecryptionKey::new(pubkey, combkey, deckey))
     }
 
     pub fn keyset(&self) -> &[PublicNodeInfo] {

--- a/timeboost/src/lib.rs
+++ b/timeboost/src/lib.rs
@@ -5,7 +5,6 @@ use anyhow::{bail, Result};
 use api::endpoints::TimeboostApiState;
 use api::metrics::serve_metrics_api;
 use cliquenet::{Address, Network, NetworkMetrics};
-use keyset::DecryptionInfo;
 use metrics::TimeboostMetrics;
 use parking_lot::Mutex;
 use reqwest::Url;
@@ -24,6 +23,7 @@ use timeboost_core::load_generation::{make_tx, tps_to_millis};
 use timeboost_core::types::block::sailfish::SailfishBlock;
 use timeboost_core::types::time::Timestamp;
 use timeboost_core::types::transaction::Transaction;
+use timeboost_types::DecryptionKey;
 use timeboost_utils::types::prometheus::PrometheusMetrics;
 use tokio::time::interval;
 use tokio::{sync::mpsc::channel, task::JoinHandle};
@@ -61,7 +61,7 @@ pub struct TimeboostInitializer {
     pub keypair: Keypair,
 
     /// The decryption key material for the node.
-    pub deckey: DecryptionInfo,
+    pub dec_sk: DecryptionKey,
 
     /// The bind address for the node.
     pub bind_address: SocketAddr,


### PR DESCRIPTION
closes: #31, #36 

## Prelims
The initial version of the decryption phase. 
The [Decentralized Timeboost Specification](https://github.com/OffchainLabs/decentralized-timeboost-spec?tab=readme-ov-file) does not treat the decryption phase in great detail (specifically the case of dishonest/offline nodes) which has spurred a set of questions during implementation. 

A subset of the questions are listed [below](#questions). Clarity on these points would aid design decisions and further interpretation of the spec.

For the same reason comprehensive error handling and testing is not considered in the scope of this PR. This will follow when there is agreement on most design decisions.

## Description

### Context
This PR implements the main part of the decryption phase. The `Decrypter` is responsible for replacing encrypted transactions (ciphertext bytes) with decrypted transactions (plaintext bytes) in the inclusion lists.
The decrypter will receive decryption shares from other nodes and is able to decrypt a ciphertext when the number of corresponding shares exceeds $t$ (if the shares are correctly constructed).
The decryption phase (`Decrypter`) de-duplicates (non-priority) duplicate transactions that could emerge in the resulting inclusion list post-decryption.

### Content
The `Decrypter` operates with a separate network instance (decryption network) and a separate keyset. Thus, it is decoupled from consensus communication (but still uses the same authentication keys).

The `Decrypter` has a main `Worker` task. Its job is to receive decryption shares from the network and send locally produced decryption shares to other nodes. In both cases the resulting decryption shares are stored in an `Incubator`. The `Incubator` contains ciphertexts and their corresponding decryption shares. When the number of decryption shares reaches $$t+1$$, the decryption shares can be combined and the ciphertext can be decrypted ("hatching").

The design of the `Decrypter` and `Worker` represents a modular approach where the `Worker` receives a list of (supposedly) encrypted items with its corresponding keyset id and produces a list of decrypted items while preserving the order of the items. The `Decrypter` handles re-assembling inclusion lists.

A decryption share may arrive before the node has locally processed the corresponding inclusion list in which case it has no knowledge about the ciphertext. Thus, the `Incubator` merely stores the ciphertext id (`cid`) which can be coupled with the correct ciphertext when it arrives on the local node's inclusion list.

### Misc
**Decryption Network**
For now the decryption network is merely instantiated with the consensus network configuration but with a port offset of 250. This is a temporary solution and we should introduce actual address/ports in the timeboost config for the decryption committee.

**Keyset Id as metdata**
The encryption scheme is augmented by adding the keyset id as input to the hash producing the symmetric key for encryption. This aligns with the concept of CCA-security with metadata and allows for access control where decryption is done only if metadata is consistent. 
(section 12.2.3 in https://toc.cryptobook.us/book.pdf)

**Prepending transaction data with Keyset Id**
This PR prepends an 8-byte keyset id to the transaction data as dictated by the spec. A non-encrypted transaction is prepended with 8 zero bytes to avoid ambiguity. This part of the spec raises a few questions (see below).

## Questions <a href="#questions" id="questions"/>
### Keyset Id
How does the transaction reveal which keyset that is needed for decryption? If we assume that a ciphertext (transaction data) is prepended with an 8-byte keyset id then how are non-priority txns supposed to preserve "normal transaction semantics". How is deduplication done on a transaction level if keyset is a part of the data? And do we need to prepend zero-bytes to non-encrypted txns to avoid ambiguity between transaction data bytes and keyset id bytes?
### Insufficient shares
What happens if enough shares are not being received to decrypt a round's ciphertexts?
- Sketch: Each ciphertext in the incubator can have a timer which can be started when the inclusion list has been produced. Upon timing out, the decryption of the round is dropped (we can additionally implement period retry share request within the time window which may increase the likelihood of receiving enough shares but ultimately the node has to move on).
- What is the ideal duration of the above timeout? If it is too small, we risk moving on without nodes being able to decrypt (due to async periods). If it is too high the nodes will stall (and other ciphertexts will queue up) waiting for shares even though the ciphertext has been decrypted by other nodes.
- What is the impact on block production? Missing decryption shares will seemingly result in inconsistent block production.
- Proposal: A decryption round is dropped when all transactions have been included in a block (by other nodes). Then the node can safely move on from decrypting this round. But extra bookkeeping is needed.
### Invalid ciphertexts and shares
- What happens if an inclusion list contains a ciphertext for an invalid (or sunset) keyset?
- What happens if we receive an invalid share from on or more nodes? This could significantly slow down the decryption phase. Should we introduce some kind of identifiable abort and ban misbehaving nodes?
### Rotating keysets and commitees
To what extend is it possible that a the committee for consensus will be different from the committee for decryption (physical machines). Will we allow for completely disjoint sets? If so, how will that work? More likely, a decryption committee could be a subset of the consensus committee? Or will it always be the same set of nodes but independent key sets?