### PR TITLE
Require RBC votes to carry evidence.

### DIFF
--- a/sailfish-rbc/src/abraham.rs
+++ b/sailfish-rbc/src/abraham.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use async_trait::async_trait;
 use committable::Committable;
 use multisig::{Certificate, Committee, Envelope, Keypair, PublicKey, Validated};
-use sailfish_types::{Comm, Message, RawComm};
+use sailfish_types::{Comm, Evidence, Message, RawComm};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
@@ -38,7 +38,7 @@ enum Protocol<'a, T: Committable + Clone, Status: Clone> {
     /// A vote for an RBC proposal.
     ///
     /// The boolean flag indicates if the sender has received enough votes.
-    Vote(Envelope<Digest, Status>, bool),
+    Vote(Envelope<Digest, Status>, Evidence, bool),
 
     /// A quorum certificate for an RBC proposal.
     Cert(Certificate<Digest>),

--- a/sailfish-rbc/src/abraham/worker.rs
+++ b/sailfish-rbc/src/abraham/worker.rs
@@ -9,7 +9,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use committable::{Commitment, Committable};
 use multisig::{Certificate, Envelope, PublicKey, VoteAccumulator};
 use multisig::{Unchecked, Validated};
-use sailfish_types::{Evidence, Message, MessageKind, RawComm, RoundNumber, Vertex};
+use sailfish_types::{Evidence, Message, RawComm, RoundNumber, Vertex};
 use serde::{Serialize, de::DeserializeOwned};
 use tokio::sync::mpsc;
 use tokio::time::{self, Instant, Interval};
@@ -401,7 +401,7 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
             Protocol::Send(msg) => self.on_message(src, msg.into_owned()).await?,
             Protocol::Ack(dig) => self.on_ack(src, dig).await?,
             Protocol::Propose(msg) => self.on_propose(src, msg.into_owned()).await?,
-            Protocol::Vote(env, evi, done) => self.on_vote(env, evi, done).await?,
+            Protocol::Vote(env, evi, done) => self.on_vote(src, env, evi, done).await?,
             Protocol::GetRequest(dig) => self.on_get_request(src, dig).await?,
             Protocol::GetResponse(msg) => self.on_get_response(src, msg.into_owned()).await?,
             Protocol::Cert(crt) => self.on_cert(src, crt).await?,
@@ -478,10 +478,7 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
             }
         }
 
-        let Some(evidence) = msg.evidence().cloned() else {
-            warn!(%src, "message without evidence");
-            return Err(RbcError::InvalidMessage);
-        };
+        let evidence = vertex.data().evidence().clone();
 
         let messages = self.buffer.entry(digest.round()).or_default();
 
@@ -622,11 +619,12 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
     /// A proposal vote has been received.
     async fn on_vote(
         &mut self,
+        src: PublicKey,
         env: Envelope<Digest, Unchecked>,
-        evidence: Evidence,
+        evi: Evidence,
         done: bool,
     ) -> Result<()> {
-        trace!(node = %self.label, src = %env.signing_key(), %done, "vote received");
+        trace!(node = %self.label, %src, %done, "vote received");
         let Some(env) = env.validated(&self.config.committee) else {
             return Err(RbcError::InvalidMessage);
         };
@@ -635,15 +633,22 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
         let commit = digest.commit();
         let source = *env.signing_key();
 
-        // For unknown rounds we check the vote evidence to make sure
-        // a quorum of parties is backing the round prior to the vote.
-        if !self.buffer.contains_key(&digest.round()) {
-            if evidence.round() + 1 != digest.round() && !digest.round().is_genesis() {
-                warn!(node = %self.label, "invalid vote evidence round");
+        // If a vote for a round greater than our current latest round + 1 arrives,
+        // we demand evidence, that a quorum of parties is backing the round prior
+        // to that vote.
+        let latest_round = self
+            .buffer
+            .last_key_value()
+            .map(|(r, _)| *r)
+            .unwrap_or_else(RoundNumber::genesis);
+
+        if digest.round() > latest_round + 1 {
+            if evi.round() + 1 != digest.round() && !digest.round().is_genesis() {
+                warn!(node = %self.label, %src, "invalid vote evidence round");
                 return Err(RbcError::InvalidMessage);
             }
-            if !evidence.is_valid(&self.config.committee) {
-                warn!(node = %self.label, "invalid vote evidence");
+            if !evi.is_valid(&self.config.committee) {
+                warn!(node = %self.label, %src, "invalid vote evidence");
                 return Err(RbcError::InvalidMessage);
             }
         }
@@ -749,7 +754,7 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
                         "replying with our vote to sender"
                     );
                     let env = Envelope::signed(digest, &self.config.keypair, false);
-                    let vote = Protocol::<'_, T, Validated>::Vote(env, evidence, true);
+                    let vote = Protocol::<'_, T, Validated>::Vote(env, evi, true);
                     let bytes = serialize(&vote)?;
                     self.comm.send(source, bytes).await.map_err(RbcError::net)?;
                 }

--- a/sailfish-types/src/message.rs
+++ b/sailfish-types/src/message.rs
@@ -60,6 +60,14 @@ impl<T: Committable, S> Message<T, S> {
         }
     }
 
+    pub fn evidence(&self) -> Option<&Evidence> {
+        if let Self::Vertex(env) = self {
+            Some(env.data().evidence())
+        } else {
+            None
+        }
+    }
+
     pub fn is_vertex(&self) -> bool {
         matches!(self, Self::Vertex(_))
     }

--- a/sailfish-types/src/message.rs
+++ b/sailfish-types/src/message.rs
@@ -43,14 +43,6 @@ impl<T: Committable, S> Message<T, S> {
         }
     }
 
-    pub fn evidence(&self) -> Option<&Evidence> {
-        if let Self::Vertex(env) = self {
-            Some(env.data().evidence())
-        } else {
-            None
-        }
-    }
-
     pub fn is_vertex(&self) -> bool {
         matches!(self, Self::Vertex(_))
     }


### PR DESCRIPTION
Like with vertex proposals we want to prevent dishonest parties to send us votes arbitrarily many rounds ahead, which we then need to store and process. Therefore we require every vote to come with evidence taken from the message this vote applies to, so we can be sure a quorum of parties is behind the previous round. To avoid excessive signature checks we only verify the evidence signatures for rounds where we do not already have some data, as the evidence plays no role in RBC voting.