### PR TITLE
Run demo with encrypted bundles

### DIFF
--- a/test-configs/local.json
+++ b/test-configs/local.json
@@ -4,31 +4,31 @@
             "url": "127.0.0.1:8000",
             "pubkey": "HCVAkbpaXjt4NqHem1Qz2mHqKRbGFCHUf4VMbiB7jAYE",
             "sig_pk": "24f9BtAxuZziE4BWMYA6FvyBuedxU9SVsgsoVcyw3aEWagH8eXsV6zi2jLnSvRVjpZkf79HDJNicXSF6FpRWkCXg",
-            "dec_pk": "j3XAf69dZ6PN58ancTgfX1LCX35km7eUNGnYFV7GyHqUJT"
+            "dec_pk": "jMbTDiLo8tgyERv92mGrCAe1s3KnnnyqhQeSYte6vUhZy1"
         },
         {
             "url": "127.0.0.1:8001",
             "pubkey": "6v8B9RK6Noa6SX8rE6RXK972v6KFfVaLjC5sbCT9VoJn",
             "sig_pk": "2gtHurFq5yeJ8HGD5mHUPqniHbpEE83ELLpPqhxEvKhPJFcjMnUwdH2YsdhngMmQTqHo9B1Qna6uM13ug2Pir97k",
-            "dec_pk": "jLKYA3vULHfFmF5bSDxqyyAvEFLTB7PeCpoyaeWeZCvhRz"
+            "dec_pk": "jysmvvvwSHu872gmxkejPP8RxUDpSpKChnkPMVeXyRibwN"
         },
         {
             "url": "127.0.0.1:8002",
             "pubkey": "7MMmoPcqd8DnqD5Ji1xNUgkvkCtNoFEHwRPuYBqeF8Ni",
             "sig_pk": "4Y7yyg11MBYJaeD2UWCh5cto8wizJoUCqFm7YjMbY3hXyWSWVPgi7y1D9e7D78a1NcWdE4k59D6vK9f6eCpzVkbQ",
-            "dec_pk": "k5iait3tEdnSQaTa4ziLK34qGchx4QJf9ZcvkU92zZm1Ud"
+            "dec_pk": "kCioHtYdX7pUVXJLceFFKx7j4czcqDjjS52FYbvy2AuyQV"
         },
         {
             "url": "127.0.0.1:8003",
             "pubkey": "EofyDbHJGLFNG8D1J6xKj9XpSfooKTim982RU726Qnn4",
             "sig_pk": "zrjZDknq9nPhiBXKeG2PeotwxAayYkv2UFmxc2UsCGHsdu5vCsjqxn8ko2Rh2fWts76u6eCJYjDgKEaveutVhjW",
-            "dec_pk": "jDTVzaaC872g4mYJ1GTPppb5kkiriza2wTKULgTtr8smKY"
+            "dec_pk": "jVEU8hbv7uUntaDt4GgDxUKgoCu8UCXugx1coMeiVfn31L"
         },
         {
             "url": "127.0.0.1:8004",
             "pubkey": "86R3D2VHNUTN1eNS1SiPQiegDs88PKUewqc1zizH6vVD",
             "sig_pk": "jW98dJM94zuvhRCA1bGLiPjakePTc1CYPP2V5iCswfayZiYujGYdSoE1MYDa61dHCyzPdEvGNBDmnFHS6jf83Km",
-            "dec_pk": "kGRPGBJAtH7FVhLJF3LgZXvjJBwxXDVuyFa739yQu3cQNo"
+            "dec_pk": "jUzpdPzgxn2zpaLXaHJiWJ2jbbD3scsP8YqscA1uZGhPfZ"
         },
         {
             "url": "127.0.0.1:8005",
@@ -122,7 +122,7 @@
         }
     ],
     "dec_keyset": {
-        "pubkey": "mBoijLwsELDGVe5Wvh2sPBqKknoUmkzK617ZBZPw29bJS3",
-        "combkey": "5pA4j6iEko83D7Rz7oMLKMHiHAJ7UtXudGunbLUKUVoVWkiuXdVwyKNMLNQ4rxcJ6d6eLq6ekNnP5PmxEEkAoGaquKv6wGyvcxEEGVTJsAXjaJKmnKRRHe31NgNojxDQQKaR7dZyJhuxkSHQfZb9neMq7nZzjWcDjU32fQq6PwimjUNLRb6322VPgzEZLYZH1vZZ9auyx93pu5ozDLN9Uy8vfcCMoPyWHfwpc6xEaomMZgsXV8Q8Nngr82aFTHtBqoom2FYmpC78NsyzkbnKGZ6gn9GpqBbohyXdVin7KiC1jtMs2NbwKxQeY8AS6fGJJg9a8x83tnLJSnKwwnQimHziRGnhwK7tB1yV9VUq78zffKXWGyyMNdP8zDP2T4EPKUCEpdnmqBCnA1NCMSiAcBU35KRYm2FukXhTcTYno1JeejQGCZjsbeoT3UpGjW38Qfo4qSfV4tzrwpE9CjxokjkgxMY7zX59Nwf1KBB9mgdJRap9nCAzJRMtWBnQNfq8eLTUASSiEY3R5KoJkoxT8CWQiLgSQ8H8njosE954y32jz8qxpP4GUBFzfrsFEGuT7NBYCQUUGU6MhssXXRuoLMhfHyQyMjHHaNc4RMTiGXeDPHZY33PpxrYLst9JyMWwGPeCMPSNPiVc6zzjSSd49fKQgtiQEPwnNJyD5zh3sWsAvEBmvG1Vq8am1AjME53ygnXTpy7kFP6p4DXEqVSDcJfWWdeBoS8bGJMuZmTCmGGBvouFi3iuzsuQXJ6EjFZndrBspQTT6rG4UZBdpp5woD79rPnd4MCfxmKDcx95f1t2sECg3sPworLSm1KSuvTwohgBYPbMQKt9gL5WPQsc253nq9Z24jcBWdm1kYkpr9jnwe2f54aaGoXPUJmbXLKrsX9yufaow3Ne3CXyrGgCYQnwAhhbw5rEVm"
+        "pubkey": "kjGsCSgKRoBte3ohUroYzckRZCTknNbF44EagVmYGGp1YK",
+        "combkey": "AuMP7yjmQH98sUnn7gcP7UUEZ1zNNbzESuNFkizXXHLeyyeH89Ky6F3M5xQ5kDXHyBAuza2CJmyXG9r1n38dW5GYj3asqB1TJzxmCDpmQo7eGjQEgcfEhz521k91kymL7u14EaGriN43WfzDBvcvWjNq93tjTUpRtv4kBycAujLxsWUoaCZBFDVcYMrLAoNXAaCMZHNerseE5V9vqMmgDXRqXZZZtJFv6kgARqmqH"
     }
 }

