### PR TITLE
Add some logs to transaction-order test.

### DIFF
--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -192,6 +192,10 @@ impl Sequencer {
         })
     }
 
+    pub fn public_key(&self) -> PublicKey {
+        self.label
+    }
+
     pub fn add_bundles<I>(&mut self, it: I)
     where
         I: IntoIterator<Item = BundleVariant>,


### PR DESCRIPTION
Also make sure the test panics if any of the tasks panic'ed.
