### PR TITLE
Use `Bucket`s in `Overlay`.

### DIFF
--- a/cliquenet/src/overlay.rs
+++ b/cliquenet/src/overlay.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::convert::Infallible;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -17,14 +17,27 @@ use crate::Network;
 
 type Result<T> = std::result::Result<T, NetworkDown>;
 
+/// `Overlay` wraps a [`Network`] and returns acknowledgements to senders.
+///
+/// It also retries messages until either an acknowledgement has been received
+/// or client code has indicated that the messages are no longer of interest
+/// by invoking `Overlay::gc`.
+///
+/// Each message that is sent has a trailer appended that contains the bucket
+/// number and ID of the message. Receivers will send this trailer back. The
+/// sender then stops retrying the corresponding message.
+///
+/// Note that if malicious parties modify the trailer and have it point to a
+/// different message, they can only remove themselves from the set of parties
+/// the sender is expecting an acknowledgement from.
 #[derive(Debug)]
 pub struct Overlay {
     this: PublicKey,
     net: Network,
     sender: Sender<(Option<PublicKey>, Bytes)>,
     parties: Vec<PublicKey>,
+    id: Id,
     buffer: Buffer,
-    id: SeqId,
     retry: JoinHandle<Infallible>,
 }
 
@@ -34,20 +47,39 @@ impl Drop for Overlay {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SeqId(u64);
-
+/// Newtype wrapping some length-checked bytes.
+///
+/// This exists to allow clients to construct a message item that will
+/// not be rejected by the network due to size violations (see the
+/// `TryFrom<BytesMut>` impl for details).
 #[derive(Debug, Clone)]
 pub struct Data(BytesMut);
 
+/// Buckets conceptionally contain messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Bucket(u64);
+
+/// A message ID uniquely identifies as message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct Id(u64);
+
+/// Messages are associated with IDs and put into buckets.
+///
+/// Bucket numbers are given to us by clients which also garbage collect
+/// explicitly by specifying the bucket up to which to remove messages.
+/// Buckets often correspond to rounds elsewhere.
 #[derive(Debug, Clone, Default)]
-struct Buffer(Arc<Mutex<BTreeMap<SeqId, Message>>>);
+struct Buffer(Arc<Mutex<BTreeMap<Bucket, HashMap<Id, Message>>>>);
 
 #[derive(Debug)]
 struct Message {
+    /// The message bytes to (re-)send.
     data: Bytes,
+    /// The time we started sending this message.
     time: Instant,
+    /// The number of times we have sent this message.
     retries: usize,
+    /// The remaining number of parties that have to acknowledge the message.
     remaining: Vec<PublicKey>,
 }
 
@@ -61,37 +93,43 @@ impl Overlay {
             sender: net.sender(),
             net,
             buffer,
-            id: SeqId(0),
+            id: Id(0),
             retry,
         }
     }
 