--- a/timeboost-crypto/benches/decryption.rs
+++ b/timeboost-crypto/benches/decryption.rs
@@ -45,7 +45,7 @@ where
 
             grp.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
                 b.iter(|| {
-                    ShoupGennaro::<G, H, D>::encrypt(rng, &committee, &pk, &plaintext)
+                    ShoupGennaro::<G, H, D>::encrypt(rng, &committee.id(), &pk, &plaintext)
                         .expect("encrypt message");
                 });
             });
@@ -60,8 +60,9 @@ where
             let (pk, _, key_shares) =
                 ShoupGennaro::<G, H, D>::keygen(rng, &committee).expect("generate key material");
             let plaintext = Plaintext::new(payload_bytes.to_vec());
-            let ciphertext = ShoupGennaro::<G, H, D>::encrypt(rng, &committee, &pk, &plaintext)
-                .expect("encrypt message");
+            let ciphertext =
+                ShoupGennaro::<G, H, D>::encrypt(rng, &committee.id(), &pk, &plaintext)
+                    .expect("encrypt message");
             grp.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
                 b.iter(|| {
                     ShoupGennaro::<G, H, D>::decrypt(&key_shares[0], &ciphertext)
@@ -79,8 +80,9 @@ where
             let (pk, comb_key, key_shares) =
                 ShoupGennaro::<G, H, D>::keygen(rng, &committee).expect("generate key material");
             let plaintext = Plaintext::new(payload_bytes.to_vec());
-            let ciphertext = ShoupGennaro::<G, H, D>::encrypt(rng, &committee, &pk, &plaintext)
-                .expect("encrypt message");
+            let ciphertext =
+                ShoupGennaro::<G, H, D>::encrypt(rng, &committee.id(), &pk, &plaintext)
+                    .expect("encrypt message");
             let dec_shares: Vec<_> = key_shares
                 .iter()
                 .map(|s| ShoupGennaro::<G, H, D>::decrypt(s, &ciphertext))

--- a/timeboost-crypto/src/lib.rs
+++ b/timeboost-crypto/src/lib.rs
@@ -2,7 +2,6 @@ pub mod cp_proof;
 pub mod sg_encryption;
 pub mod traits;
 
-use alloy_rlp::{RlpDecodable, RlpEncodable};
 use ark_ec::CurveGroup;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use committable::{Commitment, Committable, RawCommitmentBuilder};
@@ -20,19 +19,7 @@ use traits::threshold_enc::ThresholdEncScheme;
 pub struct Nonce(u128);
 
 #[derive(
-    Debug,
-    Default,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Serialize,
-    Deserialize,
-    RlpDecodable,
-    RlpEncodable,
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
 )]
 pub struct KeysetId(u64);
 
