### PR TITLE
Collect round info when recovering. 

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -90,8 +90,8 @@ jobs:
         tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
         sudo cp just /usr/bin/just
     - name: Run tests
-      run: just run_demo -url http://localhost:8547
+      run: just run_demo -url http://localhost:8547 -s /tmp/stamp --ignore-stamp
     - name: Run tests with late-start node
-      run: just run_demo -l -url http://localhost:8547
+      run: just run_demo -l -url http://localhost:8547 -s /tmp/stamp --ignore-stamp
     - name: Run sailfish demo
       run: just run_sailfish_demo

--- a/sailfish-rbc/src/abraham.rs
+++ b/sailfish-rbc/src/abraham.rs
@@ -51,7 +51,7 @@ enum Protocol<'a, T: Committable + Clone, Status: Clone> {
     /// A direct request to retrieve the current round number of a party.
     InfoRequest(Nonce),
 
-    /// The reply to an info request with round number an evidence.
+    /// The reply to an info request with round number and evidence.
     InfoResponse(Nonce, RoundNumber, Cow<'a, Evidence>)
 }
 

--- a/sailfish-rbc/src/abraham.rs
+++ b/sailfish-rbc/src/abraham.rs
@@ -70,6 +70,7 @@ enum Command<T: Committable> {
 pub struct RbcConfig {
     keypair: Keypair,
     committee: Committee,
+    recover: bool,
     early_delivery: bool,
     metrics: RbcMetrics,
 }
@@ -79,6 +80,7 @@ impl RbcConfig {
         Self {
             keypair: k,
             committee: c,
+            recover: true,
             early_delivery: true,
             metrics: RbcMetrics::default(),
         }
@@ -94,6 +96,12 @@ impl RbcConfig {
     /// Set the RBC metrics value to use.
     pub fn with_metrics(mut self, m: RbcMetrics) -> Self {
         self.metrics = m;
+        self
+    }
+
+    /// Should we recover from a previous run?
+    pub fn recover(mut self, val: bool) -> Self {
+        self.recover = val;
         self
     }
 }

--- a/sailfish-rbc/src/abraham.rs
+++ b/sailfish-rbc/src/abraham.rs
@@ -48,8 +48,10 @@ enum Protocol<'a, T: Committable + Clone, Status: Clone> {
     /// The reply to a get request.
     GetResponse(Cow<'a, Envelope<Vertex<T>, Status>>),
 
+    /// A direct request to retries the current round number of a party.
     InfoRequest(Nonce),
 
+    /// The reply to an info request with round number an evidence.
     InfoResponse(Nonce, RoundNumber, Cow<'a, Evidence>)
 }
 

--- a/sailfish-rbc/src/abraham.rs
+++ b/sailfish-rbc/src/abraham.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::fmt;
 
 use async_trait::async_trait;
 use bytes::{BufMut, BytesMut};
@@ -46,6 +47,10 @@ enum Protocol<'a, T: Committable + Clone, Status: Clone> {
 
     /// The reply to a get request.
     GetResponse(Cow<'a, Envelope<Vertex<T>, Status>>),
+
+    InfoRequest(Nonce),
+
+    InfoResponse(Nonce, RoundNumber, Cow<'a, Evidence>)
 }
 
 /// Worker command
@@ -177,7 +182,7 @@ impl<T: Committable + Send + Serialize + Clone + 'static> Comm<T> for Rbc<T> {
     }
 
     async fn receive(&mut self) -> Result<Message<T, Validated>, Self::Err> {
-        Ok(self.rx.recv().await.unwrap())
+        self.rx.recv().await.ok_or(RbcError::Shutdown)
     }
 
     async fn gc(&mut self, r: RoundNumber) -> Result<(), Self::Err> {
@@ -193,4 +198,20 @@ fn serialize<T: Serialize>(d: &T) -> Result<Data, RbcError> {
     let mut b = BytesMut::new().writer();
     bincode::serde::encode_into_std_write(d, &mut b, bincode::config::standard())?;
     Ok(b.into_inner().try_into()?)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+struct Nonce(u64);
+
+impl Nonce {
+    fn new() -> Self {
+        Self(rand::random())
+    }
+}
+
+impl fmt::Display for Nonce {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }

--- a/sailfish-rbc/src/abraham.rs
+++ b/sailfish-rbc/src/abraham.rs
@@ -48,7 +48,7 @@ enum Protocol<'a, T: Committable + Clone, Status: Clone> {
     /// The reply to a get request.
     GetResponse(Cow<'a, Envelope<Vertex<T>, Status>>),
 
-    /// A direct request to retries the current round number of a party.
+    /// A direct request to retrieve the current round number of a party.
     InfoRequest(Nonce),
 
     /// The reply to an info request with round number an evidence.

--- a/sailfish-rbc/src/abraham/worker.rs
+++ b/sailfish-rbc/src/abraham/worker.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
-use std::collections::BTreeMap;
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 use bytes::Bytes;
@@ -14,12 +15,12 @@ use sailfish_types::{Evidence, Message, RoundNumber, Vertex};
 use serde::{Serialize, de::DeserializeOwned};
 use tokio::sync::mpsc;
 use tokio::time::Instant;
-use tracing::{debug, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 use crate::RbcError;
 use crate::digest::Digest;
 
-use super::{Command, Protocol, RbcConfig, serialize};
+use super::{Command, Nonce, Protocol, RbcConfig, serialize};
 
 type RbcResult<T> = std::result::Result<T, RbcError>;
 type SendResult<T> = std::result::Result<T, NetworkDown>;
@@ -41,6 +42,15 @@ pub struct Worker<T: Committable> {
     rx: Receiver<T>,
     /// The tracking information per message.
     buffer: BTreeMap<RoundNumber, Messages<T>>,
+    /// The state the worker is in.
+    state: WorkerState,
+    /// The latest round number this worker is in.
+    round: (RoundNumber, Evidence)
+}
+
+enum WorkerState {
+    Start(Nonce, HashMap<PublicKey, RoundNumber>),
+    Barrier(RoundNumber),
 }
 
 /// Messages of a single round.
@@ -90,8 +100,6 @@ impl<T: Committable> Default for Messages<T> {
 
 /// Tracking information about a message and its status.
 struct Tracker<T: Committable> {
-    /// The producer of this message.
-    source: Option<PublicKey>,
     /// The time when this info was created.
     start: Instant,
     /// The message (if any).
@@ -116,6 +124,9 @@ impl<T: Committable> Tracker<T> {
 struct Item<T> {
     /// This item's value, i.e. the message.
     item: Option<T>,
+    prop: Option<Data>,
+    vote: Option<Data>,
+    cert: Option<Data>,
     /// If `true`, this item was delivered early.
     ///
     /// The flag is used for performance reasons to avoid duplicate delivery
@@ -127,6 +138,9 @@ impl<T> Item<T> {
     fn none() -> Self {
         Self {
             item: None,
+            prop: None,
+            vote: None,
+            cert: None,
             early: false,
         }
     }
@@ -134,6 +148,9 @@ impl<T> Item<T> {
     fn some(item: T) -> Self {
         Self {
             item: Some(item),
+            prop: None,
+            vote: None,
+            cert: None,
             early: false,
         }
     }
@@ -172,6 +189,8 @@ impl<T: Committable> Worker<T> {
             tx,
             rx,
             buffer: BTreeMap::new(),
+            round: (RoundNumber::genesis(), Evidence::Genesis),
+            state: WorkerState::Start(Nonce::new(), HashMap::new())
         }
     }
 }
@@ -183,6 +202,10 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
     /// to deliver. Periodically we also revisit our message buffer and try to make
     /// progress.
     pub async fn go(mut self) {
+        if let Err(err) = self.startup().await {
+            error!(node = %self.key, %err, "startup failure");
+            return
+        }
         loop {
             tokio::select! {
                 val = self.comm.receive(), if self.tx.capacity() > 0 => {
@@ -248,19 +271,38 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
         }
     }
 
+    /// Request round number information in startup.
+    async fn startup(&mut self) -> RbcResult<()> {
+        if let WorkerState::Start(nonce, _) = &self.state {
+            let req = Protocol::<'_, T, Validated>::InfoRequest(*nonce);
+            let bytes = serialize(&req)?;
+            self.comm.broadcast(bytes).await?;
+            debug!(node = %self.key, %nonce, "info request broadcasted");
+        }
+        Ok(())
+    }
+
     /// Best effort broadcast.
     async fn broadcast(&mut self, msg: Message<T, Validated>, data: Data) -> SendResult<()> {
+        if self.barrier().is_gt() {
+            debug!(node = %self.key, "suppressing message broadcast");
+            return Ok(())
+        }
         let digest = Digest::of_msg(&msg);
         self.comm.broadcast(data).await?;
-        debug!(node = %self.key, %digest, "best-effort broadcast");
+        debug!(node = %self.key, %digest, "message broadcasted");
         Ok(())
     }
 
     /// 1:1 communication.
     async fn send(&mut self, to: PublicKey, msg: Message<T, Validated>, data: Data) -> SendResult<()> {
+        if self.barrier().is_gt() {
+            debug!(node = %self.key, %msg, "suppressing direct send");
+            return Ok(())
+        }
         let digest = Digest::of_msg(&msg);
         self.comm.unicast(to, data).await?;
-        debug!(node = %self.key, %to, %digest, "best-effort send");
+        debug!(node = %self.key, %to, %digest, "direct send");
         Ok(())
     }
 
@@ -269,20 +311,30 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
         trace!(node = %self.key, vertex = %vertex.data(), "proposing");
         let digest = Digest::of_vertex(&vertex);
 
-        let tracker = Tracker {
-            source: Some(self.config.keypair.public_key()),
+        self.round = (*vertex.data().round().data(), vertex.data().evidence().clone());
+
+        let mut tracker = Tracker {
             start: Instant::now(),
             message: Item::some(vertex),
             votes: VoteAccumulator::new(self.config.committee.clone()),
             status: Status::Initiated,
         };
 
-        let id = self.comm.broadcast(data).await?;
-        debug!(node = %self.key, %digest, "message broadcasted");
-
+        let can_send = self.barrier().is_le();
         let messages = self.buffer.entry(digest.round()).or_default();
+
+        if !can_send {
+            tracker.message.prop = Some(data);
+            messages.map.insert(digest, tracker);
+            debug!(node = %self.key, %digest, "suppressing proposal");
+            return Ok(())
+        }
+
+        let id = self.comm.broadcast(data).await?;
         messages.map.insert(digest, tracker);
         messages.last = Some(id);
+
+        debug!(node = %self.key, %digest, "proposal broadcasted");
 
         Ok(())
     }
@@ -297,6 +349,93 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
             Protocol::GetRequest(dig) => self.on_get_request(src, dig).await?,
             Protocol::GetResponse(msg) => self.on_get_response(src, msg.into_owned()).await?,
             Protocol::Cert(crt) => self.on_cert(src, crt).await?,
+            Protocol::InfoRequest(nonce) => self.on_info_request(src, nonce).await?,
+            Protocol::InfoResponse(n, r, e) => self.on_info_response(src, n, r, e.into_owned()).await?,
+        }
+
+        Ok(())
+    }
+
+    /// We receveived a round number information request.
+    async fn on_info_request(&mut self, src: PublicKey, n: Nonce) -> RbcResult<()> {
+        debug!(node = %self.key, %src, nonce = %n, "info request received");
+        let (r, e) = &self.round;
+        let proto = Protocol::<'_, T, Validated>::InfoResponse(n, *r, Cow::Borrowed(e));
+        let bytes = serialize(&proto)?;
+        self.comm.unicast(src, bytes).await?;
+        Ok(())
+    }
+
+    /// We receveived a response to our round number information request.
+    async fn on_info_response(&mut self, src: PublicKey, n: Nonce, r: RoundNumber, e: Evidence) -> RbcResult<()> {
+        debug!(node = %self.key, %src, nonce = %n, %r, "info response received");
+
+        let WorkerState::Start(nonce, rounds) = &mut self.state else {
+            debug!(node = %self.key, %src, nonce = %n, %r, "startup phase already completed");
+            return Ok(())
+        };
+
+        if rounds.contains_key(&src) {
+            // We already received a response from this party.
+            return Ok(())
+        }
+
+        if *nonce != n {
+            warn!(node = %self.key, %src, ours = %nonce, theirs = %n, "nonce mismatch");
+            return Ok(())
+        }
+
+        if !e.is_genesis() && (e.round() + 1 != r || !e.is_valid(&self.config.committee)) {
+            warn!(node = %self.key, %src, "invalid round evidence");
+            return Err(RbcError::InvalidMessage);
+        }
+
+        rounds.insert(src, r);
+
+        if rounds.len() >= self.config.committee.quorum_size().get() {
+            let round = rounds.values().max().copied().expect("|rounds| >= quorum > 0");
+
+            let barrier = if round.is_genesis() {
+                round
+            } else {
+                round.saturating_add(2).into()
+            };
+
+            self.state = WorkerState::Barrier(barrier);
+
+            debug!(node = %self.key, %barrier, "round number info collected");
+
+            if !barrier.is_genesis() {
+                return Ok(())
+            }
+
+            for (_, messages) in self.buffer.range_mut(barrier ..) {
+                for (digest, tracker) in &mut messages.map {
+                    match tracker.status {
+                        Status::Requested | Status::Delivered => {
+                            if let Some(cert) = tracker.message.cert.take() {
+                                self.comm.broadcast(cert).await?;
+                                debug!(node = %self.key, %digest, "cert broadcasted");
+                            }
+                        }
+                        Status::Initiated => {
+                            if let Some(proposal) = tracker.message.prop.take() {
+                                let id = self.comm.broadcast(proposal).await?;
+                                messages.last = Some(id);
+                                debug!(node = %self.key, %digest, "proposal broadcasted");
+                            }
+                            if let Some(vote) = tracker.message.vote.take() {
+                                self.comm.broadcast(vote).await?;
+                                debug!(node = %self.key, %digest, "vote broadcasted");
+                            }
+                            if let Some(cert) = tracker.message.cert.take() {
+                                self.comm.broadcast(cert).await?;
+                                debug!(node = %self.key, %digest, "cert broadcasted");
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         Ok(())
@@ -339,11 +478,11 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
             }
         }
 
+        let can_send = self.barrier().is_le();
         let evidence = vertex.data().evidence().clone();
         let messages = self.buffer.entry(digest.round()).or_default();
 
         let tracker = messages.map.entry(digest).or_insert_with(|| Tracker {
-            source: None,
             start: Instant::now(),
             message: Item::none(),
             votes: VoteAccumulator::new(self.config.committee.clone()),
@@ -357,11 +496,15 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
                     let env = Envelope::signed(digest, &self.config.keypair, false);
                     let vote = Protocol::<'_, T, Validated>::Vote(env, evidence);
                     let bytes = serialize(&vote)?;
-                    self.comm.broadcast(bytes).await?;
-                    debug!(node = %self.key, %digest, "vote broadcasted");
+                    if can_send {
+                        self.comm.broadcast(bytes).await?;
+                        debug!(node = %self.key, %digest, "vote broadcasted");
+                    } else {
+                        tracker.message.vote = Some(bytes);
+                        debug!(node = %self.key, %digest, "suppressing vote");
+                    }
                 }
                 if tracker.message.item.is_none() {
-                    tracker.source = Some(src);
                     tracker.message = Item::some(vertex);
                 }
             }
@@ -370,7 +513,6 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
             // it to the application.
             Status::Requested => {
                 debug_assert!(tracker.message.item.is_none());
-                tracker.source = Some(src);
                 tracker.message = Item::some(vertex.clone());
 
                 // Now that we have the message corresponding to the voter quorum we can
@@ -382,8 +524,14 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
                 let cert_digest = Digest::of_cert(cert);
                 let m = Protocol::<'_, T, Validated>::Cert(cert.clone());
                 let b = serialize(&m)?;
-                self.comm.broadcast(b).await?;
-                debug!(node = %self.key, %digest, cert = %cert_digest, "cert broadcasted");
+
+                if can_send {
+                    self.comm.broadcast(b).await?;
+                    debug!(node = %self.key, %digest, cert = %cert_digest, "cert broadcasted");
+                } else {
+                    tracker.message.cert = Some(b);
+                    debug!(node = %self.key, %digest, "suppressing cert");
+                }
 
                 self.tx
                     .send(Message::Vertex(vertex.clone()))
@@ -468,10 +616,10 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
             }
         }
 
+        let can_send = self.barrier().is_le();
         let messages = self.buffer.entry(digest.round()).or_default();
 
         let tracker = messages.map.entry(digest).or_insert_with(|| Tracker {
-            source: None,
             start: Instant::now(),
             message: Item::none(),
             votes: VoteAccumulator::new(self.config.committee.clone()),
@@ -490,8 +638,13 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
                         let cert_digest = Digest::of_cert(cert);
                         let m = Protocol::<'_, T, Validated>::Cert(cert.clone());
                         let b = serialize(&m)?;
-                        self.comm.broadcast(b).await?;
-                        debug!(node = %self.key, %digest, cert = %cert_digest, "cert broadcasted");
+                        if can_send {
+                            self.comm.broadcast(b).await?;
+                            debug!(node = %self.key, %digest, cert = %cert_digest, "cert broadcasted");
+                        } else {
+                            tracker.message.cert = Some(b);
+                            debug!(node = %self.key, %digest, "suppressing cert");
+                        }
                         if !tracker.message.early {
                             self.tx
                                 .send(Message::Vertex(vertex.clone()))
@@ -550,9 +703,9 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
         }
 
         let commit = digest.commit();
+        let can_send = self.barrier().is_le();
         let messages = self.buffer.entry(digest.round()).or_default();
         let tracker = messages.map.entry(digest).or_insert_with(|| Tracker {
-            source: None,
             start: Instant::now(),
             message: Item::none(),
             votes: VoteAccumulator::new(self.config.committee.clone()),
@@ -568,8 +721,13 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
                 if let Some(vertex) = &tracker.message.item {
                     let m = Protocol::<'_, T, Validated>::Cert(crt);
                     let b = serialize(&m)?;
-                    self.comm.broadcast(b).await?;
-                    debug!(node = %self.key, %digest, cert = %cert_digest, "cert broadcasted");
+                    if can_send {
+                        self.comm.broadcast(b).await?;
+                        debug!(node = %self.key, %digest, cert = %cert_digest, "cert broadcasted");
+                    } else {
+                        tracker.message.cert = Some(b);
+                        debug!(node = %self.key, %digest, "suppressing cert");
+                    }
                     if !tracker.message.early {
                         self.tx
                             .send(Message::Vertex(vertex.clone()))
@@ -601,6 +759,11 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
     /// One of our peers is asking for a message proposal.
     async fn on_get_request(&mut self, src: PublicKey, digest: Digest) -> RbcResult<()> {
         debug!(node = %self.key, %src, %digest, "get request received");
+
+        if self.barrier().is_gt() {
+            debug!(node = %self.key, %src, %digest, "suppressing response to get request");
+            return Ok(())
+        }
 
         if let Some(msg) = self
             .buffer
@@ -652,5 +815,12 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
         tracker.status = Status::Delivered;
 
         Ok(())
+    }
+
+    fn barrier(&self) -> Ordering {
+        if let WorkerState::Barrier(r) = self.state {
+            return r.cmp(&self.round.0)
+        }
+        Ordering::Greater
     }
 }

--- a/sailfish-rbc/src/abraham/worker.rs
+++ b/sailfish-rbc/src/abraham/worker.rs
@@ -424,13 +424,13 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
         rounds.insert(src, r);
 
         if rounds.len() >= self.config.committee.quorum_size().get() {
-            let round = rounds.values().max().copied().expect("|rounds| >= quorum > 0");
-
-            let barrier = if round.is_genesis() {
-                round
-            } else {
-                round.saturating_add(2).into()
-            };
+            let barrier = rounds
+                .values()
+                .max()
+                .copied()
+                .expect("|rounds| >= quorum > 0")
+                .saturating_add(2)
+                .into();
 
             self.state = WorkerState::Barrier(barrier);
 

--- a/sailfish-rbc/src/abraham/worker.rs
+++ b/sailfish-rbc/src/abraham/worker.rs
@@ -44,7 +44,7 @@ pub struct Worker<T: Committable> {
     buffer: BTreeMap<RoundNumber, Messages<T>>,
     /// The state the worker is in.
     state: WorkerState,
-    /// The latest round number this worker is in.
+    /// The latest round number this worker proposed.
     round: (RoundNumber, Evidence)
 }
 
@@ -61,11 +61,12 @@ enum WorkerState {
     ///
     /// Proposals, votes and certificates that would normally be sent are
     /// stored and once the round number barrier for participation has been
-    /// determined, the deferred messages from that round number onwards will
+    /// reached, the deferred messages from that round number onwards will
     /// be sent out.
     Recover(Nonce, HashMap<PublicKey, RoundNumber>),
-    /// This is the normal running state after recovery, with the round number barrier
-    /// restricting when messages are eligible for sending.
+    /// This is the normal running state after round numbers have been collected.
+    /// The barrier is the maximum of at least 2t + 1 reported round numbers and
+    /// restricts when messages are eligible for sending.
     Barrier(RoundNumber),
 }
 

--- a/scripts/run-sailfish-demo
+++ b/scripts/run-sailfish-demo
@@ -19,6 +19,8 @@ for (( i=0; i<$nodes; i++ )); do
         --metrics-port $((9000 + $i))
         --keyset-file test-configs/local.json
         --nodes $nodes
+        --stamp "${TMPDIR:-/tmp}/stamp-$i.sf"
+        --ignore-stamp
         --until 300
     )
 

--- a/scripts/run-timeboost-demo
+++ b/scripts/run-timeboost-demo
@@ -6,6 +6,9 @@ just build_release --features until
 nodes=5
 nitro_node_url=""
 late_start=false
+stamp=
+ignore_stamp=false
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -l|--late)
@@ -24,6 +27,14 @@ while [[ $# -gt 0 ]]; do
             nitro_node_url="$2"
             shift 2
             ;;
+        -s|--stamp)
+            stamp="$2"
+            shift 2
+            ;;
+        --ignore-stamp)
+            ignore_stamp=true
+            shift
+            ;;
         *)
             echo "Unknown: $1"
             echo "Usage: $0 [-l|--late] [-url|--url <NITRO_URL>] [-n|--nodes <NUMBER>]"
@@ -31,6 +42,11 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [ ! $stamp ]; then
+    echo "Missing -s | --stamp <PATH prefix>"
+    exit 1
+fi
 
 if [ -n "$nitro_node_url" ]; then
     nitro_node_url="--nitro-node-url $nitro_node_url"
@@ -59,8 +75,14 @@ for i in $(seq 0 $((nodes - 1))); do
         $nitro_node_url \
         --tps 5 \
         --nodes $nodes \
+        --stamp \"$stamp-$i.sf\" \
         --keyset-file test-configs/local.json \
         --watchdog-timeout 300"
+
+    if $ignore_stamp; then
+        cmd="$cmd --ignore-stamp"
+    fi
+
     if $late_start; then
         cmd="$cmd --late-start --late-start-node-id 0"
     fi

--- a/scripts/runit
+++ b/scripts/runit
@@ -7,6 +7,8 @@ rounds=1000
 late_start=false
 keyset_file="test-configs/local.json"
 tps=1
+stamp=
+ignore_stamp=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -30,6 +32,14 @@ while [[ $# -gt 0 ]]; do
             tps="$2"
             shift 2
             ;;
+        -s|--stamp)
+            stamp="$2"
+            shift 2
+            ;;
+        --ignore-stamp)
+            ignore_stamp=true
+            shift
+            ;;
         *)
             echo -e "Unknown: $1\n"
             echo "Usage: $0 [Options] where
@@ -48,12 +58,23 @@ Options:
     -t | --tps <NUMBER>
         Number of transactions per second to generate.
 
+    -s | --stamp <PATH prefix>
+        Path prefix for the stamp files.
+
     -n | --nodes <NUMBER>
-        Run the given number of nodes (default = 5)."
+        Run the given number of nodes (default = 5).
+
+    --ignore-stamp
+        Ignore an existing stamp file and start from genesis"
             exit 1
             ;;
     esac
 done
+
+if [ ! $stamp ]; then
+    echo "Missing -s | --stamp <PATH prefix>"
+    exit 1
+fi
 
 set -a;
 source .env;
@@ -73,7 +94,12 @@ for (( i=0; i<$nodes; i++ )); do
         --nodes $nodes
         --keyset-file $keyset_file
         --tps $tps
+        --stamp "${stamp}-$i.sf"
         --watchdog-timeout $rounds)
+
+    if $ignore_stamp; then
+        cmd+=(--ignore-stamp)
+    fi
 
     if $late_start; then
         cmd+=(--late-start --late-start-node-id 0)

--- a/tests/src/tests/consensus/helpers/node_instrument.rs
+++ b/tests/src/tests/consensus/helpers/node_instrument.rs
@@ -164,8 +164,8 @@ fn assert_equiv(a: &Action, b: &Action, c: &Committee) {
             assert_eq!(x.is_valid(c), y.is_valid(c));
             let xv = x.data();
             let yv = y.data();
-            let xe = xv.evidence().is_valid(c);
-            let ye = yv.evidence().is_valid(c);
+            let xe = xv.evidence().is_valid(*xv.round().data(), c);
+            let ye = yv.evidence().is_valid(*yv.round().data(), c);
             let xn = xv.no_vote_cert().map(|crt| crt.is_valid(c));
             let yn = yv.no_vote_cert().map(|crt| crt.is_valid(c));
             let xve = xv.edges().copied().collect::<BTreeSet<_>>();
@@ -185,8 +185,8 @@ fn assert_equiv(a: &Action, b: &Action, c: &Committee) {
             let xt = x.data();
             let yt = y.data();
             assert_eq!(xt.timeout(), yt.timeout());
-            let xe = xt.evidence().is_valid(c);
-            let ye = yt.evidence().is_valid(c);
+            let xe = xt.evidence().is_valid(xt.timeout().data().round(), c);
+            let ye = yt.evidence().is_valid(yt.timeout().data().round(), c);
             assert_eq!(xe, ye);
         }
         (Action::SendNoVote(xto, x), Action::SendNoVote(yto, y)) => {

--- a/tests/src/tests/network/external.rs
+++ b/tests/src/tests/network/external.rs
@@ -61,7 +61,7 @@ impl TestableNetwork for BasicNetworkTest {
             )
             .await
             .expect("failed to make network");
-            let cfg = RbcConfig::new(kpr.clone(), committee.clone());
+            let cfg = RbcConfig::new(kpr.clone(), committee.clone()).recover(false);
             let net = Rbc::new(Overlay::new(net), cfg);
             tracing::debug!(%i, "created rbc");
             let test_net = TestNet::new(net, i as u64, self.interceptor.clone());

--- a/tests/src/tests/rbc.rs
+++ b/tests/src/tests/rbc.rs
@@ -53,7 +53,8 @@ fn mk_host<A, const N: usize>(
         let p = peers.clone();
         async move {
             let comm = Network::create_turmoil(a, k.clone(), p, NetworkMetrics::default()).await?;
-            let rbc = Rbc::new(Overlay::new(comm), RbcConfig::new(k.clone(), c.clone()));
+            let cfg = RbcConfig::new(k.clone(), c.clone()).recover(false);
+            let rbc = Rbc::new(Overlay::new(comm), cfg);
             let cons = Consensus::new(k, c, EmptyBlocks);
             let mut coor = Coordinator::new(rbc, cons);
             let mut actions = coor.init();
@@ -98,7 +99,8 @@ fn small_committee() {
     sim.client("C", async move {
         let addr = (UNSPECIFIED, ports[2]);
         let comm = Network::create_turmoil(addr, k.clone(), peers, NetworkMetrics::default()).await?;
-        let rbc = Rbc::new(Overlay::new(comm), RbcConfig::new(k.clone(), c.clone()));
+        let cfg = RbcConfig::new(k.clone(), c.clone()).recover(false);
+        let rbc = Rbc::new(Overlay::new(comm), cfg);
         let cons = Consensus::new(k, c, EmptyBlocks);
         let mut coor = Coordinator::new(rbc, cons);
         let mut actions = coor.init();
@@ -154,7 +156,8 @@ fn medium_committee() {
     sim.client("E", async move {
         let addr = (UNSPECIFIED, ports[4]);
         let comm = Network::create_turmoil(addr, k.clone(), peers, NetworkMetrics::default()).await?;
-        let rbc = Rbc::new(Overlay::new(comm), RbcConfig::new(k.clone(), c.clone()));
+        let cfg = RbcConfig::new(k.clone(), c.clone()).recover(false);
+        let rbc = Rbc::new(Overlay::new(comm), cfg);
         let cons = Consensus::new(k, c, EmptyBlocks);
         let mut coor = Coordinator::new(rbc, cons);
         let mut actions = coor.init();
@@ -209,7 +212,8 @@ fn medium_committee_partition_network() {
     sim.client("E", async move {
         let addr = (UNSPECIFIED, ports[4]);
         let comm = Network::create_turmoil(addr, k.clone(), peers, NetworkMetrics::default()).await?;
-        let rbc = Rbc::new(Overlay::new(comm), RbcConfig::new(k.clone(), c.clone()));
+        let cfg = RbcConfig::new(k.clone(), c.clone()).recover(false);
+        let rbc = Rbc::new(Overlay::new(comm), cfg);
         let cons = Consensus::new(k, c, EmptyBlocks);
         let mut coor = Coordinator::new(rbc, cons);
         let mut actions = coor.init();

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -466,7 +466,8 @@ impl Worker {
         self.net
             .broadcast(*share_info.round(), share_bytes)
             .await
-            .map_err(DecryptError::net)
+            .map_err(DecryptError::net)?;
+        Ok(())
     }
 
     fn insert_shares(&mut self, share_info: ShareInfo) -> Result<()> {

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -81,6 +81,10 @@ impl SequencerConfig {
         self.recover = val;
         self
     }
+
+    pub fn is_recover(&self) -> bool {
+        self.recover
+    }
 }
 
 pub struct Sequencer {

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -39,6 +39,7 @@ pub struct SequencerConfig {
     bind: net::Address,
     index: DelayedInboxIndex,
     dec_sk: DecryptionKey,
+    recover: bool,
 }
 
 impl SequencerConfig {
@@ -53,6 +54,7 @@ impl SequencerConfig {
             bind: bind.into(),
             index: DelayedInboxIndex::default(),
             dec_sk,
+            recover: true,
         }
     }
 
@@ -72,6 +74,11 @@ impl SequencerConfig {
 
     pub fn with_delayed_inbox_index(mut self, i: DelayedInboxIndex) -> Self {
         self.index = i;
+        self
+    }
+
+    pub fn recover(mut self, val: bool) -> Self {
+        self.recover = val;
         self
     }
 }
@@ -141,7 +148,7 @@ impl Sequencer {
         )
         .await?;
 
-        let rcf = RbcConfig::new(cfg.keypair.clone(), committee.clone());
+        let rcf = RbcConfig::new(cfg.keypair.clone(), committee.clone()).recover(cfg.recover);
         let rbc = Rbc::new(Overlay::new(network), rcf.with_metrics(rbc_metrics));
 
         let label = cfg.keypair.public_key();

--- a/timeboost-sequencer/tests/transaction-order.rs
+++ b/timeboost-sequencer/tests/transaction-order.rs
@@ -96,7 +96,10 @@ fn make_configs((pubkey, combkey, shares): &TrustedKeyMaterial) -> Vec<Sequencer
     let mut cfgs = Vec::new();
     for (kpair, addr, share) in parts.clone() {
         let dkey = DecryptionKey::new(pubkey.clone(), combkey.clone(), share);
-        cfgs.push(SequencerConfig::new(kpair, dkey, addr).with_peers(peers.clone()))
+        let cfg = SequencerConfig::new(kpair, dkey, addr)
+            .with_peers(peers.clone())
+            .recover(false);
+        cfgs.push(cfg)
     }
     cfgs
 }

--- a/timeboost-sequencer/tests/transaction-order.rs
+++ b/timeboost-sequencer/tests/transaction-order.rs
@@ -21,9 +21,13 @@ use tracing::{debug, info, warn};
 type EncKey = <DecryptionScheme as ThresholdEncScheme>::PublicKey;
 
 const NUM_OF_TRANSACTIONS: usize = 500;
+const RECOVER_INDEX: usize = 2;
 
 /// Run some timboost sequencer instances and check that they produce the
 /// same sequence of transaction.
+///
+/// We include testing for round info recovery of a node by delaying the start
+/// of one sequencer and configuring it to recover.
 #[tokio::test]
 async fn transaction_order() {
     init_logging();
@@ -43,6 +47,10 @@ async fn transaction_order() {
         let (tx, rx) = mpsc::unbounded_channel();
         let mut brx = bcast.subscribe();
         tasks.spawn(async move {
+            if c.is_recover() {
+                // delay start of a recovering node:
+                sleep(Duration::from_secs(5)).await
+            }
             let mut s = Sequencer::new(c, &NoMetrics).await.unwrap();
             let mut i = 0;
             while i < NUM_OF_TRANSACTIONS {
@@ -94,11 +102,11 @@ fn make_configs((pubkey, combkey, shares): &TrustedKeyMaterial) -> Vec<Sequencer
     let peers = parts.iter().map(|(k, a, _)| (k.public_key(), *a));
 
     let mut cfgs = Vec::new();
-    for (kpair, addr, share) in parts.clone() {
+    for (i, (kpair, addr, share)) in parts.clone().into_iter().enumerate() {
         let dkey = DecryptionKey::new(pubkey.clone(), combkey.clone(), share);
         let cfg = SequencerConfig::new(kpair, dkey, addr)
             .with_peers(peers.clone())
-            .recover(false);
+            .recover(i == RECOVER_INDEX);
         cfgs.push(cfg)
     }
     cfgs

--- a/timeboost/src/binaries/builder.rs
+++ b/timeboost/src/binaries/builder.rs
@@ -114,6 +114,10 @@ struct Cli {
     /// Backwards compatibility. This allows for a single region to run (i.e. local)
     #[clap(long, default_value_t = false)]
     multi_region: bool,
+
+    /// Path to a file that this process creates or reads as execution proof.
+    #[clap(long)]
+    stamp: PathBuf,
 }
 
 #[tokio::main]
@@ -252,6 +256,7 @@ async fn main() -> Result<()> {
         sender: tb_app_tx,
         receiver: tb_app_rx,
         tps: cli.tps,
+        stamp: cli.stamp,
     };
 
     let timeboost = Timeboost::new(init).await?;

--- a/timeboost/src/binaries/builder.rs
+++ b/timeboost/src/binaries/builder.rs
@@ -118,6 +118,10 @@ struct Cli {
     /// Path to a file that this process creates or reads as execution proof.
     #[clap(long)]
     stamp: PathBuf,
+
+    /// Ignore any existing stamp file and start from genesis.
+    #[clap(long, default_value_t = false)]
+    ignore_stamp: bool,
 }
 
 #[tokio::main]
@@ -257,6 +261,7 @@ async fn main() -> Result<()> {
         receiver: tb_app_rx,
         tps: cli.tps,
         stamp: cli.stamp,
+        ignore_stamp: cli.ignore_stamp,
     };
 
     let timeboost = Timeboost::new(init).await?;

--- a/timeboost/src/binaries/sailfish.rs
+++ b/timeboost/src/binaries/sailfish.rs
@@ -109,6 +109,9 @@ struct Cli {
     /// Path to a file that this process creates or reads as execution proof.
     #[clap(long)]
     stamp: PathBuf,
+
+    #[clap(long, default_value_t = false)]
+    ignore_stamp: bool,
 }
 
 /// Payload data type is a block of 512 random bytes.
@@ -360,7 +363,11 @@ async fn main() -> Result<()> {
     );
 
     // If the stamp file exists we need to recover from a previous run.
-    let recover = tokio::fs::try_exists(&cli.stamp).await?;
+    let recover = if cli.ignore_stamp {
+        false
+    } else {
+        tokio::fs::try_exists(&cli.stamp).await?
+    };
 
     let cfg = RbcConfig::new(keypair.clone(), committee.clone()).recover(recover);
     let rbc = Rbc::new(Overlay::new(network), cfg.with_metrics(rbc_metrics));

--- a/timeboost/src/lib.rs
+++ b/timeboost/src/lib.rs
@@ -65,6 +65,9 @@ pub struct TimeboostConfig {
 
     /// Path to a file that this process creates or reads as execution proof.
     pub stamp: PathBuf,
+
+    /// Ignore any existing stamp file and start with genesis round.
+    pub ignore_stamp: bool,
 }
 
 pub struct Timeboost {
@@ -78,7 +81,12 @@ pub struct Timeboost {
 
 impl Timeboost {
     pub async fn new(init: TimeboostConfig) -> Result<Self> {
-        let recover = tokio::fs::try_exists(&init.stamp).await?;
+        let recover = if init.ignore_stamp {
+            false
+        } else {
+            tokio::fs::try_exists(&init.stamp).await?
+        };
+
         let scf =
             SequencerConfig::new(init.keypair.clone(), init.dec_sk.clone(), init.bind_address)
                 .recover(recover)


### PR DESCRIPTION
Implements Fig. 11 of the spec. One complication is how to know when to recover. This PR solves this by creating a stamp file when first starting. Subsequent starts will switch to recovery when the file exists. The command-line option `--stamp` has been added to allow specifying the path of the stamp file. To make test scripts not terribly inconvenient to use a second option `--ignore-stamp` is available which does what it says.

In addition to that `Evidence::is_valid` has been improved by always requiring a round number as parameter, as the validity of the evidence is linked to the round number it is meant to support.