### PR TITLE
Fix decryption

### DIFF
--- a/timeboost-sequencer/src/include.rs
+++ b/timeboost-sequencer/src/include.rs
@@ -125,8 +125,8 @@ impl Includer {
                         .insert(*rb.digest());
                     include.push(rb)
                 }
-            } else {
-                retry.add_regular(rb)
+            } else if self.is_unknown(&rb) {
+                retry.add_regular(rb);
             }
         }
 

--- a/timeboost-utils/src/load_generation.rs
+++ b/timeboost-utils/src/load_generation.rs
@@ -1,19 +1,34 @@
 use arbitrary::{Arbitrary, Unstructured};
 use ark_std::rand::{self, Rng};
-use timeboost_crypto::{DecryptionScheme, traits::threshold_enc::ThresholdEncScheme};
+use bincode::error::EncodeError;
+use bytes::{BufMut, Bytes, BytesMut};
+use serde::Serialize;
+use timeboost_crypto::{
+    DecryptionScheme, KeysetId, Plaintext, traits::threshold_enc::ThresholdEncScheme,
+};
 use timeboost_types::{Address, Bundle, BundleVariant, PriorityBundle, SeqNo, Signer};
 
 type EncKey = <DecryptionScheme as ThresholdEncScheme>::PublicKey;
 
-pub fn make_bundle(_pubkey: &EncKey) -> anyhow::Result<BundleVariant> {
+pub fn make_bundle(pubkey: &EncKey) -> anyhow::Result<BundleVariant> {
     let mut rng = rand::thread_rng();
     let mut v = [0; 256];
     rng.fill(&mut v);
     let mut u = Unstructured::new(&v);
 
     let max_seqno = 10;
-    let bundle = Bundle::arbitrary(&mut u)?;
+    let mut bundle = Bundle::arbitrary(&mut u)?;
 
+    let kid = KeysetId::from(1);
+    if rng.gen_bool(0.5) {
+        // encrypt bundle
+        let data = bundle.data();
+        let plaintext = Plaintext::new(data.to_vec());
+        let ciphertext = DecryptionScheme::encrypt(&mut rng, &kid, pubkey, &plaintext)?;
+        let encoded = serialize(&ciphertext)?;
+        bundle.set_data(encoded.into());
+        bundle.set_kid(kid);
+    }
     if rng.gen_bool(0.5) {
         // priority
         let auction = Address::default();
@@ -31,4 +46,10 @@ pub fn make_bundle(_pubkey: &EncKey) -> anyhow::Result<BundleVariant> {
 /// Transactions per second to milliseconds is 1000 / TPS
 pub fn tps_to_millis<N: Into<u64>>(tps: N) -> u64 {
     1000 / tps.into()
+}
+
+fn serialize<T: Serialize>(d: &T) -> Result<Bytes, EncodeError> {
+    let mut b = BytesMut::new().writer();
+    bincode::serde::encode_into_std_write(d, &mut b, bincode::config::standard())?;
+    Ok(b.into_inner().freeze())
 }

--- a/timeboost-utils/src/load_generation.rs
+++ b/timeboost-utils/src/load_generation.rs
@@ -14,10 +14,10 @@ pub fn make_bundle(_pubkey: &EncKey) -> anyhow::Result<BundleVariant> {
     let max_seqno = 10;
     let bundle = Bundle::arbitrary(&mut u)?;
 
-    if rng.gen_bool(0.1) {
+    if rng.gen_bool(0.5) {
         // priority
         let auction = Address::default();
-        let seqno = SeqNo::from(u.int_in_range(1..=max_seqno)?);
+        let seqno = SeqNo::from(u.int_in_range(0..=max_seqno)?);
         let signer = Signer::default();
         let priority = PriorityBundle::new(bundle, auction, seqno);
         let signed_priority = priority.sign(signer)?;

--- a/timeboost-utils/src/load_generation.rs
+++ b/timeboost-utils/src/load_generation.rs
@@ -1,34 +1,19 @@
 use arbitrary::{Arbitrary, Unstructured};
 use ark_std::rand::{self, Rng};
-use bincode::error::EncodeError;
-use bytes::{BufMut, Bytes, BytesMut};
-use serde::Serialize;
-use timeboost_crypto::{
-    DecryptionScheme, KeysetId, Plaintext, traits::threshold_enc::ThresholdEncScheme,
-};
+use timeboost_crypto::{DecryptionScheme, traits::threshold_enc::ThresholdEncScheme};
 use timeboost_types::{Address, Bundle, BundleVariant, PriorityBundle, SeqNo, Signer};
 
 type EncKey = <DecryptionScheme as ThresholdEncScheme>::PublicKey;
 
-pub fn make_bundle(pubkey: &EncKey) -> anyhow::Result<BundleVariant> {
+pub fn make_bundle(_pubkey: &EncKey) -> anyhow::Result<BundleVariant> {
     let mut rng = rand::thread_rng();
     let mut v = [0; 256];
     rng.fill(&mut v);
     let mut u = Unstructured::new(&v);
 
     let max_seqno = 10;
-    let kid = KeysetId::from(1);
-    let mut bundle = Bundle::arbitrary(&mut u)?;
+    let bundle = Bundle::arbitrary(&mut u)?;
 
-    if rng.gen_bool(0.1) {
-        // encrypt bundle
-        let data = bundle.data();
-        let plaintext = Plaintext::new(data.to_vec());
-        let ciphertext = DecryptionScheme::encrypt(&mut rng, &kid, pubkey, &plaintext)?;
-        let encoded = serialize(&ciphertext)?;
-        bundle.set_data(encoded.into());
-        bundle.set_kid(kid);
-    }
     if rng.gen_bool(0.1) {
         // priority
         let auction = Address::default();
@@ -39,17 +24,11 @@ pub fn make_bundle(pubkey: &EncKey) -> anyhow::Result<BundleVariant> {
         Ok(BundleVariant::Priority(signed_priority))
     } else {
         // non-priority
-        Ok(BundleVariant::Regular(Bundle::arbitrary(&mut u)?))
+        Ok(BundleVariant::Regular(bundle))
     }
 }
 
 /// Transactions per second to milliseconds is 1000 / TPS
 pub fn tps_to_millis<N: Into<u64>>(tps: N) -> u64 {
     1000 / tps.into()
-}
-
-fn serialize<T: Serialize>(d: &T) -> Result<Bytes, EncodeError> {
-    let mut b = BytesMut::new().writer();
-    bincode::serde::encode_into_std_write(d, &mut b, bincode::config::standard())?;
-    Ok(b.into_inner().freeze())
 }


### PR DESCRIPTION
### Content
This PR fixes the decrypter logic and re-enables load generation with encrypted bundles.

1. The cid2idx mapping was stored using a BiMap. This caused entries to be overwritten and would eventually corrupt the state of the incubator.
2. The decrypter would insert shares from other nodes even if it had already hatched the corresponding ciphertext, effectively, causing the node to "start over" and eventually failing to decrypt because of missing shares.
3. The assembly of inclusion list would index into the decrypted data using the total number of priority bundles (instead of the number of modified priority bundles).

This PR fixes the above.