### PR TITLE
Add priority bundle decoding.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ opt-level = 3
 
 [workspace.dependencies]
 aes-gcm = { version = "0.10.3" }
+alloy-consensus = { version = "0.11.1", features = ["serde"] }
+alloy-primitives = { version = "0.8.22", features = ["serde"] }
+alloy-rlp = "0.3.11"
 anyhow = "1.0.89"
 ark-bn254 = "0.5"
 ark-ec = "0.5"

--- a/timeboost-sequencer/Cargo.toml
+++ b/timeboost-sequencer/Cargo.toml
@@ -8,6 +8,7 @@ description.workspace = true
 blake3 = { workspace = true }
 cliquenet = { path = "../cliquenet" }
 committable = { workspace = true }
+ethereum_ssz = { workspace = true }
 metrics = { path = "../metrics" }
 multisig = { path = "../multisig" }
 parking_lot = { workspace = true }

--- a/timeboost-sequencer/src/include.rs
+++ b/timeboost-sequencer/src/include.rs
@@ -1,10 +1,10 @@
 use std::cmp::max;
 use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use multisig::Committee;
 use sailfish::types::RoundNumber;
-use timeboost_types::{math, PriorityBundle, RetryList, Transaction};
+use timeboost_types::{math, Hash, PriorityBundle, RetryList, Transaction};
 use timeboost_types::{CandidateList, DelayedInboxIndex, Epoch, InclusionList, SeqNo, Timestamp};
 
 #[derive(Debug)]
