### PR TITLE
Use `bincode::Configuration::with_limit`.

### DIFF
--- a/cliquenet/src/lib.rs
+++ b/cliquenet/src/lib.rs
@@ -13,3 +13,6 @@ pub use error::NetworkError;
 pub use metrics::NetworkMetrics;
 pub use net::Network;
 pub use overlay::Overlay;
+
+/// Max. number of bytes for a message (potentially consisting of several frames).
+pub const MAX_MESSAGE_SIZE: usize = 5 * 1024 * 1024;

--- a/cliquenet/src/net.rs
+++ b/cliquenet/src/net.rs
@@ -24,7 +24,7 @@ use crate::error::Empty;
 use crate::frame::{Header, Type};
 use crate::tcp::{self, Stream};
 use crate::time::{Countdown, Timestamp};
-use crate::{Address, NetworkError, NetworkMetrics};
+use crate::{Address, MAX_MESSAGE_SIZE, NetworkError, NetworkMetrics};
 
 type Result<T> = std::result::Result<T, NetworkError>;
 
@@ -36,9 +36,6 @@ const MAX_NOISE_MESSAGE_SIZE: usize = 64 * 1024;
 
 /// Max. number of bytes for payload data.
 const MAX_PAYLOAD_SIZE: usize = 63 * 1024;
-
-/// Max. number of bytes for a message (potentially consisting of several frames).
-pub(crate) const MAX_TOTAL_SIZE: usize = 5 * 1024 * 1024;
 
 /// Max. number of messages to queue for a peer.
 const PEER_CAPACITY: usize = 256;
@@ -290,13 +287,9 @@ impl Network {
         self.parties.iter()
     }
 
