### PR TITLE
Use reliability layer in RBC too.

### DIFF
--- a/cliquenet/Cargo.toml
+++ b/cliquenet/Cargo.toml
@@ -5,9 +5,6 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
-[features]
-sailfish = ["async-trait", "sailfish-types"]
-
 [dependencies]
 bimap = { workspace = true }
 bytes = { workspace = true }
@@ -20,8 +17,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 # optional:
-async-trait = { workspace = true, optional = true }
-sailfish-types = { path = "../sailfish-types", optional = true }
 turmoil = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/cliquenet/src/lib.rs
+++ b/cliquenet/src/lib.rs
@@ -2,12 +2,14 @@ mod addr;
 mod error;
 mod frame;
 mod metrics;
+mod net;
 mod tcp;
 mod time;
 
-pub mod reliable;
-pub mod unreliable;
+pub mod overlay;
 
 pub use addr::{Address, InvalidAddress};
 pub use error::NetworkError;
 pub use metrics::NetworkMetrics;
+pub use net::Network;
+pub use overlay::Overlay;

--- a/cliquenet/tests/frame-handling.rs
+++ b/cliquenet/tests/frame-handling.rs
@@ -55,7 +55,7 @@ async fn multiple_frames() {
 /// Generate a vector with random data and random length (within bounds).
 fn gen_message() -> Data {
     let mut g = rand::rng();
-    let mut v = vec![0; g.random_range(1..4 * 1024 * 1024)];
+    let mut v = vec![0; g.random_range(1..5 * 1024 * 1024)];
     g.fill_bytes(&mut v);
     BytesMut::from(&v[..]).try_into().unwrap()
 }

--- a/cliquenet/tests/frame-handling.rs
+++ b/cliquenet/tests/frame-handling.rs
@@ -1,7 +1,7 @@
 use std::net::{Ipv4Addr, SocketAddr};
 
-use bytes::Bytes;
-use cliquenet::{NetworkMetrics, unreliable::Network};
+use bytes::BytesMut;
+use cliquenet::{Network, NetworkMetrics, Overlay, overlay::Data};
 use multisig::{Keypair, PublicKey};
 use portpicker::pick_unused_port;
 use rand::{Rng, RngCore};
@@ -24,22 +24,26 @@ async fn multiple_frames() {
         ),
     ];
 
-    let mut net_a = Network::create(
-        all_parties[0].1,
-        party_a,
-        all_parties,
-        NetworkMetrics::default(),
-    )
-    .await
-    .unwrap();
-    let mut net_b = Network::create(
-        all_parties[1].1,
-        party_b,
-        all_parties,
-        NetworkMetrics::default(),
-    )
-    .await
-    .unwrap();
+    let mut net_a = Overlay::new(
+        Network::create(
+            all_parties[0].1,
+            party_a,
+            all_parties,
+            NetworkMetrics::default(),
+        )
+        .await
+        .unwrap(),
+    );
+    let mut net_b = Overlay::new(
+        Network::create(
+            all_parties[1].1,
+            party_b,
+            all_parties,
+            NetworkMetrics::default(),
+        )
+        .await
+        .unwrap(),
+    );
 
     let sender = all_parties[0].0;
 
@@ -49,25 +53,25 @@ async fn multiple_frames() {
 }
 
 /// Generate a vector with random data and random length (within bounds).
