### PR TITLE
Garbage collect decryption network messages

### DIFF
--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -472,7 +472,7 @@ impl Worker {
             .broadcast(share_bytes)
             .await
             .map(|seqid| {
-                self.round2seqs.insert(share_info.round(), seqid);
+                self.round2seqs.entry(share_info.round()).or_insert(seqid);
             })
             .map_err(DecryptError::net)
     }


### PR DESCRIPTION
This PR adds garbage collection (GC) for messages in the overlay network used during the decryption phase.

For catch-up nodes, it's crucial that the decryption phase's GC window is at least as large as Sailfish's GC window. Otherwise, Sailfish might generate inclusion lists that cannot be decrypted because the corresponding messages with decryption shares have already been garbage collected. To prevent this, the decryption phase now depends on Sailfish's GC round. However, just because a round can be GC’ed in Sailfish doesn’t mean it should be GC’ed in the decryption phase—especially when the decryption phase is lagging behind. In such cases, prematurely GC’ing may drop messages still needed by other nodes for decryption.

To address this, the decryption GC window is defined relative to Sailfish GC round (`sailfish_gc_round - 100`). The constant 100 is already somewhat heuristically applied as the channel capacity between the Decrypter and its Worker, effectively acting as a leash between Sailfish and Timeboost. Since the Timeboost sequencer checks this channel’s capacity before allowing Sailfish to proceed, this value provides a safe margin for GC coordination.