### PR TITLE
Ensure deduplication cache invariants.

### DIFF
--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -67,6 +67,10 @@ impl Decrypter {
         }
     }
 
+    pub fn has_capacity(&mut self) -> bool {
+        self.dec_tx.capacity() > 0 && self.enc_tx.capacity() > 0
+    }
+
     /// Identifies encrypted txns in inclusion lists and sends the
     /// encrypted data to the worker for hatching.
     pub async fn enqueue(&mut self, incl: InclusionList) -> Result<(), DecryptError> {

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -299,7 +299,7 @@ impl Task {
                     }
                     // Unless we passively observe, stop execution if
                     // garbage collection goes past our latest processed round.
-                    Action::Gc(r) if self.mode.is_active() && self.round < r => {
+                    Action::Gc(r) if self.mode.is_active() && r >= self.round => {
                         self.actions.push_front(action);
                         debug!(node = %self.label, round = %r, "gc cutoff reached");
                         break 'outer;

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -332,13 +332,14 @@ impl Task {
             self.bundles.update_bundles(&outcome.ilist, outcome.retry);
             if !outcome.is_valid {
                 self.mode = Mode::Passive;
+                self.bundles.set_mode(self.mode);
                 info!(node = %self.label, %round, "passive mode");
                 continue;
-            } else {
-                if self.mode.is_passive() {
-                    info!(node = %self.label, %round, "entering active mode");
-                }
+            }
+            if self.mode.is_passive() {
+                info!(node = %self.label, %round, "entering active mode");
                 self.mode = Mode::Active;
+                self.bundles.set_mode(self.mode);
             }
             return Some(outcome.ilist);
         }

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -114,6 +114,10 @@ impl Mode {
     fn is_active(self) -> bool {
         matches!(self, Self::Active)
     }
+
+    fn is_passive(self) -> bool {
+        matches!(self, Self::Passive)
+    }
 }
 
 impl Sequencer {
@@ -318,8 +322,10 @@ impl Task {
                 info!(node = %self.label, %round, "passive mode");
                 continue;
             } else {
+                if self.mode.is_passive() {
+                    info!(node = %self.label, %round, "entering active mode");
+                }
                 self.mode = Mode::Active;
-                info!(node = %self.label, %round, "active mode");
             }
             if let Err(err) = self.decrypter.enqueue(outcome.ilist).await {
                 error!(node = %self.label, %err, "decrypt enqueue error");

--- a/timeboost-sequencer/src/metrics.rs
+++ b/timeboost-sequencer/src/metrics.rs
@@ -3,14 +3,8 @@ use metrics::{Gauge, Metrics, NoMetrics};
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct SequencerMetrics {
-    /// Sailfish round number.
-    pub sailfish_round: Box<dyn Gauge>,
-    /// Timeboost round number.
-    pub timeboost_round: Box<dyn Gauge>,
     /// Unix time.
     pub time: Box<dyn Gauge>,
-    /// Number of Sailfish actions.
-    pub sailfish_actions: Box<dyn Gauge>,
     /// Number of priority bundles in queue.
     pub queued_priority: Box<dyn Gauge>,
     /// Number of regular bundles in queue.
@@ -26,10 +20,7 @@ impl Default for SequencerMetrics {
 impl SequencerMetrics {
     pub fn new<M: Metrics>(m: &M) -> Self {
         Self {
-            sailfish_round: m.create_gauge("sailfish_round", None),
-            timeboost_round: m.create_gauge("timeboost_round", None),
             time: m.create_gauge("sequencer_time", Some("s")),
-            sailfish_actions: m.create_gauge("sailfish_actions", None),
             queued_priority: m.create_gauge("queued_prio_bundles", None),
             queued_regular: m.create_gauge("queued_reg_bundles", None),
         }

--- a/timeboost-sequencer/src/queue.rs
+++ b/timeboost-sequencer/src/queue.rs
@@ -87,7 +87,11 @@ impl BundleQueue {
     }
 
     pub fn update_bundles(&self, incl: &InclusionList, retry: RetryList) {
+        let time = Timestamp::now();
+
         let mut inner = self.0.lock();
+
+        inner.set_time(time);
 
         // Retain priority bundles not in the inclusion list.
         if let Some(bundles) = inner.priority.get_mut(&incl.epoch()) {
@@ -103,22 +107,28 @@ impl BundleQueue {
             });
         }
 
-        // Retain transactions not in the inclusion list.
+        // Retain regular bundles not in the inclusion list.
         inner
             .regular
             .retain(|(_, t)| !incl.regular_bundles().contains(t));
 
-        // Process transactions and bundles that should be retried:
         let (priority, regular) = retry.into_parts();
 
-        let now = inner
+        let earliest = inner
             .regular
             .front()
             .map(|(t, _)| *t)
             .unwrap_or_else(Instant::now);
 
-        for t in regular {
-            inner.regular.push_front((now, t));
+        let current_epoch = inner.time.epoch();
+
+        for b in regular {
+            if b.epoch() < current_epoch {
+                // Transactions that have not progressed in the protocol for
+                // over a minute can be discarded.
+                continue;
+            }
+            inner.regular.push_front((earliest, b));
         }
 
         for b in priority {

--- a/timeboost-sequencer/src/queue.rs
+++ b/timeboost-sequencer/src/queue.rs
@@ -126,7 +126,7 @@ impl BundleQueue {
         let current_epoch = inner.time.epoch();
 
         for b in regular {
-            if b.epoch() < current_epoch {
+            if b.epoch() + 1 < current_epoch {
                 // Transactions that have not progressed in the protocol for
                 // over a minute can be discarded.
                 continue;


### PR DESCRIPTION
During the inclusion phase, the cache must end with at least 8 consecutive rounds to allow a node to participate in subsequent phases.

Edit: This also changes the way, Sailfish is allowed to get ahead of Timeboost.