-fn gen_message() -> Bytes {
+fn gen_message() -> Data {
     let mut g = rand::rng();
-    let mut v = vec![0; g.random_range(1..5 * 1024 * 1024)];
+    let mut v = vec![0; g.random_range(1..4 * 1024 * 1024)];
     g.fill_bytes(&mut v);
-    v.into()
+    BytesMut::from(&v[..]).try_into().unwrap()
 }
 
 /// Multicast a message and receive them in both networks.
 ///
-/// Since `Network` is essentially unreliable, this will retry multicasting
+/// Since `Network` is essentially unordered, this will retry multicasting
 /// until the expected message has been received by both parties.
-async fn send_recv(sender: PublicKey, net_a: &mut Network, net_b: &mut Network, data: Bytes) {
+async fn send_recv(sender: PublicKey, net_a: &mut Overlay, net_b: &mut Overlay, data: Data) {
     'main: loop {
-        net_a.multicast(data.clone()).await.unwrap();
+        net_a.broadcast(data.clone()).await.unwrap();
 
         for net in [&mut *net_a, net_b] {
             if let Ok(Ok((k, x))) = timeout(Duration::from_millis(5), net.receive()).await {
                 assert_eq!(k, sender);
-                if x != data {
+                if *x != *data {
                     continue 'main;
                 }
             } else {

--- a/sailfish-rbc/Cargo.toml
+++ b/sailfish-rbc/Cargo.toml
@@ -10,6 +10,7 @@ async-trait = { workspace = true }
 bincode = { workspace = true }
 bs58 = { workspace = true }
 bytes = { workspace = true }
+cliquenet = { path = "../cliquenet" }
 committable = { workspace = true }
 metrics = { path = "../metrics" }
 multisig = { path = "../multisig" }

--- a/sailfish-rbc/src/abraham.rs
+++ b/sailfish-rbc/src/abraham.rs
@@ -13,6 +13,7 @@ use tokio::task::JoinHandle;
 use crate::digest::Digest;
 use crate::{RbcError, RbcMetrics};
 
+#[rustfmt::skip]
 mod worker;
 
 use worker::Worker;

--- a/sailfish-rbc/src/abraham/worker.rs
+++ b/sailfish-rbc/src/abraham/worker.rs
@@ -1,17 +1,19 @@
 use std::borrow::Cow;
-use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::fmt;
-use std::time::Duration;
 
 use bytes::{BufMut, Bytes, BytesMut};
+use cliquenet::{
+    Overlay,
+    overlay::{Data, SeqId},
+};
 use committable::{Commitment, Committable};
 use multisig::{Certificate, Envelope, PublicKey, VoteAccumulator};
 use multisig::{Unchecked, Validated};
-use sailfish_types::{Evidence, Message, RawComm, RoundNumber, Vertex};
+use sailfish_types::{Evidence, Message, RoundNumber, Vertex};
 use serde::{Serialize, de::DeserializeOwned};
 use tokio::sync::mpsc;
-use tokio::time::{self, Instant, Interval};
+use tokio::time::Instant;
 use tracing::{debug, trace, warn};
 
 use crate::RbcError;
@@ -25,21 +27,19 @@ type Receiver<T> = mpsc::Receiver<Command<T>>;
 
 /// A worker is run by `Rbc` to perform the actual work of sending and
 /// delivering messages.
-pub struct Worker<C, T: Committable> {
+pub struct Worker<T: Committable> {
     /// RBC configuration.
     config: RbcConfig,
-    /// Label, used in debug logs.
-    label: PublicKey,
-    /// Underlying communication type.
-    comm: C,
+    /// Our own public key.
+    key: PublicKey,
+    /// Underlying communication network.
+    comm: Overlay,
     /// Our channel to deliver messages to the application layer.
     tx: Sender<T>,
     /// Our channel to receive messages from the application layer.
     rx: Receiver<T>,
     /// The tracking information per message.
     buffer: BTreeMap<RoundNumber, Messages<T>>,
-    /// A timer to retry messages.
-    timer: Interval,
 }
 
 /// Messages of a single round.
@@ -54,9 +54,13 @@ struct Messages<T: Committable> {
     early: bool,
     /// Tracking info per message.
     map: BTreeMap<Digest, Tracker<T>>,
-    /// This tracks the remaining number of ACKs we still expect for the given
-    /// message digest.
-    acks: BTreeMap<Digest, Acks>,
+    /// The last sequence ID used when we proposed a message.
+    ///
+    /// This ties our own garbage collection to the one on the overlay network,
+    /// i.e. when we garbage collect a round we also garbage collect the
+    /// overlay network up to this sequence ID. It is set whenever we send out
+    /// a proposal.
+    last: Option<SeqId>,
 }
 
 impl<T: Committable> Messages<T> {
@@ -78,38 +82,18 @@ impl<T: Committable> Default for Messages<T> {
         Self {
             early: false,
             map: Default::default(),
-            acks: Default::default(),
+            last: None,
         }
     }
-}
-
-/// Tracks remaining expected ACKs of a message.
-struct Acks {
-    /// The message we sent and await ACKs for.
-    msg: Bytes,
-    /// The time when the message was first sent.
-    start: Instant,
-    /// The time when the message was last sent.
-    timestamp: Instant,
-    /// The number of delivery retries.
-    retries: usize,
-    /// The number of parties that still have to send an ACK back.
-    rem: Vec<PublicKey>,
 }
 
 /// Tracking information about a message and its status.
 struct Tracker<T: Committable> {
     /// The producer of this message.
     source: Option<PublicKey>,
-    /// Are we the original producer of this message?
-    ours: bool,
     /// The time when this info was created.
     start: Instant,
-    /// The time when this info was last updated.
-    timestamp: Instant,
-    /// The number of delivery retries.
-    retries: usize,
-    /// The message, if any.
+    /// The message (if any).
     ///
     /// If we receive votes before the message, this item will be empty.
     message: Item<Envelope<Vertex<T>, Validated>>,
@@ -157,23 +141,13 @@ impl<T> Item<T> {
 /// Message status.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum Status {
-    /// Nothing has happened yet
-    Init,
-    /// Message proposal has been submitted to the network.
-    SentMsg,
-    /// A message proposal has been received from the network.
-    ReceivedMsg,
-    /// Our vote for a message proposal has been submitted to the network.
-    SentVote,
-    /// We ask for the message corresponding to a quorum of votes.
+    /// Message or votes have been sent or received.
+    Initiated,
+    /// We asked for the message corresponding to a quorum of votes.
     ///
     /// If we have collected a quorum of votes or received a quorum certificate
     /// before we received the message itself, we asked a random signer for it.
-    RequestedMsg,
-    /// We have received one or more votes.
-    ReceivedVotes,
-    /// A quorum of votes has been reached.
-    ReachedQuorum,
+    Requested,
     /// The message has been RBC delivered (terminal state).
     Delivered,
 }
@@ -181,37 +155,27 @@ enum Status {
 impl fmt::Display for Status {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Init => f.write_str("init"),
-            Self::SentMsg => f.write_str("sent-msg"),
-            Self::ReceivedMsg => f.write_str("recv-msg"),
-            Self::SentVote => f.write_str("sent-vote"),
-            Self::ReceivedVotes => f.write_str("recv-votes"),
-            Self::ReachedQuorum => f.write_str("quorum"),
-            Self::RequestedMsg => f.write_str("req-msg"),
+            Self::Initiated => f.write_str("initiated"),
+            Self::Requested => f.write_str("requested"),
             Self::Delivered => f.write_str("delivered"),
         }
     }
 }
 
-impl<C: RawComm, T: Committable> Worker<C, T> {
-    pub fn new(tx: Sender<T>, rx: Receiver<T>, cfg: RbcConfig, nt: C) -> Self {
+impl<T: Committable> Worker<T> {
+    pub fn new(tx: Sender<T>, rx: Receiver<T>, cfg: RbcConfig, net: Overlay) -> Self {
         Self {
-            label: cfg.keypair.public_key(),
+            key: cfg.keypair.public_key(),
             config: cfg,
-            comm: nt,
+            comm: net,
             tx,
             rx,
             buffer: BTreeMap::new(),
-            timer: {
-                let mut i = time::interval(Duration::from_secs(1));
-                i.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
-                i
-            },
         }
     }
 }
 
-impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C, T> {
+impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
     /// The main event loop of this worker.
     ///
     /// We either receive messages from the application to send or from the network
@@ -220,34 +184,22 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
     pub async fn go(mut self) {
         loop {
             tokio::select! {
-                now = self.timer.tick() => {
-                    match self.retry(now).await {
-                        Ok(()) => {}
-                        Err(RbcError::Shutdown) => {
-                            debug!(node = %self.label, "rbc shutdown detected");
-                            return;
-                        }
-                        Err(err) => {
-                            warn!(node = %self.label, %err, "error retrying");
-                        }
-                    }
-                },
                 val = self.comm.receive(), if self.tx.capacity() > 0 => {
                     match val {
                         Ok((key, bytes)) => {
                             match self.on_inbound(key, bytes).await {
                                 Ok(()) => {}
                                 Err(RbcError::Shutdown) => {
-                                    debug!(node = %self.label, "rbc shutdown detected");
+                                    debug!(node = %self.key, "rbc shutdown detected");
                                     return;
                                 }
                                 Err(err) => {
-                                    warn!(node = %self.label, %err, "error on inbound message");
+                                    warn!(node = %self.key, %err, "error on inbound message");
                                 }
                             }
                         }
                         Err(err) => {
-                            warn!(node = %self.label, %err, "error receiving message from network")
+                            warn!(node = %self.key, %err, "error receiving message from network")
                         }
                     }
                 },
@@ -259,7 +211,7 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
                                     let _ = tx.send(Ok(()));
                                 }
                                 Err(err) => {
-                                    warn!(node = %self.label, %err, "error rbc broadcasting message");
+                                    warn!(node = %self.key, %err, "error rbc broadcasting message");
                                     let _ = tx.send(Err(err));
                                 }
                             }
@@ -268,7 +220,7 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
                         Some(Command::Send(to, msg)) => {
                             match self.on_send(to, msg).await {
                                 Ok(()) => {}
-                                Err(err) => warn!(node = %self.label, %err, "error sending message")
+                                Err(err) => warn!(node = %self.key, %err, "error sending message")
                             }
                         }
                         // Best-effort broadcast without RBC properties.
@@ -276,17 +228,19 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
                             match self.on_broadcast(msg).await {
                                 Ok(()) => {}
                                 Err(err) => {
-                                    warn!(node = %self.label, %err, "error broadcasting message")
+                                    warn!(node = %self.key, %err, "error broadcasting message")
                                 }
                             }
                         }
                         Some(Command::Gc(round)) => {
-                            debug!(node = %self.label, r = %round, "garbage collect");
+                            debug!(node = %self.key, r = %round, "garbage collect");
+                            if let Some(id) = self.buffer.get(&round).and_then(|m| m.last) {
+                                self.comm.gc(id)
+                            }
                             self.buffer.retain(|r, _| *r >= round);
-
                         }
                         None => {
-                            debug!(node = %self.label, "rbc shutdown detected");
+                            debug!(node = %self.key, "rbc shutdown detected");
                             return
                         }
                     }
@@ -300,24 +254,8 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
         let proto = Protocol::Send(Cow::Borrowed(&msg));
         let bytes = serialize(&proto)?;
         let digest = Digest::of_msg(&msg);
-        // Expect an ACK from each party:
-        self.buffer
-            .entry(digest.round())
-            .or_default()
-            .acks
-            .entry(digest)
-            .or_insert_with(|| {
-                let now = Instant::now();
-                Acks {
-                    msg: bytes.clone(),
-                    start: now,
-                    timestamp: now,
-                    retries: 0,
-                    rem: self.config.committee.parties().copied().collect(),
-                }
-            });
-        self.comm.broadcast(bytes).await.map_err(RbcError::net)?;
-        debug!(node = %self.label, %digest, "best-effort broadcast");
+        self.comm.broadcast(bytes).await?;
+        debug!(node = %self.key, %digest, "best-effort broadcast");
         Ok(())
     }
 
@@ -326,73 +264,43 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
         let proto = Protocol::Send(Cow::Borrowed(&msg));
         let bytes = serialize(&proto)?;
         let digest = Digest::of_msg(&msg);
-        // Expect an ACK from `to`:
-        self.buffer
-            .entry(digest.round())
-            .or_default()
-            .acks
-            .entry(digest)
-            .or_insert_with(|| {
-                let now = Instant::now();
-                Acks {
-                    msg: bytes.clone(),
-                    start: now,
-                    timestamp: now,
-                    retries: 0,
-                    rem: vec![to],
-                }
-            });
-        self.comm.send(to, bytes).await.map_err(RbcError::net)?;
-        debug!(node = %self.label, %to, %digest, "best-effort send");
+        self.comm.unicast(to, bytes).await?;
+        debug!(node = %self.key, %to, %digest, "best-effort send");
         Ok(())
     }
 
     /// Start RBC broadcast.
     async fn on_outbound(&mut self, vertex: Envelope<Vertex<T>, Validated>) -> Result<()> {
-        trace!(node = %self.label, vertex = %vertex.data(), "proposing");
+        trace!(node = %self.key, vertex = %vertex.data(), "proposing");
         let proto = Protocol::Propose(Cow::Borrowed(&vertex));
         let bytes = serialize(&proto)?;
         let digest = Digest::of_vertex(&vertex);
 
-        let now = Instant::now();
-
         let tracker = Tracker {
             source: Some(self.config.keypair.public_key()),
-            ours: true,
-            start: now,
-            timestamp: now,
-            retries: 0,
+            start: Instant::now(),
             message: Item::some(vertex),
             votes: VoteAccumulator::new(self.config.committee.clone()),
-            status: Status::Init,
+            status: Status::Initiated,
         };
 
-        let tracker = self
-            .buffer
-            .entry(digest.round())
-            .or_default()
-            .map
-            .entry(digest)
-            .or_insert(tracker);
+        let id = self.comm.broadcast(bytes).await?;
+        debug!(node = %self.key, %digest, "message broadcasted");
 
-        if let Err(err) = self.comm.broadcast(bytes).await {
-            debug!(node = %self.label, %digest, %err, "network error");
-        } else {
-            debug!(node = %self.label, %digest, "message broadcasted");
-            tracker.status = Status::SentMsg;
-        }
+        let messages = self.buffer.entry(digest.round()).or_default();
+        messages.map.insert(digest, tracker);
+        messages.last = Some(id);
 
         Ok(())
     }
 
     /// We received a message from the network.
     async fn on_inbound(&mut self, src: PublicKey, bytes: Bytes) -> Result<()> {
-        trace!(node = %self.label, %src, buf = %self.buffer.len(), "inbound message");
+        trace!(node = %self.key, %src, buf = %self.buffer.len(), "inbound message");
         match bincode::serde::decode_from_slice(&bytes, bincode::config::standard())?.0 {
             Protocol::Send(msg) => self.on_message(src, msg.into_owned()).await?,
-            Protocol::Ack(dig) => self.on_ack(src, dig).await?,
             Protocol::Propose(msg) => self.on_propose(src, msg.into_owned()).await?,
-            Protocol::Vote(env, evi, done) => self.on_vote(src, env, evi, done).await?,
+            Protocol::Vote(env, evi) => self.on_vote(src, env, evi).await?,
             Protocol::GetRequest(dig) => self.on_get_request(src, dig).await?,
             Protocol::GetResponse(msg) => self.on_get_response(src, msg.into_owned()).await?,
             Protocol::Cert(crt) => self.on_cert(src, crt).await?,
@@ -403,43 +311,15 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
 
     /// A non-RBC message has been received which we deliver directly to the application.
     async fn on_message(&mut self, src: PublicKey, msg: Message<T, Unchecked>) -> Result<()> {
-        debug!(node = %self.label, %src, %msg, digest = %Digest::of_msg(&msg), "message received");
+        debug!(node = %self.key, %src, %msg, digest = %Digest::of_msg(&msg), "message received");
         if msg.is_vertex() {
-            warn!(node = %self.label, %src, "received rbc message as non-rbc message");
+            warn!(node = %self.key, %src, "received rbc message as non-rbc message");
             return Err(RbcError::InvalidMessage);
         }
         let Some(msg) = msg.validated(&self.config.committee) else {
             return Err(RbcError::InvalidMessage);
         };
-        let dig = Digest::of_msg(&msg);
-        let ack = Protocol::<'_, T, Validated>::Ack(dig);
-        let bytes = serialize(&ack)?;
         self.tx.send(msg).await.map_err(|_| RbcError::Shutdown)?;
-        self.comm.send(src, bytes).await.map_err(RbcError::net)?;
-        debug!(node = %self.label, to = %src, digest = %dig, "ack sent");
-        Ok(())
-    }
-
-    /// A message acknowledgement has been received.
-    async fn on_ack(&mut self, src: PublicKey, digest: Digest) -> Result<()> {
-        debug!(node = %self.label, %src, %digest, "ack received");
-        let Some(msgs) = self.buffer.get_mut(&digest.round()) else {
-            debug!(node = %self.label, %src, %digest, "no ack expected for digest round");
-            return Ok(());
-        };
-
-        let Some(acks) = msgs.acks.get_mut(&digest) else {
-            trace!(node = %self.label, %src, %digest, "no ack expected for digest");
-            return Ok(());
-        };
-
-        acks.rem.retain(|k| *k != src);
-
-        if acks.rem.is_empty() {
-            self.config.metrics.add_ack_duration(acks.start.elapsed());
-            msgs.acks.remove(&digest);
-        }
-
         Ok(())
     }
 
@@ -449,13 +329,13 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
         src: PublicKey,
         vertex: Envelope<Vertex<T>, Unchecked>,
     ) -> Result<()> {
-        debug!(node = %self.label, %src, digest = %Digest::of_vertex(&vertex), "proposal received");
+        debug!(node = %self.key, %src, digest = %Digest::of_vertex(&vertex), "proposal received");
         let Some(vertex) = vertex.validated(&self.config.committee) else {
             return Err(RbcError::InvalidMessage);
         };
 
         if *vertex.signing_key() != src {
-            warn!(node = %self.label, %src, "message sender != message signer");
+            warn!(node = %self.key, %src, "message sender != message signer");
             return Err(RbcError::InvalidMessage);
         }
 
@@ -464,119 +344,68 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
         if let Some(messages) = self.buffer.get(&digest.round()) {
             if let Some(d) = messages.digest(&src) {
                 if d != digest {
-                    warn!(node = %self.label, %src, "multiple proposals received");
+                    warn!(node = %self.key, %src, "multiple proposals received");
                     return Err(RbcError::InvalidMessage);
                 }
             }
         }
 
         let evidence = vertex.data().evidence().clone();
-
         let messages = self.buffer.entry(digest.round()).or_default();
 
-        let tracker = messages.map.entry(digest).or_insert_with(|| {
-            let now = Instant::now();
-            Tracker {
-                source: None,
-                ours: false,
-                start: now,
-                timestamp: now,
-                retries: 0,
-                message: Item::none(),
-                votes: VoteAccumulator::new(self.config.committee.clone()),
-                status: Status::Init,
-            }
+        let tracker = messages.map.entry(digest).or_insert_with(|| Tracker {
+            source: None,
+            start: Instant::now(),
+            message: Item::none(),
+            votes: VoteAccumulator::new(self.config.committee.clone()),
+            status: Status::Initiated,
         });
 
         match tracker.status {
-            // First time we see this message.
-            Status::Init => {
-                tracker.source = Some(src);
-                tracker.message = Item::some(vertex);
-                tracker.status = Status::ReceivedMsg;
-                let env = Envelope::signed(digest, &self.config.keypair, false);
-                let vote = Protocol::<'_, T, Validated>::Vote(env, evidence, false);
-                let bytes = serialize(&vote)?;
-                self.comm.broadcast(bytes).await.map_err(RbcError::net)?;
-                tracker.status = Status::SentVote;
-                debug!(node = %self.label, %digest, "vote broadcasted");
-            }
-            // We received a duplicate or a reflection of our own outbound message.
-            // In any case we did not manage to cast our vote yet, so we try again.
-            Status::ReceivedMsg | Status::SentMsg => {
-                debug_assert!(tracker.message.item.is_some());
-                let env = Envelope::signed(digest, &self.config.keypair, false);
-                let vote = Protocol::<'_, T, Validated>::Vote(env, evidence, false);
-                let bytes = serialize(&vote)?;
-                self.comm.broadcast(bytes).await.map_err(RbcError::net)?;
-                tracker.status = Status::SentVote;
-                debug!(node = %self.label, %digest, "vote broadcasted");
-            }
-            // We received votes, possibly prior to the message. If so we update the
-            // tracking info with the actual message proposal and vote on the message.
-            Status::ReceivedVotes => {
+            // If this is a new message or we received our own we vote for it.
+            Status::Initiated => {
+                if tracker.message.item.is_none() || src == self.key {
+                    let env = Envelope::signed(digest, &self.config.keypair, false);
+                    let vote = Protocol::<'_, T, Validated>::Vote(env, evidence);
+                    let bytes = serialize(&vote)?;
+                    self.comm.broadcast(bytes).await?;
+                    debug!(node = %self.key, %digest, "vote broadcasted");
+                }
                 if tracker.message.item.is_none() {
                     tracker.source = Some(src);
                     tracker.message = Item::some(vertex);
-                    let env = Envelope::signed(digest, &self.config.keypair, false);
-                    let vote = Protocol::<'_, T, Validated>::Vote(env, evidence, false);
-                    let bytes = serialize(&vote)?;
-                    self.comm.broadcast(bytes).await.map_err(RbcError::net)?;
-                    tracker.status = Status::SentVote;
-                    debug!(node = %self.label, %digest, "vote broadcasted");
                 }
             }
-            // We have received enough votes to form a quorum but we either did not manage
-            // to request the message or to broadcast the certificate.
-            Status::ReachedQuorum => {
-                if tracker.message.item.is_none() {
-                    tracker.source = Some(src);
-                    tracker.message = Item::some(vertex.clone());
-                    let cert = tracker.votes.certificate().expect("quorum => certificate");
-                    if let Entry::Vacant(acks) = messages.acks.entry(Digest::of_cert(cert)) {
-                        let m = Protocol::<'_, T, Validated>::Cert(cert.clone());
-                        let b = serialize(&m)?;
-                        let now = Instant::now();
-                        acks.insert(Acks {
-                            msg: b.clone(),
-                            start: now,
-                            timestamp: now,
-                            retries: 0,
-                            rem: self.config.committee.parties().copied().collect(),
-                        });
-                        self.comm.broadcast(b).await.map_err(RbcError::net)?;
-                        debug!(node = %self.label, %digest, cert = %Digest::of_cert(cert), "cert broadcasted");
-                    }
-                }
-                self.tx
-                    .send(Message::Vertex(vertex.clone()))
-                    .await
-                    .map_err(|_| RbcError::Shutdown)?;
-                self.config
-                    .metrics
-                    .add_delivery_duration(tracker.start.elapsed());
-                debug!(node = %self.label, vertex = %vertex.data(), %digest, "delivered");
-                tracker.status = Status::Delivered
-            }
-            // We had previously reached a quorum of votes but were missing the message
-            // which now arrived (after we requested it). We can finally deliver it to
-            // the application.
-            Status::RequestedMsg => {
+            // We had previously reached a quorum of votes but were missing the
+            // message which now arrived independently. We can finally deliver
+            // it to the application.
+            Status::Requested => {
+                debug_assert!(tracker.message.item.is_none());
                 tracker.source = Some(src);
                 tracker.message = Item::some(vertex.clone());
-                debug!(node = %self.label, vertex = %vertex.data(), %digest, "delivered");
+
+                // Now that we have the message corresponding to the voter quorum we can
+                // broadcast the certificate as well:
+                let cert = tracker.votes.certificate().expect("requested message => certificate");
+                let cert_digest = Digest::of_cert(cert);
+                let m = Protocol::<'_, T, Validated>::Cert(cert.clone());
+                let b = serialize(&m)?;
+                self.comm.broadcast(b).await?;
+                debug!(node = %self.key, %digest, cert = %cert_digest, "cert broadcasted");
+
                 self.tx
-                    .send(Message::Vertex(vertex))
+                    .send(Message::Vertex(vertex.clone()))
                     .await
                     .map_err(|_| RbcError::Shutdown)?;
                 tracker.status = Status::Delivered;
                 self.config
                     .metrics
-                    .add_delivery_duration(tracker.start.elapsed())
+                    .add_delivery_duration(tracker.start.elapsed());
+                debug!(node = %self.key, vertex = %vertex.data(), %digest, "delivered");
             }
-            // These states already have the message, so there is nothing to be done.
-            Status::Delivered | Status::SentVote => {
-                debug!(node = %self.label, %digest, status = %tracker.status, "ignoring message proposal");
+            // Nothing to do here:
+            Status::Delivered => {
+                debug!(node = %self.key, %src, %digest, status = %tracker.status, "ignoring proposal");
                 debug_assert!(tracker.message.item.is_some())
             }
         }
@@ -602,7 +431,7 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
                         self.config
                             .metrics
                             .add_delivery_duration(tracker.start.elapsed());
-                        debug!(node = %self.label, vertex = %vertex.data(), "delivered");
+                        debug!(node = %self.key, vertex = %vertex.data(), "delivered");
                     }
                 }
                 messages.early = true
@@ -618,21 +447,19 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
         src: PublicKey,
         env: Envelope<Digest, Unchecked>,
         evi: Evidence,
-        done: bool,
     ) -> Result<()> {
-        debug!(node = %self.label, %src, digest = %env.data(), %done, "vote received");
+        debug!(node = %self.key, %src, digest = %env.data(), "vote received");
         let Some(env) = env.validated(&self.config.committee) else {
             return Err(RbcError::InvalidMessage);
         };
 
         if *env.signing_key() != src {
-            warn!(node = %self.label, %src, "vote sender != vote signer");
+            warn!(node = %self.key, %src, "vote sender != vote signer");
             return Err(RbcError::InvalidMessage);
         }
 
         let digest = *env.data();
         let commit = digest.commit();
-        let source = *env.signing_key();
 
         // If a vote for a round greater than our current latest round + 1 arrives,
         // we demand evidence, that a quorum of parties is backing the round prior
@@ -645,29 +472,23 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
 
         if digest.round() > latest_round + 1 {
             if evi.round() + 1 != digest.round() && !digest.round().is_genesis() {
-                warn!(node = %self.label, %src, "invalid vote evidence round");
+                warn!(node = %self.key, %src, "invalid vote evidence round");
                 return Err(RbcError::InvalidMessage);
             }
             if !evi.is_valid(&self.config.committee) {
-                warn!(node = %self.label, %src, "invalid vote evidence");
+                warn!(node = %self.key, %src, "invalid vote evidence");
                 return Err(RbcError::InvalidMessage);
             }
         }
 
         let messages = self.buffer.entry(digest.round()).or_default();
 
-        let tracker = messages.map.entry(digest).or_insert_with(|| {
-            let now = Instant::now();
-            Tracker {
-                source: None,
-                ours: false,
-                start: now,
-                timestamp: now,
-                retries: 0,
-                message: Item::none(),
-                votes: VoteAccumulator::new(self.config.committee.clone()),
-                status: Status::Init,
-            }
+        let tracker = messages.map.entry(digest).or_insert_with(|| Tracker {
+            source: None,
+            start: Instant::now(),
+            message: Item::none(),
+            votes: VoteAccumulator::new(self.config.committee.clone()),
+            status: Status::Initiated,
         });
 
         match tracker.status {
@@ -676,30 +497,14 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
             // we broadcast the certificate and deliver the message to the application
             // unless of course we are missing it, in which case we ask a single peer
             // to send it to us.
-            Status::Init
-            | Status::ReceivedMsg
-            | Status::SentMsg
-            | Status::ReceivedVotes
-            | Status::SentVote => match tracker.votes.add(env.into_signed()) {
-                Ok(None) => tracker.status = Status::ReceivedVotes,
+            Status::Initiated => match tracker.votes.add(env.into_signed()) {
                 Ok(Some(cert)) => {
-                    tracker.status = Status::ReachedQuorum;
                     if let Some(vertex) = &tracker.message.item {
                         let cert_digest = Digest::of_cert(cert);
-                        if let Entry::Vacant(acks) = messages.acks.entry(cert_digest) {
-                            let m = Protocol::<'_, T, Validated>::Cert(cert.clone());
-                            let b = serialize(&m)?;
-                            let now = Instant::now();
-                            acks.insert(Acks {
-                                msg: b.clone(),
-                                start: now,
-                                timestamp: now,
-                                retries: 0,
-                                rem: self.config.committee.parties().copied().collect(),
-                            });
-                            self.comm.broadcast(b).await.map_err(RbcError::net)?;
-                            debug!(node = %self.label, %digest, cert = %cert_digest, "cert broadcasted");
-                        }
+                        let m = Protocol::<'_, T, Validated>::Cert(cert.clone());
+                        let b = serialize(&m)?;
+                        self.comm.broadcast(b).await?;
+                        debug!(node = %self.key, %digest, cert = %cert_digest, "cert broadcasted");
                         if !tracker.message.early {
                             self.tx
                                 .send(Message::Vertex(vertex.clone()))
@@ -708,20 +513,23 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
                             self.config
                                 .metrics
                                 .add_delivery_duration(tracker.start.elapsed());
-                            debug!(node = %self.label, vertex = %vertex.data(), %digest, "delivered");
+                            debug!(node = %self.key, vertex = %vertex.data(), %digest, "delivered");
                         }
                         tracker.status = Status::Delivered
                     } else {
                         let m = Protocol::<'_, T, Validated>::GetRequest(digest);
                         let b = serialize(&m)?;
                         let s = tracker.choose_voter(&commit).expect("certificate => voter");
-                        self.comm.send(s, b).await.map_err(RbcError::net)?;
-                        tracker.status = Status::RequestedMsg;
-                        debug!(node = %self.label, from = %s, %digest, "message requested")
+                        self.comm.unicast(s, b).await?;
+                        tracker.status = Status::Requested;
+                        debug!(node = %self.key, from = %s, %digest, "message requested")
                     }
                 }
+                Ok(None) => {
+                    // quorum not reached yet => nothing else to do
+                }
                 Err(err) => {
-                    warn!(node = %self.label, %err, %digest, "failed to add vote");
+                    warn!(node = %self.key, %err, %digest, "failed to add vote");
                     if tracker.votes.is_empty() && tracker.message.item.is_none() {
                         if let Some(messages) = self.buffer.get_mut(&digest.round()) {
                             messages.map.remove(&digest);
@@ -729,26 +537,8 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
                     }
                 }
             },
-            // We have previously reached the quorum of votes but did not manage to request
-            // the still missing message. We use this additional vote to try again.
-            Status::ReachedQuorum if tracker.message.item.is_none() => {
-                let m = Protocol::<'_, T, Validated>::GetRequest(digest);
-                let b = serialize(&m)?;
-                let s = tracker.choose_voter(&commit).expect("quorum => voter");
-                self.comm.send(s, b).await.map_err(RbcError::net)?;
-                tracker.status = Status::RequestedMsg;
-                debug!(node = %self.label, from = %s, %digest, "message requested")
-            }
-            Status::ReachedQuorum | Status::RequestedMsg | Status::Delivered => {
-                if done {
-                    debug!(node = %self.label, status = %tracker.status, "ignoring vote")
-                } else {
-                    let env = Envelope::signed(digest, &self.config.keypair, false);
-                    let vote = Protocol::<'_, T, Validated>::Vote(env, evi, true);
-                    let bytes = serialize(&vote)?;
-                    self.comm.send(source, bytes).await.map_err(RbcError::net)?;
-                    debug!(node = %self.label, to = %source, %digest, "vote sent")
-                }
+            Status::Requested | Status::Delivered => {
+                debug!(node = %self.key, status = %tracker.status, "ignoring vote")
             }
         }
 
@@ -760,12 +550,10 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
         let digest = *crt.data();
         let cert_digest = Digest::of_cert(&crt);
 
-        debug!(node = %self.label, %src, %digest, cert = %cert_digest, "cert received");
+        debug!(node = %self.key, %src, %digest, cert = %cert_digest, "cert received");
 
         if let Some(r) = self.buffer.keys().next() {
             if digest.round() < *r {
-                // Certificate is too old.
-                self.ack(src, cert_digest).await?;
                 return Ok(());
             }
         }
@@ -775,50 +563,26 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
         }
 
         let commit = digest.commit();
-
         let messages = self.buffer.entry(digest.round()).or_default();
-
-        let tracker = messages.map.entry(digest).or_insert_with(|| {
-            let now = Instant::now();
-            Tracker {
-                source: None,
-                ours: false,
-                start: now,
-                timestamp: now,
-                retries: 0,
-                message: Item::none(),
-                votes: VoteAccumulator::new(self.config.committee.clone()),
-                status: Status::Init,
-            }
+        let tracker = messages.map.entry(digest).or_insert_with(|| Tracker {
+            source: None,
+            start: Instant::now(),
+            message: Item::none(),
+            votes: VoteAccumulator::new(self.config.committee.clone()),
+            status: Status::Initiated,
         });
 
         match tracker.status {
             // The certificate allows us to immediately reach the quorum and deliver the
             // message to the application layer. If we are missing the message, we have to
             // ask one of our peers for it.
-            Status::Init
-            | Status::ReceivedMsg
-            | Status::SentMsg
-            | Status::ReceivedVotes
-            | Status::SentVote => {
+            Status::Initiated => {
                 tracker.votes.set_certificate(crt.clone());
-                tracker.status = Status::ReachedQuorum;
-
                 if let Some(vertex) = &tracker.message.item {
-                    if let Entry::Vacant(acks) = messages.acks.entry(cert_digest) {
-                        let m = Protocol::<'_, T, Validated>::Cert(crt);
-                        let b = serialize(&m)?;
-                        let now = Instant::now();
-                        acks.insert(Acks {
-                            msg: b.clone(),
-                            start: now,
-                            timestamp: now,
-                            retries: 0,
-                            rem: self.config.committee.parties().copied().collect(),
-                        });
-                        self.comm.broadcast(b).await.map_err(RbcError::net)?;
-                        debug!(node = %self.label, %digest, cert = %cert_digest, "cert broadcasted");
-                    }
+                    let m = Protocol::<'_, T, Validated>::Cert(crt);
+                    let b = serialize(&m)?;
+                    self.comm.broadcast(b).await?;
+                    debug!(node = %self.key, %digest, cert = %cert_digest, "cert broadcasted");
                     if !tracker.message.early {
                         self.tx
                             .send(Message::Vertex(vertex.clone()))
@@ -827,89 +591,40 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
                         self.config
                             .metrics
                             .add_delivery_duration(tracker.start.elapsed());
-                        debug!(node = %self.label, vertex = %vertex.data(), %digest, "delivered");
+                        debug!(node = %self.key, vertex = %vertex.data(), %digest, "delivered");
                     }
                     tracker.status = Status::Delivered
                 } else {
                     let m = Protocol::<'_, T, Validated>::GetRequest(digest);
                     let b = serialize(&m)?;
                     let s = tracker.choose_voter(&commit).expect("certificate => voter");
-                    self.comm.send(s, b).await.map_err(RbcError::net)?;
-                    tracker.status = Status::RequestedMsg;
-                    debug!(node = %self.label, from = %s, %digest, "message requested");
+                    self.comm.unicast(s, b).await?;
+                    tracker.status = Status::Requested;
+                    debug!(node = %self.key, from = %s, %digest, "message requested");
                 }
             }
-            // We have previously reached the quorum of votes but did not manage to request
-            // the still missing message. Let's try again.
-            Status::ReachedQuorum if tracker.message.item.is_none() => {
-                let m = Protocol::<'_, T, Validated>::GetRequest(digest);
-                let b = serialize(&m)?;
-                let s = tracker.choose_voter(&commit).expect("quorum => voter");
-                self.comm.send(s, b).await.map_err(RbcError::net)?;
-                tracker.status = Status::RequestedMsg;
-                debug!(node = %self.label, from = %s, %digest, "message requested");
-            }
-            Status::ReachedQuorum | Status::Delivered => {
-                // A received certificate is considered an implicit ACK for the
-                // one we sent out earlier (if any), so the source key is removed
-                // from the collection of remaining parties who have yet to
-                // acknowledge the receipt.
-                if let Some(acks) = messages.acks.get_mut(&cert_digest) {
-                    acks.rem.retain(|k| *k != src);
-                    if acks.rem.is_empty() {
-                        self.config.metrics.add_ack_duration(acks.start.elapsed());
-                        messages.acks.remove(&cert_digest);
-                    }
-                }
-            }
-            Status::RequestedMsg => {
-                debug!(node = %self.label, %digest, status = %tracker.status, "ignoring certificate")
+            Status::Requested | Status::Delivered => {
+                debug!(node = %self.key, %digest, status = %tracker.status, "ignoring certificate")
             }
         }
-
-        self.ack(src, cert_digest).await?;
 
         Ok(())
     }
 
     /// One of our peers is asking for a message proposal.
     async fn on_get_request(&mut self, src: PublicKey, digest: Digest) -> Result<()> {
-        debug!(node = %self.label, %src, %digest, "get request received");
-        let Some(tracker) = self
+        debug!(node = %self.key, %src, %digest, "get request received");
+
+        if let Some(msg) = self
             .buffer
             .get_mut(&digest.round())
             .and_then(|m| m.map.get_mut(&digest))
-        else {
-            warn!(
-                node = %self.label,
-                src  = %src,
-                "ignoring get request for data we do not have"
-            );
-            return Ok(());
-        };
-
-        match tracker.status {
-            // We do not have the message ourselves when in these states.
-            Status::Init | Status::RequestedMsg => {
-                debug!(node = %self.label, %digest, status = %tracker.status, "ignoring get request");
-                debug_assert!(tracker.message.item.is_none())
-            }
-            // Here, we may have the message and if so, we gladly share it.
-            Status::SentVote | Status::ReceivedVotes | Status::ReachedQuorum => {
-                if let Some(msg) = &tracker.message.item {
-                    respond(&mut self.comm, src, msg).await?;
-                }
-            }
-            // In these states we must have the message and send to the peer.
-            Status::ReceivedMsg | Status::SentMsg | Status::Delivered => {
-                let msg = tracker
-                    .message
-                    .item
-                    .as_ref()
-                    .expect("message item is present in these status");
-                respond(&mut self.comm, src, msg).await?;
-            }
+            .and_then(|t| t.message.item.as_ref())
+        {
+            return respond(&mut self.comm, src, msg).await;
         }
+
+        warn!(node = %self.key, %src, "ignoring get request for data we do not have");
 
         Ok(())
     }
@@ -920,7 +635,7 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
         src: PublicKey,
         vertex: Envelope<Vertex<T>, Unchecked>,
     ) -> Result<()> {
-        debug!(node = %self.label, %src, digest = %Digest::of_vertex(&vertex), "get response received");
+        debug!(node = %self.key, %src, digest = %Digest::of_vertex(&vertex), "get response received");
         let Some(vertex) = vertex.validated(&self.config.committee) else {
             return Err(RbcError::InvalidMessage);
         };
@@ -932,12 +647,12 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
             .get_mut(&digest.round())
             .and_then(|m| m.map.get_mut(&digest))
         else {
-            debug!(node = %self.label, %src, "no tracker for get response");
+            debug!(node = %self.key, %src, "no tracker for get response");
             return Ok(());
         };
 
-        if Status::RequestedMsg != tracker.status {
-            debug!(node = %self.label, status = %tracker.status, %src, "ignoring get response");
+        if Status::Requested != tracker.status {
+            debug!(node = %self.key, status = %tracker.status, %src, "ignoring get response");
             return Ok(());
         }
 
@@ -946,228 +661,29 @@ impl<C: RawComm, T: Clone + Committable + Serialize + DeserializeOwned> Worker<C
             .await
             .map_err(|_| RbcError::Shutdown)?;
 
-        debug!(node = %self.label, vertex = %vertex.data(), %digest, "delivered");
+        debug!(node = %self.key, vertex = %vertex.data(), %digest, "delivered");
         tracker.message = Item::some(vertex);
         tracker.status = Status::Delivered;
 
         Ok(())
     }
-
-    /// Periodically we go over message status and retry incomplete items.
-    async fn retry(&mut self, now: Instant) -> Result<()> {
-        trace!(node = %self.label, "retrying ...");
-        // Go over RBC messages and check status:
-        for (digest, tracker) in self.buffer.values_mut().flat_map(|m| m.map.iter_mut()) {
-            if matches!(tracker.status, Status::Init | Status::Delivered) {
-                continue; // nothing to do here (1).
-            }
-            debug!(
-                node     = %self.label,
-                digest   = %digest,
-                present  = %tracker.message.item.is_some(),
-                status   = %tracker.status,
-                ours     = %tracker.ours,
-                elapsed  = ?tracker.start.elapsed(),
-                retries  = %tracker.retries,
-                votes    = %tracker.votes.votes(&digest.commit()),
-                "revisiting ..."
-            );
-            match tracker.status {
-                Status::Init | Status::Delivered => {
-                    unreachable!() // because of (1)
-                }
-                // We have sent a message but did not make further progress, so
-                // we try to send the message again and hope for some response.
-                Status::SentMsg => {
-                    let timeout = [3, 6, 10, 15, 30]
-                        .get(tracker.retries)
-                        .copied()
-                        .unwrap_or(30);
-                    if tracker.timestamp.elapsed() < Duration::from_secs(timeout) {
-                        continue;
-                    }
-                    let vertex = tracker
-                        .message
-                        .item
-                        .as_ref()
-                        .expect("message was sent => set in tracker");
-                    debug!(node = %self.label, %digest, vertex = %vertex.data(), "re-broadcasting");
-                    let proto = Protocol::Propose(Cow::Borrowed(vertex));
-                    let bytes = serialize(&proto).expect("idempotent serialization");
-                    tracker.timestamp = now;
-                    tracker.retries = tracker.retries.saturating_add(1);
-                    self.config.metrics.retries.add(1);
-                    if let Err(err) = self.comm.broadcast(bytes).await {
-                        debug!(node = %self.label, %err, "network error");
-                    }
-                }
-                // If we have a message we might not have been able to send our vote
-                // or it might not have reached enough parties, so we try again here.
-                Status::ReceivedMsg | Status::ReceivedVotes | Status::SentVote => {
-                    if let Some(msg) = &tracker.message.item {
-                        let timeout = [3, 6, 10, 15, 30]
-                            .get(tracker.retries)
-                            .copied()
-                            .unwrap_or(30);
-                        if tracker.timestamp.elapsed() < Duration::from_millis(timeout) {
-                            continue;
-                        }
-                        if tracker.ours {
-                            let proto = Protocol::Propose(Cow::Borrowed(msg));
-                            let bytes = serialize(&proto)?;
-                            if let Some(rem) = remaining_voters(&self.config, tracker) {
-                                for to in rem {
-                                    debug!(node = %self.label, %to, %digest, "sending our message (again)");
-                                    self.comm
-                                        .send(to, bytes.clone())
-                                        .await
-                                        .map_err(RbcError::net)?;
-                                }
-                            } else {
-                                debug!(node = %self.label, %digest, "broadcasting our message (again)");
-                                self.comm.broadcast(bytes).await.map_err(RbcError::net)?;
-                            }
-                        }
-                        let evidence = msg.data().evidence().clone();
-                        let env = Envelope::signed(*digest, &self.config.keypair, false);
-                        let vote = Protocol::<'_, T, Validated>::Vote(env, evidence, false);
-                        let bytes = serialize(&vote).expect("idempotent serialization");
-                        tracker.timestamp = now;
-                        tracker.retries = tracker.retries.saturating_add(1);
-                        self.config.metrics.retries.add(1);
-                        if let Some(rem) = remaining_voters(&self.config, tracker) {
-                            for to in rem {
-                                debug!(node = %self.label, %to, %digest, "sending our vote (again)");
-                                self.comm
-                                    .send(to, bytes.clone())
-                                    .await
-                                    .map_err(RbcError::net)?;
-                            }
-                        } else {
-                            debug!(node = %self.label, %digest, "broadcasting our vote (again)");
-                            self.comm.broadcast(bytes).await.map_err(RbcError::net)?;
-                        }
-                        tracker.status = Status::SentVote
-                    }
-                }
-                // We have reached a quorum of votes but are missing the message which we
-                // had previously requested => try again, potentially from a different
-                // source.
-                Status::RequestedMsg => {
-                    let timeout = [1, 3, 6, 10, 15, 30]
-                        .get(tracker.retries)
-                        .copied()
-                        .unwrap_or(30);
-                    if tracker.timestamp.elapsed() < Duration::from_millis(timeout) {
-                        continue;
-                    }
-                    debug!(node = %self.label, %digest, "requesting message again");
-                    let m = Protocol::<'_, T, Validated>::GetRequest(*digest);
-                    let b = serialize(&m).expect("idempotent serialization");
-                    let c = digest.commit();
-                    let s = tracker.choose_voter(&c).expect("req-msg => voter");
-                    tracker.timestamp = now;
-                    tracker.retries = tracker.retries.saturating_add(1);
-                    self.config.metrics.retries.add(1);
-                    self.comm.send(s, b).await.map_err(RbcError::net)?;
-                    debug!(node = %self.label, from = %s, %digest, "message requested");
-                }
-                // We have reached a quorum of votes. We may either already have the message,
-                // in which case we previously failed to broadcast the certificate, or we did
-                // not manage to request the message yet.
-                Status::ReachedQuorum => {
-                    let timeout = [3, 6, 10, 15, 30]
-                        .get(tracker.retries)
-                        .copied()
-                        .unwrap_or(30);
-                    if tracker.timestamp.elapsed() < Duration::from_millis(timeout) {
-                        continue;
-                    }
-                    if let Some(vertex) = &tracker.message.item {
-                        if !tracker.message.early {
-                            self.tx
-                                .send(Message::Vertex(vertex.clone()))
-                                .await
-                                .map_err(|_| RbcError::Shutdown)?;
-                            self.config
-                                .metrics
-                                .add_delivery_duration(tracker.start.elapsed());
-                            debug!(node = %self.label, vertex = %vertex.data(), %digest, "delivered");
-                        }
-                        tracker.status = Status::Delivered
-                    } else {
-                        debug!(node = %self.label, %digest, "requesting message");
-                        let m = Protocol::<'_, T, Validated>::GetRequest(*digest);
-                        let b = serialize(&m).expect("idempotent serialization");
-                        let c = digest.commit();
-                        let s = tracker.choose_voter(&c).expect("quorum => voter");
-                        tracker.timestamp = now;
-                        tracker.retries = tracker.retries.saturating_add(1);
-                        self.config.metrics.retries.add(1);
-                        self.comm.send(s, b).await.map_err(RbcError::net)?;
-                        tracker.status = Status::RequestedMsg;
-                        debug!(node = %self.label, from = %s, %digest, "message requested");
-                    }
-                }
-            }
-        }
-
-        // Go over outstanding ACKs and re-transmit:
-        for (digest, acks) in self.buffer.values_mut().flat_map(|m| m.acks.iter_mut()) {
-            let timeout = [3, 6, 10, 15, 30].get(acks.retries).copied().unwrap_or(30);
-            if acks.timestamp.elapsed() < Duration::from_millis(timeout) {
-                continue;
-            }
-            for party in &acks.rem {
-                debug!(node = %self.label, %digest, to = %party, "re-sending message");
-                self.comm
-                    .send(*party, acks.msg.clone())
-                    .await
-                    .map_err(RbcError::net)?;
-            }
-            acks.retries = acks.retries.saturating_add(1);
-            self.config.metrics.retries.add(1);
-            acks.timestamp = now
-        }
-
-        Ok(())
-    }
-
-    async fn ack(&mut self, to: PublicKey, dig: Digest) -> Result<()> {
-        let ack = Protocol::<'_, T, Validated>::Ack(dig);
-        let bytes = serialize(&ack)?;
-        self.comm.send(to, bytes).await.map_err(RbcError::net)?;
-        debug!(node = %self.label, %to, digest = %dig, "ack sent");
-        Ok(())
-    }
-}
-
-fn remaining_voters<T>(c: &RbcConfig, t: &Tracker<T>) -> Option<impl Iterator<Item = PublicKey>>
-where
-    T: Committable,
-{
-    let msg = t.message.item.as_ref()?;
-    let com = Digest::of_vertex(msg).commit();
-    let fin = t.votes.voters(&com).copied().collect::<HashSet<_>>();
-    let all = c.committee.parties().copied().collect::<HashSet<_>>();
-    Some(all.into_iter().filter(move |p| !fin.contains(p)))
 }
 
 /// Factored out of `Worker` to help with borrowing.
-async fn respond<T: Clone + Committable + Serialize, C: RawComm>(
-    net: &mut C,
+async fn respond<T: Clone + Committable + Serialize>(
+    net: &mut Overlay,
     to: PublicKey,
     vertex: &Envelope<Vertex<T>, Validated>,
 ) -> Result<()> {
     let proto = Protocol::GetResponse(Cow::Borrowed(vertex));
     let bytes = serialize(&proto)?;
-    net.send(to, bytes).await.map_err(RbcError::net)?;
+    net.unicast(to, bytes).await?;
     Ok(())
 }
 
-/// Serialize a given data type into `Bytes`
-fn serialize<T: Serialize>(d: &T) -> Result<Bytes> {
+/// Serialize a given data type into `BytesMut`
+fn serialize<T: Serialize>(d: &T) -> Result<Data> {
     let mut b = BytesMut::new().writer();
     bincode::serde::encode_into_std_write(d, &mut b, bincode::config::standard())?;
-    Ok(b.into_inner().freeze())
+    Ok(b.into_inner().try_into()?)
 }

--- a/sailfish-rbc/src/error.rs
+++ b/sailfish-rbc/src/error.rs
@@ -1,8 +1,10 @@
+use cliquenet::overlay::{DataError, NetworkDown};
+
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum RbcError {
-    #[error("network error: {0}")]
-    Net(#[source] Box<dyn std::error::Error + Send + Sync>),
+    #[error("data error: {0}")]
+    DataError(#[from] DataError),
 
     #[error("serialization error: {0}")]
     Serialization(#[from] bincode::error::EncodeError),
@@ -20,8 +22,8 @@ pub enum RbcError {
     Shutdown,
 }
 
-impl RbcError {
-    pub(crate) fn net<E: std::error::Error + Send + Sync + 'static>(e: E) -> Self {
-        Self::Net(Box::new(e))
+impl From<NetworkDown> for RbcError {
+    fn from(_: NetworkDown) -> Self {
+        Self::Shutdown
     }
 }

--- a/sailfish-types/src/comm.rs
+++ b/sailfish-types/src/comm.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use committable::Committable;
 use multisig::{PublicKey, Validated};
 
@@ -27,22 +26,6 @@ pub trait Comm<T: Committable> {
     }
 }
 
-/// Types that provide broadcast and 1:1 message communication.
-///
-/// In contrast to `Comm` this trait operates on raw byte vectors instead
-/// of `Message`s.
-#[async_trait]
-pub trait RawComm {
-    type Id;
-    type Err: Error + Send + Sync + 'static;
-
-    async fn broadcast(&mut self, msg: Bytes) -> Result<Self::Id, Self::Err>;
-
-    async fn send(&mut self, to: PublicKey, msg: Bytes) -> Result<Self::Id, Self::Err>;
-
-    async fn receive(&mut self) -> Result<(PublicKey, Bytes), Self::Err>;
-}
-
 #[async_trait]
 impl<A: Committable + Send + 'static, T: Comm<A> + Send> Comm<A> for Box<T> {
     type Err = T::Err;
@@ -56,24 +39,6 @@ impl<A: Committable + Send + 'static, T: Comm<A> + Send> Comm<A> for Box<T> {
     }
 
     async fn receive(&mut self) -> Result<Message<A, Validated>, Self::Err> {
-        (**self).receive().await
-    }
-}
-
-#[async_trait]
-impl<T: RawComm + Send> RawComm for Box<T> {
-    type Id = T::Id;
-    type Err = T::Err;
-
-    async fn broadcast(&mut self, msg: Bytes) -> Result<Self::Id, Self::Err> {
-        (**self).broadcast(msg).await
-    }
-
-    async fn send(&mut self, to: PublicKey, msg: Bytes) -> Result<Self::Id, Self::Err> {
-        (**self).send(to, msg).await
-    }
-
-    async fn receive(&mut self) -> Result<(PublicKey, Bytes), Self::Err> {
         (**self).receive().await
     }
 }

--- a/sailfish-types/src/lib.rs
+++ b/sailfish-types/src/lib.rs
@@ -4,7 +4,7 @@ mod payload;
 mod round;
 mod vertex;
 
-pub use comm::{Comm, CommError, RawComm};
+pub use comm::{Comm, CommError};
 pub use message::{Action, Evidence, Payload};
 pub use message::{Message, NoVote, NoVoteMessage, Timeout, TimeoutMessage};
 pub use payload::DataSource;

--- a/sailfish/Cargo.toml
+++ b/sailfish/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 test = ["sailfish-consensus/test"]
 
 [dependencies]
-cliquenet = { path = "../cliquenet", features = ["sailfish"] }
+cliquenet = { path = "../cliquenet" }
 committable = { workspace = true }
 futures = { workspace = true }
 multisig = { path = "../multisig" }

--- a/tests/src/tests/network/external.rs
+++ b/tests/src/tests/network/external.rs
@@ -2,7 +2,7 @@ pub mod test_simple_network;
 
 use std::collections::HashMap;
 
-use cliquenet::{NetworkMetrics, unreliable::Network};
+use cliquenet::{Network, NetworkMetrics, Overlay};
 use multisig::PublicKey;
 use sailfish::Coordinator;
 use sailfish::rbc::{Rbc, RbcConfig};
@@ -62,7 +62,7 @@ impl TestableNetwork for BasicNetworkTest {
             .await
             .expect("failed to make network");
             let cfg = RbcConfig::new(kpr.clone(), committee.clone());
-            let net = Rbc::new(net, cfg);
+            let net = Rbc::new(Overlay::new(net), cfg);
             tracing::debug!(%i, "created rbc");
             let test_net = TestNet::new(net, i as u64, self.interceptor.clone());
             let messages = test_net.messages();

--- a/tests/src/tests/rbc.rs
+++ b/tests/src/tests/rbc.rs
@@ -1,7 +1,7 @@
 use std::net::Ipv4Addr;
 use std::time::Duration;
 
-use cliquenet::{Address, NetworkMetrics, unreliable::Network};
+use cliquenet::{Address, Network, NetworkMetrics, Overlay};
 use multisig::{Committee, Keypair, PublicKey};
 use sailfish::Coordinator;
 use sailfish::rbc::{Rbc, RbcConfig};
@@ -53,7 +53,7 @@ fn mk_host<A, const N: usize>(
         let p = peers.clone();
         async move {
             let comm = Network::create_turmoil(a, k.clone(), p, NetworkMetrics::default()).await?;
-            let rbc = Rbc::new(comm, RbcConfig::new(k.clone(), c.clone()));
+            let rbc = Rbc::new(Overlay::new(comm), RbcConfig::new(k.clone(), c.clone()));
             let cons = Consensus::new(k, c, EmptyBlocks);
             let mut coor = Coordinator::new(rbc, cons);
             let mut actions = coor.init();
@@ -75,7 +75,7 @@ fn small_committee() {
     let mut sim = turmoil::Builder::new()
         .enable_random_order()
         .fail_rate(0.05)
-        .simulation_duration(Duration::from_secs(500))
+        .simulation_duration(Duration::from_secs(5000))
         .tcp_capacity(256)
         .build();
 
@@ -98,7 +98,7 @@ fn small_committee() {
     sim.client("C", async move {
         let addr = (UNSPECIFIED, ports[2]);
         let comm = Network::create_turmoil(addr, k.clone(), peers, NetworkMetrics::default()).await?;
-        let rbc = Rbc::new(comm, RbcConfig::new(k.clone(), c.clone()));
+        let rbc = Rbc::new(Overlay::new(comm), RbcConfig::new(k.clone(), c.clone()));
         let cons = Consensus::new(k, c, EmptyBlocks);
         let mut coor = Coordinator::new(rbc, cons);
         let mut actions = coor.init();
@@ -154,7 +154,7 @@ fn medium_committee() {
     sim.client("E", async move {
         let addr = (UNSPECIFIED, ports[4]);
         let comm = Network::create_turmoil(addr, k.clone(), peers, NetworkMetrics::default()).await?;
-        let rbc = Rbc::new(comm, RbcConfig::new(k.clone(), c.clone()));
+        let rbc = Rbc::new(Overlay::new(comm), RbcConfig::new(k.clone(), c.clone()));
         let cons = Consensus::new(k, c, EmptyBlocks);
         let mut coor = Coordinator::new(rbc, cons);
         let mut actions = coor.init();
@@ -209,7 +209,7 @@ fn medium_committee_partition_network() {
     sim.client("E", async move {
         let addr = (UNSPECIFIED, ports[4]);
         let comm = Network::create_turmoil(addr, k.clone(), peers, NetworkMetrics::default()).await?;
-        let rbc = Rbc::new(comm, RbcConfig::new(k.clone(), c.clone()));
+        let rbc = Rbc::new(Overlay::new(comm), RbcConfig::new(k.clone(), c.clone()));
         let cons = Consensus::new(k, c, EmptyBlocks);
         let mut coor = Coordinator::new(rbc, cons);
         let mut actions = coor.init();

--- a/timeboost/src/binaries/sailfish.rs
+++ b/timeboost/src/binaries/sailfish.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
-use cliquenet::{Address, NetworkMetrics, unreliable::Network};
+use cliquenet::{Address, Network, NetworkMetrics, Overlay};
 use committable::{Commitment, Committable, RawCommitmentBuilder};
 use multisig::{Committee, Keypair, PublicKey};
 use sailfish::{
@@ -356,7 +356,7 @@ async fn main() -> Result<()> {
     );
 
     let cfg = RbcConfig::new(keypair.clone(), committee.clone());
-    let rbc = Rbc::new(network, cfg.with_metrics(rbc_metrics));
+    let rbc = Rbc::new(Overlay::new(network), cfg.with_metrics(rbc_metrics));
 
     let consensus =
         Consensus::new(keypair, committee, repeat_with(Block::random)).with_metrics(sf_metrics);


### PR DESCRIPTION
ACK based message delivery is available as `Overlay` (previously known as `reliable::Network`), which wraps the underlying `Network` (previously `unreliable::Network`), retrying messages until acknowledged or garbage collected. RBC can therefore treat broadcast and unicast messaging as reliable which allows us to simplify the internal state handling. The RBC worker no longer needs to implement the retry logic on its own.

As a consequence, there are only two potential failures the RBC worker needs to consider: (1) the network going down, or (2) the serialised message being larger than what the network is willing to accept. Fortunately (1) is a permanent failure and the worker does not need to attempt to recover from it. To make (2) less of a concern, this PR also moves the serialisation out of the worker so that it only deals with `Data` items that have been checked w.r.t. network size constraints. (We do assume that serialising votes or certificates never exceeds the allowed size)

Finally, we remove the trait `RawComm`. RBC itself implements `Comm` but needs the specific properties of `cliquenet::Overlay` so there is no longer a point in having `RawComm`. The layering is now: `Rbc(Overlay(Network))`, where `Network` is an unrealiable, package based transport, `Overlay` adds reliability and `Rbc` byzantine reliability.