-    pub async fn broadcast(&mut self, data: Data) -> Result<SeqId> {
-        self.send(None, data).await
+    pub async fn broadcast<B>(&mut self, b: B, data: Data) -> Result<()>
+    where
+        B: Into<Bucket>,
+    {
+        self.send(b.into(), None, data).await
     }
 
-    pub async fn unicast(&mut self, to: PublicKey, data: Data) -> Result<SeqId> {
-        self.send(Some(to), data).await
+    pub async fn unicast<B>(&mut self, to: PublicKey, b: B, data: Data) -> Result<()>
+    where
+        B: Into<Bucket>,
+    {
+        self.send(b.into(), Some(to), data).await
     }
 
     pub async fn receive(&mut self) -> Result<(PublicKey, Bytes)> {
         loop {
             let (src, mut bytes) = self.net.receive().await.map_err(|_| NetworkDown(()))?;
 
-            if bytes.len() < 8 {
+            if bytes.len() < 16 {
                 warn!(node = %self.this, "received unexpected message");
                 return Ok((src, bytes));
             }
 
-            let tail: [u8; 8] = bytes
-                .split_off(bytes.len() - 8)
+            let trailer: [u8; 16] = bytes
+                .split_off(bytes.len() - 16)
                 .as_ref()
                 .try_into()
                 .expect("bytes len checked above");
 
             if !bytes.is_empty() {
-                // Send the Id value back as acknowledgement:
-                let ack = Bytes::copy_from_slice(&tail);
+                // Send the trailer back as acknowledgement:
+                let ack = Bytes::copy_from_slice(&trailer);
                 self.sender
                     .send((Some(src), ack))
                     .await
@@ -99,28 +137,32 @@ impl Overlay {
                 return Ok((src, bytes));
             }
 
-            let id = SeqId(u64::from_be_bytes(tail));
+            let (b, i) = from_trailer(&trailer);
 
             let mut messages = self.buffer.0.lock();
-            if let Some(m) = messages.get_mut(&id) {
-                m.remaining.retain(|k| *k != src);
-                if m.remaining.is_empty() {
-                    messages.remove(&id);
+
+            if let Some(buckets) = messages.get_mut(&b) {
+                if let Some(m) = buckets.get_mut(&i) {
+                    m.remaining.retain(|k| *k != src);
+                    if m.remaining.is_empty() {
+                        buckets.remove(&i);
+                    }
                 }
             }
         }
     }
 
-    pub fn gc(&mut self, id: SeqId) {
-        self.buffer.0.lock().retain(|i, _| *i >= id);
+    pub fn gc<B: Into<Bucket>>(&mut self, bucket: B) {
+        let bucket = bucket.into();
+        self.buffer.0.lock().retain(|b, _| *b >= bucket);
     }
 
-    async fn send(&mut self, to: Option<PublicKey>, data: Data) -> Result<SeqId> {
-        let id = self.next_id();
+    async fn send(&mut self, b: Bucket, to: Option<PublicKey>, data: Data) -> Result<()> {
+        let i = self.next_id();
 
         let mut msg = data.0;
 
-        msg.extend_from_slice(&id.0.to_be_bytes());
+        msg.extend_from_slice(&to_trailer(b, i));
         let msg = msg.freeze();
 
         let now = Instant::now();
@@ -139,8 +181,8 @@ impl Overlay {
             self.parties.clone()
         };
 
-        self.buffer.0.lock().insert(
-            id,
+        self.buffer.0.lock().entry(b).or_default().insert(
+            i,
             Message {
                 data: msg,
                 time: now,
@@ -149,14 +191,29 @@ impl Overlay {
             },
         );
 
-        Ok(id)
+        Ok(())
     }
 
-    fn next_id(&mut self) -> SeqId {
+    fn next_id(&mut self) -> Id {
         let id = self.id;
-        self.id = SeqId(self.id.0 + 1);
+        self.id = Id(self.id.0 + 1);
         id
     }
+}
+
+/// Serialize a `Bucket` and `Id`.
+fn to_trailer(b: Bucket, i: Id) -> [u8; 16] {
+    let mut t = [0; 16];
+    t[..8].copy_from_slice(&b.0.to_be_bytes());
+    t[8..].copy_from_slice(&i.0.to_be_bytes());
+    t
+}
+
+/// Deserialize into `Bucket` and `Id`.
+fn from_trailer(t: &[u8; 16]) -> (Bucket, Id) {
+    let b = u64::from_be_bytes(t[..8].try_into().expect("8 bytes"));
+    let i = u64::from_be_bytes(t[8..].try_into().expect("8 bytes"));
+    (Bucket(b), Id(i))
 }
 
 async fn retry(buf: Buffer, net: Sender<(Option<PublicKey>, Bytes)>) -> Infallible {
@@ -165,37 +222,51 @@ async fn retry(buf: Buffer, net: Sender<(Option<PublicKey>, Bytes)>) -> Infallib
     let mut i = time::interval(Duration::from_secs(1));
     i.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
 
+    let mut buckets = Vec::new();
     let mut ids = Vec::new();
 
     loop {
         let now = i.tick().await;
 
-        debug_assert!(ids.is_empty());
-        ids.extend(buf.0.lock().keys().copied());
+        debug_assert!(buckets.is_empty());
+        buckets.extend(buf.0.lock().keys().copied());
 
-        for id in ids.drain(..) {
-            let message;
-            let remaining;
+        for b in buckets.drain(..) {
+            debug_assert!(ids.is_empty());
+            ids.extend(
+                buf.0
+                    .lock()
+                    .get(&b)
+                    .into_iter()
+                    .flat_map(|m| m.keys().copied()),
+            );
 
-            {
-                let mut buf = buf.0.lock();
-                let Some(m) = buf.get_mut(&id) else { continue };
+            for id in ids.drain(..) {
+                let message;
+                let remaining;
 
-                let delay = DELAYS.get(m.retries).copied().unwrap_or(30);
+                {
+                    let mut buf = buf.0.lock();
+                    let Some(m) = buf.get_mut(&b).and_then(|m| m.get_mut(&id)) else {
+                        continue;
+                    };
 
-                if now.saturating_duration_since(m.time) < Duration::from_secs(delay) {
-                    continue;
+                    let delay = DELAYS.get(m.retries).copied().unwrap_or(30);
+
+                    if now.saturating_duration_since(m.time) < Duration::from_secs(delay) {
+                        continue;
+                    }
+
+                    m.time = now;
+                    m.retries = m.retries.saturating_add(1);
+
+                    message = m.data.clone();
+                    remaining = m.remaining.clone();
                 }
 
-                m.time = now;
-                m.retries = m.retries.saturating_add(1);
-
-                message = m.data.clone();
-                remaining = m.remaining.clone();
-            }
-
-            for p in remaining {
-                let _ = net.send((Some(p), message.clone())).await;
+                for p in remaining {
+                    let _ = net.send((Some(p), message.clone())).await;
+                }
             }
         }
     }
@@ -228,5 +299,11 @@ impl Deref for Data {
 
     fn deref(&self) -> &Self::Target {
         self.0.as_ref()
+    }
+}
+
+impl From<u64> for Bucket {
+    fn from(val: u64) -> Self {
+        Bucket(val)
     }
 }

--- a/cliquenet/tests/frame-handling.rs
+++ b/cliquenet/tests/frame-handling.rs
@@ -66,7 +66,7 @@ fn gen_message() -> Data {
 /// until the expected message has been received by both parties.
 async fn send_recv(sender: PublicKey, net_a: &mut Overlay, net_b: &mut Overlay, data: Data) {
     'main: loop {
-        net_a.broadcast(data.clone()).await.unwrap();
+        net_a.broadcast(0, data.clone()).await.unwrap();
 
         for net in [&mut *net_a, net_b] {
             if let Ok(Ok((k, x))) = timeout(Duration::from_millis(5), net.receive()).await {

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -2,7 +2,7 @@ use bimap::BiMap;
 use bytes::{BufMut, BytesMut};
 use cliquenet::{
     Overlay,
-    overlay::{Data, DataError, NetworkDown, SeqId},
+    overlay::{Data, DataError, NetworkDown},
 };
 use multisig::PublicKey;
 use sailfish::types::RoundNumber;
@@ -278,7 +278,6 @@ struct Worker {
     dec_sk: DecryptionKey,
     cid2idx: HashMap<Nonce, usize>,
     cid2ct: BiMap<(RoundNumber, Nonce), Ciphertext>,
-    round2seqs: BTreeMap<RoundNumber, SeqId>,
     shares: Incubator,
 }
 
@@ -291,7 +290,6 @@ impl Worker {
             dec_sk,
             cid2idx: HashMap::default(),
             cid2ct: BiMap::default(),
-            round2seqs: BTreeMap::default(),
             shares: Incubator::default(),
         }
     }
@@ -395,10 +393,7 @@ impl Worker {
                                 gc_round  = %gc_round,
                                 "gc"
                             );
-                            if let Some(seqid) = self.round2seqs.get(&gc_round) {
-                                self.net.gc(*seqid);
-                            }
-                            self.round2seqs.retain(|r, _| gc_round <= *r);
+                            self.net.gc(*round);
                             hatched_rounds.retain(|r| gc_round <= *r);
                             continue;
                         }
@@ -469,11 +464,8 @@ impl Worker {
     async fn broadcast(&mut self, share_info: &ShareInfo) -> Result<()> {
         let share_bytes = serialize(share_info)?;
         self.net
-            .broadcast(share_bytes)
+            .broadcast(*share_info.round(), share_bytes)
             .await
-            .map(|seqid| {
-                self.round2seqs.entry(share_info.round()).or_insert(seqid);
-            })
             .map_err(DecryptError::net)
     }
 


### PR DESCRIPTION
Due to message reordering the use of `SeqId` for garbage collection is not correct. If for example a proposal in round `r + 1` arrived and we send back a vote, yielding an `x : SeqId` and we later send out a proposal for a round `r`, we get a `y : SeqId` with `y > x`. When garbage collecting `r` we would remove all sequence numbers up to `y` which includes `x` even though round `r + 1` is still active.

Here we change the approach and require senders to give us a bucket number (usually corresponding directly to a round number) when sending a message and also when garbage collecting.