@@ -93,7 +80,8 @@ impl Keyset {
     }
 
     pub fn threshold(&self) -> NonZeroUsize {
-        NonZeroUsize::new(self.size.get() / 3).expect("ceil(n/3) with n > 0 never gives 0")
+        let t = self.size().get().div_ceil(3);
+        NonZeroUsize::new(t).expect("ceil(n/3) with n > 0 never gives 0")
     }
 }
 
@@ -272,6 +260,12 @@ impl<C: CurveGroup> Ciphertext<C> {
     }
 }
 
+impl<C: CurveGroup> DecShare<C> {
+    pub fn index(&self) -> u32 {
+        self.index
+    }
+}
+
 // Type initialization for decryption scheme
 type G = ark_secp256k1::Projective;
 type H = Sha256;
@@ -319,11 +313,11 @@ impl ThresholdEncScheme for DecryptionScheme {
 
     fn encrypt<R: ark_std::rand::Rng>(
         rng: &mut R,
-        committee: &Keyset,
+        kid: &KeysetId,
         pk: &Self::PublicKey,
         message: &Self::Plaintext,
     ) -> Result<Self::Ciphertext, traits::threshold_enc::ThresholdEncError> {
-        <ShoupGennaro<G, H, D> as ThresholdEncScheme>::encrypt(rng, committee, pk, message)
+        <ShoupGennaro<G, H, D> as ThresholdEncScheme>::encrypt(rng, kid, pk, message)
     }
 
     fn decrypt(

--- a/timeboost-crypto/src/traits/threshold_enc.rs
+++ b/timeboost-crypto/src/traits/threshold_enc.rs
@@ -1,7 +1,7 @@
 use ark_std::rand::Rng;
 use thiserror::Error;
 
-use crate::Keyset;
+use crate::{Keyset, KeysetId};
 
 /// A Threshold Encryption Scheme.
 pub trait ThresholdEncScheme {
@@ -23,7 +23,7 @@ pub trait ThresholdEncScheme {
     /// Encrypt a `message` using the encryption key `pk`.
     fn encrypt<R: Rng>(
         rng: &mut R,
-        committee: &Keyset,
+        kid: &KeysetId,
         pk: &Self::PublicKey,
         message: &Self::Plaintext,
     ) -> Result<Self::Ciphertext, ThresholdEncError>;

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -152,7 +152,7 @@ impl Sequencer {
 
         let task = Task {
             label,
-            transactions: queue.clone(),
+            bundles: queue.clone(),
             sailfish: Coordinator::new(rbc, consensus),
             includer: Includer::new(committee, cfg.index),
             decrypter: Decrypter::new(cfg.keypair.public_key(), network, keyset, cfg.dec_sk),
@@ -248,7 +248,7 @@ impl Task {
                         }
                         for (round, candidates) in lists {
                             let (i, r) = self.includer.inclusion_list(round, candidates);
-                            self.transactions.update_bundles(&i, r);
+                            self.bundles.update_bundles(&i, r);
                             if let Err(err) = self.decrypter.enqueue(i).await {
                                 error!(%err, "decrypt enqueue error");
                             }

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -88,7 +88,7 @@ impl Drop for Sequencer {
 
 struct Task {
     label: PublicKey,
-    transactions: BundleQueue,
+    bundles: BundleQueue,
     sailfish: Coordinator<CandidateList, Rbc<CandidateList>>,
     includer: Includer,
     decrypter: Decrypter,

--- a/timeboost-sequencer/src/queue.rs
+++ b/timeboost-sequencer/src/queue.rs
@@ -11,7 +11,7 @@ use tracing::trace;
 const MIN_WAIT_TIME: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Clone)]
-pub struct TransactionQueue(Arc<Mutex<Inner>>);
+pub struct BundleQueue(Arc<Mutex<Inner>>);
 
 #[derive(Debug)]
 struct Inner {
@@ -33,7 +33,7 @@ impl Inner {
     }
 }
 
-impl TransactionQueue {
+impl BundleQueue {
     pub fn new(prio: Address, idx: DelayedInboxIndex) -> Self {
         Self(Arc::new(Mutex::new(Inner {
             priority_addr: prio,
@@ -86,7 +86,7 @@ impl TransactionQueue {
         }
     }
 
-    pub fn update_transactions(&self, incl: &InclusionList, retry: RetryList) {
+    pub fn update_bundles(&self, incl: &InclusionList, retry: RetryList) {
         let mut inner = self.0.lock();
 
         // Retain priority bundles not in the inclusion list.
@@ -131,7 +131,7 @@ impl TransactionQueue {
     }
 }
 
-impl DataSource for TransactionQueue {
+impl DataSource for BundleQueue {
     type Data = CandidateList;
 
     fn next(&mut self, r: RoundNumber) -> Self::Data {

--- a/timeboost-types/src/bundle.rs
+++ b/timeboost-types/src/bundle.rs
@@ -74,6 +74,11 @@ impl Bundle {
         self.data = d;
         self.update_hash()
     }
+
+    pub fn set_kid(&mut self, kid: KeysetId) {
+        self.kid = Some(kid);
+        self.update_hash()
+    }
 }
 
 #[cfg(feature = "arbitrary")]

--- a/timeboost-utils/Cargo.toml
+++ b/timeboost-utils/Cargo.toml
@@ -11,9 +11,13 @@ test = ["committable", "crossbeam-queue", "sailfish-types"]
 [dependencies]
 anyhow = { workspace = true }
 arbitrary = { workspace = true }
+ark-std = { workspace = true }
 async-trait = { workspace = true }
-bs58 = { workspace = true }
+bincode = { workspace = true }
 blake3 = { workspace = true }
+bs58 = { workspace = true }
+bytes = { workspace = true }
+ethereum_ssz = { workspace = true }
 futures = { workspace = true }
 metrics = { path = "../metrics" }
 multisig = { path = "../multisig" }
@@ -21,8 +25,9 @@ parking_lot = { workspace = true }
 prometheus = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
-ethereum_ssz = { workspace = true }
+serde = { workspace = true }
 tide-disco = { workspace = true }
+timeboost-crypto = { path = "../timeboost-crypto" }
 timeboost-types = { path = "../timeboost-types", features = ["arbitrary"] }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/timeboost-utils/src/load_generation.rs
+++ b/timeboost-utils/src/load_generation.rs
@@ -1,19 +1,55 @@
 use arbitrary::{Arbitrary, Unstructured};
-use rand::Rng;
-use timeboost_types::{Bundle, BundleVariant, SignedPriorityBundle};
+use ark_std::rand::{self, Rng};
+use bincode::error::EncodeError;
+use bytes::{BufMut, Bytes, BytesMut};
+use serde::Serialize;
+use timeboost_crypto::{
+    DecryptionScheme, KeysetId, Plaintext, traits::threshold_enc::ThresholdEncScheme,
+};
+use timeboost_types::{Address, Bundle, BundleVariant, PriorityBundle, SeqNo, Signer};
 
-pub fn make_bundle() -> BundleVariant {
+type EncKey = <DecryptionScheme as ThresholdEncScheme>::PublicKey;
+
+pub fn make_bundle(pubkey: &EncKey) -> anyhow::Result<BundleVariant> {
+    let mut rng = rand::thread_rng();
     let mut v = [0; 256];
-    rand::fill(&mut v);
+    rng.fill(&mut v);
     let mut u = Unstructured::new(&v);
-    if rand::rng().random_bool(0.1) {
-        BundleVariant::Priority(SignedPriorityBundle::arbitrary(&mut u, 10).unwrap())
+
+    let max_seqno = 10;
+    let kid = KeysetId::from(1);
+    let mut bundle = Bundle::arbitrary(&mut u)?;
+
+    if rng.gen_bool(0.1) {
+        // encrypt bundle
+        let data = bundle.data();
+        let plaintext = Plaintext::new(data.to_vec());
+        let ciphertext = DecryptionScheme::encrypt(&mut rng, &kid, pubkey, &plaintext)?;
+        let encoded = serialize(&ciphertext)?;
+        bundle.set_data(encoded.into());
+        bundle.set_kid(kid);
+    }
+    if rng.gen_bool(0.1) {
+        // priority
+        let auction = Address::default();
+        let seqno = SeqNo::from(u.int_in_range(1..=max_seqno)?);
+        let signer = Signer::default();
+        let priority = PriorityBundle::new(bundle, auction, seqno);
+        let signed_priority = priority.sign(signer)?;
+        Ok(BundleVariant::Priority(signed_priority))
     } else {
-        BundleVariant::Regular(Bundle::arbitrary(&mut u).unwrap())
+        // non-priority
+        Ok(BundleVariant::Regular(Bundle::arbitrary(&mut u)?))
     }
 }
 
 /// Transactions per second to milliseconds is 1000 / TPS
 pub fn tps_to_millis<N: Into<u64>>(tps: N) -> u64 {
     1000 / tps.into()
+}
+
+fn serialize<T: Serialize>(d: &T) -> Result<Bytes, EncodeError> {
+    let mut b = BytesMut::new().writer();
+    bincode::serde::encode_into_std_write(d, &mut b, bincode::config::standard())?;
+    Ok(b.into_inner().freeze())
 }


### PR DESCRIPTION
### Content
This PR extends the current load generator so it also encrypts a subset of (non-)priority bundles.

### Additional Changes
- Encryption scheme has been updated such that encryption (`encrypt`) only takes the keysetId as argument and not the full Keyset definition (committee size is not relevant for encryption).
- Introduce a BTreeMap into the Incubator to avoid having duplicate shares when combining.
- Updates local.json to ensure correct decryption for committees of size 5 (Note that decryption will not work for other committee sizes until we have adjusted our config/keyset approach).
- Fixes a bug in our decryption threshold to correctly compute ceiling division.