-    pub fn max_message_size(&self) -> usize {
-        MAX_TOTAL_SIZE
-    }
-
     /// Send a message to a party, identified by the given public key.
     pub async fn unicast(&self, to: PublicKey, msg: Bytes) -> Result<()> {
-        if msg.len() > MAX_TOTAL_SIZE {
+        if msg.len() > MAX_MESSAGE_SIZE {
             warn!(node = %self.label, %to, len = %msg.len(), "message too large to send");
             return Err(NetworkError::MessageTooLarge);
         }
@@ -308,7 +301,7 @@ impl Network {
 
     /// Send a message to all parties.
     pub async fn multicast(&self, msg: Bytes) -> Result<()> {
-        if msg.len() > MAX_TOTAL_SIZE {
+        if msg.len() > MAX_MESSAGE_SIZE {
             warn!(node = %self.label, len = %msg.len(), "message too large to broadcast");
             return Err(NetworkError::MessageTooLarge);
         }
@@ -826,7 +819,7 @@ where
                                     if !h.is_partial() {
                                         break;
                                     }
-                                    if msg.len() > MAX_TOTAL_SIZE {
+                                    if msg.len() > MAX_MESSAGE_SIZE {
                                         return Err(NetworkError::MessageTooLarge);
                                     }
                                 }

--- a/cliquenet/src/overlay.rs
+++ b/cliquenet/src/overlay.rs
@@ -216,7 +216,7 @@ impl TryFrom<BytesMut> for Data {
     type Error = DataError;
 
     fn try_from(val: BytesMut) -> std::result::Result<Self, Self::Error> {
-        if val.len() > crate::net::MAX_TOTAL_SIZE {
+        if val.len() > crate::MAX_MESSAGE_SIZE {
             return Err(DataError::MaxSize);
         }
         Ok(Self(val))

--- a/sailfish-rbc/src/abraham/worker.rs
+++ b/sailfish-rbc/src/abraham/worker.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use bytes::Bytes;
 use cliquenet::{
     Overlay,
+    MAX_MESSAGE_SIZE,
     overlay::{Data, NetworkDown, SeqId},
 };
 use committable::{Commitment, Committable};
@@ -290,7 +291,8 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
     /// We received a message from the network.
     async fn on_inbound(&mut self, src: PublicKey, bytes: Bytes) -> RbcResult<()> {
         trace!(node = %self.key, %src, buf = %self.buffer.len(), "inbound message");
-        match bincode::serde::decode_from_slice(&bytes, bincode::config::standard())?.0 {
+        let conf = bincode::config::standard().with_limit::<MAX_MESSAGE_SIZE>();
+        match bincode::serde::decode_from_slice(&bytes, conf)?.0 {
             Protocol::Send(msg) => self.on_message(src, msg.into_owned()).await?,
             Protocol::Propose(msg) => self.on_propose(src, msg.into_owned()).await?,
             Protocol::Vote(env, evi) => self.on_vote(src, env, evi).await?,

--- a/sailfish-types/src/message.rs
+++ b/sailfish-types/src/message.rs
@@ -462,26 +462,6 @@ impl NoVoteMessage {
     }
 }
 
-impl<'a, T: Committable + Deserialize<'a>> Message<T, Unchecked> {
-    pub fn decode(bytes: &'a [u8]) -> Option<Self> {
-        bincode::serde::borrow_decode_from_slice(bytes, bincode::config::standard())
-            .ok()
-            .map(|(msg, _)| msg)
-    }
-}
-
-impl<T: Committable + Serialize, S: Serialize> Message<T, S> {
-    pub fn encode(&self, buf: &mut Vec<u8>) {
-        bincode::serde::encode_into_std_write(self, buf, bincode::config::standard())
-            .expect("serializing a `Message` never fails");
-    }
-
-    pub fn to_vec(&self) -> Vec<u8> {
-        bincode::serde::encode_to_vec(self, bincode::config::standard())
-            .expect("serializing a `Message` never fails")
-    }
-}
-
 impl<T: Committable, S> fmt::Display for Message<T, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -8,7 +8,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use cliquenet as net;
-use cliquenet::{Network, NetworkError, NetworkMetrics, Overlay};
+use cliquenet::{MAX_MESSAGE_SIZE, Network, NetworkError, NetworkMetrics, Overlay};
 use metrics::SequencerMetrics;
 use multisig::{Committee, Keypair, PublicKey};
 use sailfish::Coordinator;
@@ -172,7 +172,7 @@ impl Sequencer {
         .await?;
 
         // Limit max. size of candidate list. Leave margin of 128 KiB for overhead.
-        queue.set_max_data_len(network.max_message_size() - 128 * 1024);
+        queue.set_max_data_len(cliquenet::MAX_MESSAGE_SIZE - 128 * 1024);
 
         let decrypter = Decrypter::new(
             cfg.keypair.public_key(),
@@ -317,7 +317,7 @@ impl Task {
                 match action {
                     Action::Deliver(payload) => {
                         round = payload.round();
-                        match CandidateList::try_from(payload.data().as_ref()) {
+                        match payload.data().decode::<MAX_MESSAGE_SIZE>() {
                             Ok(data) => lists.push(data),
                             Err(err) => {
                                 warn!(

--- a/timeboost-types/src/candidate_list.rs
+++ b/timeboost-types/src/candidate_list.rs
@@ -145,12 +145,11 @@ impl TryFrom<CandidateList> for CandidateListBytes {
     }
 }
 
-impl TryFrom<&[u8]> for CandidateList {
-    type Error = bincode::error::DecodeError;
-
-    fn try_from(val: &[u8]) -> Result<Self, Self::Error> {
-        let (this, _) = bincode::serde::decode_from_slice(val, bincode::config::standard())?;
-        Ok(this)
+impl CandidateListBytes {
+    pub fn decode<const N: usize>(&self) -> Result<CandidateList, bincode::error::DecodeError> {
+        let config = bincode::config::standard().with_limit::<N>();
+        let (list, _) = bincode::serde::decode_from_slice(&self.0, config)?;
+        Ok(list)
     }
 }
 

--- a/timeboost/src/binaries/keygen.rs
+++ b/timeboost/src/binaries/keygen.rs
@@ -45,14 +45,14 @@ impl Scheme {
             Self::Decryption => {
                 let (pub_key, comb_key, key_shares) = DecryptionScheme::trusted_keygen(num);
                 debug!("generating new threshold encryption keyset");
-                let pub_key = bs58_encode(&pub_key.as_bytes());
-                let comb_key = bs58_encode(&comb_key.as_bytes());
+                let pub_key = bs58_encode(&pub_key.to_bytes());
+                let comb_key = bs58_encode(&comb_key.to_bytes());
 
                 for index in 0..num.into() {
                     let key_share = key_shares
                         .get(index)
                         .expect("key share should exist in generated material");
-                    let key_share = bs58_encode(&key_share.as_bytes());
+                    let key_share = bs58_encode(&key_share.to_bytes());
                     let path = out.join(format!("{index}.env"));
                     let mut env_file = File::options().append(true).create(true).open(&path)?;
                     writeln!(env_file, "TIMEBOOST_PRIVATE_DECRYPTION_KEY={}", key_share)?;

--- a/timeboost/src/keyset.rs
+++ b/timeboost/src/keyset.rs
@@ -46,9 +46,9 @@ impl KeysetConfig {
     }
 
     pub fn build_decryption_material(&self, deckey: KeyShare) -> Result<DecryptionKey> {
-        let pubkey = PublicKey::try_from(self.dec_keyset.pubkey.as_str())
+        let pubkey = PublicKey::try_from_str::<8192>(self.dec_keyset.pubkey.as_str())
             .context("Failed to parse public key from keyset")?;
-        let combkey = CombKey::try_from(self.dec_keyset.combkey.as_str())
+        let combkey = CombKey::try_from_str::<8192>(self.dec_keyset.combkey.as_str())
             .context("Failed to parse combination key from keyset")?;
         Ok(DecryptionKey::new(pubkey, combkey, deckey))
     }
@@ -84,10 +84,10 @@ pub fn private_keys(
         let bytes = &bs58::decode(dec_key)
             .into_vec()
             .context("unable to decode bs58")?;
-        let dec_key: KeyShare =
-            bincode::serde::decode_from_slice(bytes, bincode::config::standard())
-                .map(|(val, _)| val)
-                .expect("unable to read bytes into keyshare");
+        let config = bincode::config::standard().with_limit::<8192>();
+        let dec_key: KeyShare = bincode::serde::decode_from_slice(bytes, config)
+            .map(|(val, _)| val)
+            .expect("unable to read bytes into keyshare");
 
         Ok((sig_key, dec_key))
     } else {


### PR DESCRIPTION
Otherwise malformed input can cause it to allocate too much, e.g. something like this:

```rust
let input = [253, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
let _ = bincode::decode_from_slice::<Vec<u8>, _>(&input, bincode::config::standard());
```

will result in a panic ("capacity overflow").