@@ -21,7 +21,7 @@ pub struct Includer {
     /// Consensus delayed inbox index.
     index: DelayedInboxIndex,
     /// Cache of transaction hashes for the previous 8 rounds.
-    cache: BTreeMap<RoundNumber, HashSet<[u8; 32]>>,
+    cache: BTreeMap<RoundNumber, HashSet<Hash>>,
 }
 
 impl Includer {
@@ -68,7 +68,7 @@ impl Includer {
             self.seqno = SeqNo::zero();
         }
 
-        let mut transactions: BTreeMap<Transaction, usize> = BTreeMap::new();
+        let mut transactions: HashMap<Transaction, usize> = HashMap::new();
         let mut bundles: BTreeMap<SeqNo, PriorityBundle> = BTreeMap::new();
         let mut retry = RetryList::new();
 

--- a/timeboost-sequencer/src/queue.rs
+++ b/timeboost-sequencer/src/queue.rs
@@ -60,7 +60,7 @@ impl TransactionQueue {
         inner.set_time(time);
 
         for t in it.into_iter() {
-            if t.to() != inner.priority_addr {
+            if t.to() != Some(inner.priority_addr) {
                 inner.transactions.push_back((now, t));
                 continue;
             }

--- a/timeboost-sequencer/src/sort.rs
+++ b/timeboost-sequencer/src/sort.rs
@@ -1,4 +1,11 @@
-use timeboost_types::{InclusionList, Transaction};
+use std::cmp::Ordering;
+
+use ssz::decode_list_of_variable_length_items as ssz_decode;
+use timeboost_types::{Bytes, InclusionList, Transaction};
+use tracing::warn;
+
+const MAX_BUNDLE_TXS: usize = 1024;
+const MAX_TXS_SIZE: usize = 1024 * 1024;
 
 #[derive(Debug)]
 pub struct Sorter {}
@@ -9,8 +16,52 @@ impl Sorter {
     }
 
     pub fn sort(&mut self, list: InclusionList) -> impl Iterator<Item = Transaction> {
-        // TODO
-        let (_, t) = list.into_transactions();
-        t.into_iter()
+        let seed = list.digest();
+
+        let (bundles, mut transactions) = list.into_transactions();
+
+        let mut priority = Vec::new();
+
+        for b in bundles {
+            match ssz_decode::<Bytes, Vec<_>>(b.data(), Some(MAX_BUNDLE_TXS)) {
+                Ok(txs) => {
+                    for t in txs {
+                        if t.len() > MAX_TXS_SIZE {
+                            warn!("transaction exceeds max. allowed size {MAX_TXS_SIZE}");
+                            continue;
+                        }
+                        match Transaction::decode(&t) {
+                            Ok(trx) => priority.push(trx),
+                            Err(err) => {
+                                warn!(%err, "failed to decode transaction")
+                            }
+                        }
+                    }
+                }
+                Err(err) => {
+                    warn!(?err, "failed to ssz-decode priority bundle")
+                }
+            }
+        }
+
+        transactions.sort_unstable_by(|x, y| compare(&seed, x, y));
+
+        priority.into_iter().chain(transactions)
     }
+}
+
+#[rustfmt::skip]
+fn compare(seed: &[u8], x: &Transaction, y: &Transaction) -> Ordering {
+    let mut hx = blake3::Hasher::new();
+    let mut hy = blake3::Hasher::new();
+
+    hx.update(seed);
+    hy.update(seed);
+
+    hx.update(x.from().as_deref().unwrap_or(&[]));
+    hy.update(y.from().as_deref().unwrap_or(&[]));
+
+    hx.finalize().as_bytes().cmp(hy.finalize().as_bytes())
+        .then_with(|| x.nonce().cmp(&y.nonce())
+        .then_with(|| x.digest().cmp(y.digest())))
 }

--- a/timeboost-types/Cargo.toml
+++ b/timeboost-types/Cargo.toml
@@ -5,11 +5,17 @@ edition.workspace = true
 description.workspace = true
 
 [dependencies]
+alloy-consensus = { workspace = true }
+alloy-primitives = { workspace = true }
+alloy-rlp = { workspace = true }
 blake3 = { workspace = true }
+bytes = { workspace = true }
 committable = { workspace = true }
+ethereum_ssz = { workspace = true }
 multisig = { path = "../multisig" }
 serde = { workspace = true }
 sailfish-types = { path = "../sailfish-types" }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 quickcheck = "1"

--- a/timeboost-types/src/address.rs
+++ b/timeboost-types/src/address.rs
@@ -1,12 +1,35 @@
+use std::ops::Deref;
+
+use alloy_primitives::Address as EthAddress;
 use committable::{Commitment, Committable, RawCommitmentBuilder};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct Address([u8; 32]);
+pub struct Address(EthAddress);
 
 impl Address {
     pub fn zero() -> Self {
-        Self([0; 32])
+        Self(EthAddress::ZERO)
+    }
+}
+
+impl AsRef<[u8]> for Address {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+impl From<EthAddress> for Address {
+    fn from(value: EthAddress) -> Self {
+        Self(value)
+    }
+}
+
+impl Deref for Address {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
     }
 }
 

--- a/timeboost-types/src/bytes.rs
+++ b/timeboost-types/src/bytes.rs
@@ -1,0 +1,39 @@
+use std::ops::Deref;
+
+#[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Bytes(bytes::Bytes);
+
+impl From<bytes::Bytes> for Bytes {
+    fn from(value: bytes::Bytes) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Bytes> for bytes::Bytes {
+    fn from(value: Bytes) -> Self {
+        value.0
+    }
+}
+
+impl Deref for Bytes {
+    type Target = bytes::Bytes;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl ssz::Decode for Bytes {
+    fn is_ssz_fixed_len() -> bool {
+        alloy_primitives::Bytes::is_ssz_fixed_len()
+    }
+
+    fn ssz_fixed_len() -> usize {
+        alloy_primitives::Bytes::ssz_fixed_len()
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        let b = alloy_primitives::Bytes::from_ssz_bytes(bytes)?;
+        Ok(Self(b.into()))
+    }
+}

--- a/timeboost-types/src/candidate_list.rs
+++ b/timeboost-types/src/candidate_list.rs
@@ -5,11 +5,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::{DelayedInboxIndex, Epoch, PriorityBundle, Timestamp, Transaction};
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct CandidateList(Arc<Inner>);
 
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename = "CandidateList")]
 struct Inner {
     time: Timestamp,

--- a/timeboost-types/src/inclusion_list.rs
+++ b/timeboost-types/src/inclusion_list.rs
@@ -1,18 +1,13 @@
-use std::collections::BTreeSet;
-
-use committable::{Commitment, Committable, RawCommitmentBuilder};
-use serde::{Deserialize, Serialize};
-
 use crate::{DelayedInboxIndex, Epoch, PriorityBundle, Timestamp, Transaction};
 use sailfish_types::RoundNumber;
 
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug)]
 pub struct InclusionList {
     round: RoundNumber,
     time: Timestamp,
     index: DelayedInboxIndex,
     priority: Vec<PriorityBundle>,
-    transactions: BTreeSet<Transaction>,
+    transactions: Vec<Transaction>,
 }
 
 impl InclusionList {
@@ -22,7 +17,7 @@ impl InclusionList {
             time: t,
             index: i,
             priority: Vec::new(),
-            transactions: BTreeSet::new(),
+            transactions: Vec::new(),
         }
     }
 
@@ -35,7 +30,8 @@ impl InclusionList {
     where
         I: IntoIterator<Item = Transaction>,
     {
-        self.transactions = it.into_iter().collect();
+        self.transactions.clear();
+        self.transactions.extend(it);
         self
     }
 
@@ -59,11 +55,11 @@ impl InclusionList {
         self.transactions.len() + self.priority.len()
     }
 
-    pub fn into_transactions(self) -> (Vec<PriorityBundle>, BTreeSet<Transaction>) {
+    pub fn into_transactions(self) -> (Vec<PriorityBundle>, Vec<Transaction>) {
         (self.priority, self.transactions)
     }
 
-    pub fn transactions(&self) -> &BTreeSet<Transaction> {
+    pub fn transactions(&self) -> &[Transaction] {
         &self.transactions
     }
 
@@ -74,23 +70,18 @@ impl InclusionList {
     pub fn delayed_inbox_index(&self) -> DelayedInboxIndex {
         self.index
     }
-}
 
-impl Committable for InclusionList {
-    fn commit(&self) -> Commitment<Self> {
-        let mut builder = RawCommitmentBuilder::new("InclusionList")
-            .u64_field("round", self.round.into())
-            .u64_field("time", self.time.into())
-            .u64_field("index", self.index.into())
-            .u64_field("priority", self.priority.len() as u64);
-        builder = self
-            .priority
-            .iter()
-            .fold(builder, |b, t| b.var_size_bytes(t.commit().as_ref()));
-        builder = builder.u64_field("transactions", self.transactions.len() as u64);
-        self.transactions
-            .iter()
-            .fold(builder, |b, t| b.var_size_bytes(t.commit().as_ref()))
-            .finalize()
+    pub fn digest(&self) -> [u8; 32] {
+        let mut h = blake3::Hasher::new();
+        h.update(&self.round.u64().to_be_bytes());
+        h.update(&u64::from(self.time).to_be_bytes());
+        h.update(&u64::from(self.index).to_be_bytes());
+        for b in &self.priority {
+            h.update(&b.digest()[..]);
+        }
+        for t in &self.transactions {
+            h.update(&t.digest()[..]);
+        }
+        h.finalize().into()
     }
 }

--- a/timeboost-types/src/lib.rs
+++ b/timeboost-types/src/lib.rs
@@ -1,4 +1,5 @@
 mod address;
+mod bytes;
 mod candidate_list;
 mod delayed_inbox;
 mod inclusion_list;
@@ -10,10 +11,11 @@ mod transaction;
 pub mod math;
 
 pub use address::Address;
+pub use bytes::Bytes;
 pub use candidate_list::CandidateList;
 pub use delayed_inbox::DelayedInboxIndex;
 pub use inclusion_list::InclusionList;
 pub use retry_list::RetryList;
 pub use seqno::SeqNo;
 pub use time::{Epoch, Timestamp};
-pub use transaction::{PriorityBundle, Transaction};
+pub use transaction::{Hash, PriorityBundle, Transaction};

--- a/timeboost-types/src/retry_list.rs
+++ b/timeboost-types/src/retry_list.rs
@@ -1,11 +1,10 @@
-use std::collections::BTreeSet;
-
 use crate::{PriorityBundle, Transaction};
+use std::collections::HashSet;
 
 #[derive(Debug, Default)]
 pub struct RetryList {
-    transactions: BTreeSet<Transaction>,
-    bundles: BTreeSet<PriorityBundle>,
+    transactions: HashSet<Transaction>,
+    bundles: HashSet<PriorityBundle>,
 }
 
 impl RetryList {
@@ -21,7 +20,7 @@ impl RetryList {
         self.bundles.insert(b);
     }
 
-    pub fn into_parts(self) -> (BTreeSet<Transaction>, BTreeSet<PriorityBundle>) {
+    pub fn into_parts(self) -> (HashSet<Transaction>, HashSet<PriorityBundle>) {
         (self.transactions, self.bundles)
     }
 }

--- a/timeboost-types/src/seqno.rs
+++ b/timeboost-types/src/seqno.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 #[derive(
     Debug, Clone, Default, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
 )]
-pub struct SeqNo(u128);
+#[serde(transparent)]
+pub struct SeqNo(u64);
 
 impl SeqNo {
     pub fn zero() -> Self {
@@ -23,24 +24,24 @@ impl Add<u64> for SeqNo {
     type Output = Self;
 
     fn add(self, rhs: u64) -> Self::Output {
-        Self(self.0 + u128::from(rhs))
+        Self(self.0 + rhs)
     }
 }
 
-impl From<u128> for SeqNo {
-    fn from(value: u128) -> Self {
+impl From<u64> for SeqNo {
+    fn from(value: u64) -> Self {
         Self(value)
     }
 }
 
-impl From<SeqNo> for u128 {
+impl From<SeqNo> for u64 {
     fn from(value: SeqNo) -> Self {
         value.0
     }
 }
 
 impl Deref for SeqNo {
-    type Target = u128;
+    type Target = u64;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -49,8 +50,6 @@ impl Deref for SeqNo {
 
 impl Committable for SeqNo {
     fn commit(&self) -> Commitment<Self> {
-        RawCommitmentBuilder::new("SeqNo")
-            .fixed_size_bytes(&self.0.to_be_bytes())
-            .finalize()
+        RawCommitmentBuilder::new("SeqNo").u64(self.0).finalize()
     }
 }

--- a/timeboost/Cargo.toml
+++ b/timeboost/Cargo.toml
@@ -20,7 +20,6 @@ clap = { workspace = true }
 cliquenet = { path = "../cliquenet" }
 committable = { workspace = true }
 dashmap = "6.1.0"
-derive_more = { version = "1", features = ["display"] } # for alloy
 dotenvy = { workspace = true }
 futures = { workspace = true }
 metrics = { path = "../metrics" }


### PR DESCRIPTION
The PR relies on the [`alloy`](https://crates.io/crates/alloy) family of crates to handle decoding of transactions. Their `nonce` is defined as an `u64` instead of `U256`, breaking the mapping to `Epoch` and `SeqNo` which assumes 32 bytes. For the time being I chose to use this anyway to implement SSZ decoding of priority bundles to transactions and to support the various transactions types. This will most likely be changed again but except for the delayed inbox transactions the ordering considers bundles and transactions with this PR.

On top of #272.