### PR TITLE
Fix priority bundles

### DIFF
--- a/timeboost-sequencer/src/queue.rs
+++ b/timeboost-sequencer/src/queue.rs
@@ -1,10 +1,13 @@
+use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
 use sailfish::types::{DataSource, RoundNumber};
-use timeboost_types::{Address, Bundle, BundleVariant, Epoch, RetryList, SignedPriorityBundle};
+use timeboost_types::{
+    Address, Bundle, BundleVariant, Epoch, RetryList, SeqNo, SignedPriorityBundle,
+};
 use timeboost_types::{CandidateList, DelayedInboxIndex, InclusionList, Timestamp};
 use tracing::trace;
 
@@ -21,7 +24,7 @@ struct Inner {
     priority_addr: Address,
     time: Timestamp,
     index: DelayedInboxIndex,
-    priority: BTreeMap<Epoch, Vec<SignedPriorityBundle>>,
+    priority: BTreeMap<Epoch, BTreeMap<SeqNo, SignedPriorityBundle>>,
     regular: VecDeque<(Instant, Bundle)>,
     metrics: Arc<SequencerMetrics>,
     mode: Mode,
@@ -75,7 +78,11 @@ impl BundleQueue {
                     match b.validate(epoch_now, Some(inner.priority_addr)) {
                         Ok(_) => {
                             let epoch = b.bundle().epoch();
-                            inner.priority.entry(epoch).or_default().push(b);
+                            inner
+                                .priority
+                                .entry(epoch)
+                                .or_default()
+                                .insert(b.seqno(), b);
                         }
                         Err(e) => {
                             trace!(signer = ?b.sender(), err = %e, "bundle validation failed")
@@ -88,7 +95,7 @@ impl BundleQueue {
         inner
             .metrics
             .queued_priority
-            .set(inner.priority.values().map(Vec::len).sum());
+            .set(inner.priority.values().map(BTreeMap::len).sum());
         inner.metrics.queued_regular.set(inner.regular.len());
     }
 
@@ -105,15 +112,8 @@ impl BundleQueue {
 
         // Retain priority bundles not in the inclusion list.
         if let Some(bundles) = inner.priority.get_mut(&incl.epoch()) {
-            bundles.retain(|b| {
-                if let Ok(i) = incl
-                    .priority_bundles()
-                    .binary_search_by_key(&b.seqno(), |x| x.seqno())
-                {
-                    incl.priority_bundles()[i] != *b
-                } else {
-                    true
-                }
+            incl.priority_bundles().iter().for_each(|b| {
+                bundles.remove(&b.seqno());
             });
         }
 
@@ -122,6 +122,7 @@ impl BundleQueue {
             .regular
             .retain(|(_, t)| !incl.regular_bundles().contains(t));
 
+        // Process bundles that should be retried:
         let (priority, regular) = retry.into_parts();
 
         let earliest = inner
@@ -145,14 +146,24 @@ impl BundleQueue {
             inner
                 .priority
                 .entry(b.bundle().epoch())
-                .or_default()
-                .push(b)
+                .and_modify(|bundles| match bundles.entry(b.seqno()) {
+                    Entry::Vacant(e) => {
+                        e.insert(b.clone());
+                    }
+                    Entry::Occupied(mut e) => {
+                        let sb = e.get_mut();
+                        if b.digest() < sb.digest() {
+                            *sb = b.clone();
+                        }
+                    }
+                })
+                .or_insert([(b.seqno(), b)].into());
         }
 
         inner
             .metrics
             .queued_priority
-            .set(inner.priority.values().map(Vec::len).sum());
+            .set(inner.priority.values().map(BTreeMap::len).sum());
         inner.metrics.queued_regular.set(inner.regular.len());
     }
 }
@@ -176,6 +187,7 @@ impl DataSource for BundleQueue {
             .priority
             .get(&inner.time.epoch())
             .cloned()
+            .map(|map| map.into_values().collect::<Vec<_>>())
             .unwrap_or_default();
 
         let regular = inner

--- a/timeboost-utils/src/load_generation.rs
+++ b/timeboost-utils/src/load_generation.rs
@@ -14,10 +14,10 @@ pub fn make_bundle(_pubkey: &EncKey) -> anyhow::Result<BundleVariant> {
     let max_seqno = 10;
     let bundle = Bundle::arbitrary(&mut u)?;
 
-    if rng.gen_bool(0.1) {
+    if rng.gen_bool(0.5) {
         // priority
         let auction = Address::default();
-        let seqno = SeqNo::from(u.int_in_range(1..=max_seqno)?);
+        let seqno = SeqNo::from(u.int_in_range(0..=max_seqno)?);
         let signer = Signer::default();
         let priority = PriorityBundle::new(bundle, auction, seqno);
         let signed_priority = priority.sign(signer)?;

--- a/timeboost-utils/src/load_generation.rs
+++ b/timeboost-utils/src/load_generation.rs
@@ -1,34 +1,19 @@
 use arbitrary::{Arbitrary, Unstructured};
 use ark_std::rand::{self, Rng};
-use bincode::error::EncodeError;
-use bytes::{BufMut, Bytes, BytesMut};
-use serde::Serialize;
-use timeboost_crypto::{
-    DecryptionScheme, KeysetId, Plaintext, traits::threshold_enc::ThresholdEncScheme,
-};
+use timeboost_crypto::{DecryptionScheme, traits::threshold_enc::ThresholdEncScheme};
 use timeboost_types::{Address, Bundle, BundleVariant, PriorityBundle, SeqNo, Signer};
 
 type EncKey = <DecryptionScheme as ThresholdEncScheme>::PublicKey;
 
-pub fn make_bundle(pubkey: &EncKey) -> anyhow::Result<BundleVariant> {
+pub fn make_bundle(_pubkey: &EncKey) -> anyhow::Result<BundleVariant> {
     let mut rng = rand::thread_rng();
     let mut v = [0; 256];
     rng.fill(&mut v);
     let mut u = Unstructured::new(&v);
 
     let max_seqno = 10;
-    let kid = KeysetId::from(1);
-    let mut bundle = Bundle::arbitrary(&mut u)?;
+    let bundle = Bundle::arbitrary(&mut u)?;
 
-    if rng.gen_bool(0.1) {
-        // encrypt bundle
-        let data = bundle.data();
-        let plaintext = Plaintext::new(data.to_vec());
-        let ciphertext = DecryptionScheme::encrypt(&mut rng, &kid, pubkey, &plaintext)?;
-        let encoded = serialize(&ciphertext)?;
-        bundle.set_data(encoded.into());
-        bundle.set_kid(kid);
-    }
     if rng.gen_bool(0.1) {
         // priority
         let auction = Address::default();
@@ -39,17 +24,11 @@ pub fn make_bundle(pubkey: &EncKey) -> anyhow::Result<BundleVariant> {
         Ok(BundleVariant::Priority(signed_priority))
     } else {
         // non-priority
-        Ok(BundleVariant::Regular(Bundle::arbitrary(&mut u)?))
+        Ok(BundleVariant::Regular(bundle))
     }
 }
 
 /// Transactions per second to milliseconds is 1000 / TPS
 pub fn tps_to_millis<N: Into<u64>>(tps: N) -> u64 {
     1000 / tps.into()
-}
-
-fn serialize<T: Serialize>(d: &T) -> Result<Bytes, EncodeError> {
-    let mut b = BytesMut::new().writer();
-    bincode::serde::encode_into_std_write(d, &mut b, bincode::config::standard())?;
-    Ok(b.into_inner().freeze())
 }


### PR DESCRIPTION
**First PR in a series of upcoming changes.** This temporarily disables encrypted load_gen to enable downstream fixes before re-enabling encryption.

## Context

If a priority bundle isn’t included—e.g., because another bundle with the same sequence number but lower hash takes precedence—it gets added to the retry list. These retried bundles are then blindly appended to the bundle queue in the next round.

The spec touches on this behavior [here](https://github.com/OffchainLabs/decentralized-timeboost-spec/blob/e314d70f9d0ebabccea17a59804e3b90ec96b936/inclusion.md?plain=1#L152), noting that the retry mechanism helps ensure eventual inclusion.

The core issue is that retried bundles are naively re-added, regardless of conflicts at the same sequence number. This causes Sailfish to accumulate increasingly large vertices until it either fails or a new epoch resets the priority queue.

### Load Generator as Amplification

Profiling Timeboost on a test like transaction-order—which uses large bundles—quickly reveals the issue: most of the time is spent creating and committing vertices.

Additionally, because priority bundles are distributed in the same way as non-priority bundles (i.e., broadcast to all nodes), the problem is amplified. This results in an even greater buildup of bundles with duplicate sequence numbers.

### Relation to the Coupon Collector’s Problem

So did this ever work? Have Timeboost ever produced inclusion lists with priority bundles?

Yes—despite the underlying issue, Timeboost has occasionally produced inclusion lists containing priority bundles. In particular, the transaction-order test would sometimes manage to push priority bundles through, triggering transient errors in downstream logic such as decryption.

Why only occasionally? In the test, load_gen submits priority bundles with probability $p=0.1$ over 500 transactions, yielding around 50 priority candidates. However, due to how Transaction::arbitrary assigns timestamps—targeting the current epoch only 50% of the time—only about half (≈25) are actually eligible for inclusion in the current round.

Now, what’s the chance these ~25 transactions cover all sequence numbers in the target set {0,...,10}? This is a variation of the [Coupon Collector’s Problem](https://en.wikipedia.org/wiki/Coupon_collector%27s_problem), where the expected number of samples needed to collect all $n$ unique items is $\Theta(n \log n)$. 
For $n=11$, the expected number is approximately 26.

So with just 25 eligible priority bundles per test run, it’s unsurprising that full coverage—and thus successful inclusion—only happens occasionally.

### Why do we only see this issue now

Previously, the load generator submitted transactions and priority bundles with payloads around 8 bytes, allowing Sailfish to run longer before hitting issues with large vertices. Now that bundle sizes are in the 100–200 byte range, the problem surfaces much more quickly—often within just a few rounds.

While tests like transaction-order verify that Timeboost nodes agree on the produced transactions and bundles, they don’t check whether the output matches the load that was generated. A test validating this alignment would have caught the bug earlier.

Lastly, the shift to a bundle-centric model introduced a related bug in load_gen: it only generated priority bundles with seqno in  {0,...,10}. As a result, these bundles consistently failed verification, since the inclusion phase expects sequence numbers to start at 0 in each epoch.

## Rationale

This PR introduces sequence number deduplication on the queuing phase, before consensus. While no rational client should submit multiple bundles with the same sequence number and epoch, if it does happen, this change ensures deduplication happens early—when forming the candidate list—rather than after consensus. This prevents Sailfish from wasting resources processing duplicate data that would ultimately be filtered out during final inclusion list construction anyway.

## Content

The PR contains the following changes:

1. Removes encrypted bundle logic from load generation (see justification above).

2. Applies deduplication to retried bundles by storing priority bundles in a BTreeMap keyed by sequence number.

3. Fixes a bug in load generation to ensure priority bundle sequence numbers are sampled uniformly from the range [0, 10], inclusive.