### PR TITLE
Block production init

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ opt-level = 3
 aes-gcm = { version = "0.10.3" }
 alloy-chains = "0.2.0"
 alloy-consensus = { version = "0.14.0", features = ["arbitrary", "k256"] }
+alloy-eips = { version = "0.14.0" }
 alloy-primitives = { version = "1.0.0", features = ["serde", "rlp"] }
 alloy-rlp = { version = "0.3.11", features = ["derive"] }
 alloy-signer = "0.14.0"

--- a/cliquenet/src/lib.rs
+++ b/cliquenet/src/lib.rs
@@ -12,6 +12,7 @@ pub use addr::{Address, InvalidAddress};
 pub use error::NetworkError;
 pub use metrics::NetworkMetrics;
 pub use net::Network;
+pub use net::PEER_CAPACITY;
 pub use overlay::Overlay;
 
 /// Max. number of bytes for a message (potentially consisting of several frames).

--- a/cliquenet/src/lib.rs
+++ b/cliquenet/src/lib.rs
@@ -12,8 +12,10 @@ pub use addr::{Address, InvalidAddress};
 pub use error::NetworkError;
 pub use metrics::NetworkMetrics;
 pub use net::Network;
-pub use net::PEER_CAPACITY;
 pub use overlay::Overlay;
 
 /// Max. number of bytes for a message (potentially consisting of several frames).
 pub const MAX_MESSAGE_SIZE: usize = 5 * 1024 * 1024;
+
+/// Max. number of messages to queue for a peer.
+pub const PEER_CAPACITY: usize = 256;

--- a/cliquenet/src/net.rs
+++ b/cliquenet/src/net.rs
@@ -24,7 +24,7 @@ use crate::error::Empty;
 use crate::frame::{Header, Type};
 use crate::tcp::{self, Stream};
 use crate::time::{Countdown, Timestamp};
-use crate::{Address, MAX_MESSAGE_SIZE, NetworkError, NetworkMetrics};
+use crate::{Address, MAX_MESSAGE_SIZE, NetworkError, NetworkMetrics, PEER_CAPACITY};
 
 type Result<T> = std::result::Result<T, NetworkError>;
 
@@ -36,9 +36,6 @@ const MAX_NOISE_MESSAGE_SIZE: usize = 64 * 1024;
 
 /// Max. number of bytes for payload data.
 const MAX_PAYLOAD_SIZE: usize = 63 * 1024;
-
-/// Max. number of messages to queue for a peer.
-pub const PEER_CAPACITY: usize = 256;
 
 /// Noise parameters to initialize the builders.
 const NOISE_PARAMS: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";

--- a/cliquenet/src/net.rs
+++ b/cliquenet/src/net.rs
@@ -38,7 +38,7 @@ const MAX_NOISE_MESSAGE_SIZE: usize = 64 * 1024;
 const MAX_PAYLOAD_SIZE: usize = 63 * 1024;
 
 /// Max. number of messages to queue for a peer.
-const PEER_CAPACITY: usize = 256;
+pub const PEER_CAPACITY: usize = 256;
 
 /// Noise parameters to initialize the builders.
 const NOISE_PARAMS: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";

--- a/multisig/src/envelope.rs
+++ b/multisig/src/envelope.rs
@@ -71,6 +71,15 @@ impl<D: Committable, S> Envelope<D, S> {
     }
 }
 
+impl<D: Committable> From<Envelope<D, Validated>> for Envelope<D, Unchecked> {
+    fn from(value: Envelope<D, Validated>) -> Self {
+        Envelope {
+            signed: value.signed,
+            _marker: PhantomData,
+        }
+    }
+}
+
 impl<D: Committable, S> Deref for Envelope<D, S> {
     type Target = Signed<D>;
 

--- a/multisig/src/envelope.rs
+++ b/multisig/src/envelope.rs
@@ -71,15 +71,6 @@ impl<D: Committable, S> Envelope<D, S> {
     }
 }
 
-impl<D: Committable> From<Envelope<D, Validated>> for Envelope<D, Unchecked> {
-    fn from(value: Envelope<D, Validated>) -> Self {
-        Envelope {
-            signed: value.signed,
-            _marker: PhantomData,
-        }
-    }
-}
-
 impl<D: Committable, S> Deref for Envelope<D, S> {
     type Target = Signed<D>;
 

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -15,12 +15,12 @@ use tokio::sync::mpsc::{Receiver, Sender, channel};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, trace, warn};
 
+use crate::MAX_SIZE;
+
 type Result<T> = std::result::Result<T, DecryptError>;
 type StateDiff = BTreeMap<RoundNumber, (Vec<usize>, Vec<usize>)>;
 type DecShare = <DecryptionScheme as ThresholdEncScheme>::DecShare;
 type Ciphertext = <DecryptionScheme as ThresholdEncScheme>::Ciphertext;
-
-const MAX_ROUNDS: usize = 100;
 
 /// Status of the inclusion list
 enum Status {
@@ -71,8 +71,8 @@ impl Decrypter {
         ibound: Receiver<(PublicKey, ShareInfo)>,
         obound: Sender<MultiplexMessage>,
     ) -> Self {
-        let (enc_tx, enc_rx) = channel(MAX_ROUNDS);
-        let (dec_tx, dec_rx) = channel(MAX_ROUNDS);
+        let (enc_tx, enc_rx) = channel(MAX_SIZE);
+        let (dec_tx, dec_rx) = channel(MAX_SIZE);
         let decrypter = Worker::new(label, committee, dec_sk);
 
         Self {

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -23,7 +23,6 @@ type Ciphertext = <DecryptionScheme as ThresholdEncScheme>::Ciphertext;
 const MAX_ROUNDS: usize = 100;
 
 /// Status of the inclusion list
-#[derive(Clone)]
 enum Status {
     Encrypted(InclusionList),
     Decrypted(InclusionList),

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -92,6 +92,7 @@ impl Decrypter {
     }
 
     pub async fn gc(&mut self, _r: RoundNumber) -> Result<()> {
+        // TODO: Implement gc when interface stabilizes.
         Ok(())
     }
 

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -744,18 +744,19 @@ mod tests {
             )
             .await
             .expect("starting network");
-
-            let (dec_rx, _block_rx, multiplexer) = Multiplex::go(
+            let multiplex = Multiplex::new(
                 sig_key.public_key(),
                 committee.clone(),
                 Overlay::new(network),
             );
+            let tx = multiplex.tx();
+            let (dec_rx, _block_rx) = multiplex.go();
             let decrypter = Decrypter::new(
                 sig_key.public_key(),
                 keyset.clone(),
                 decryption_keys[i].clone(),
                 dec_rx,
-                multiplexer.tx.clone(),
+                tx,
             );
             decrypters.push(decrypter);
         }

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -332,7 +332,6 @@ impl Worker {
                         if let Err(e) = self.insert_shares(s) {
                             warn!("failed to insert shares from remote: {:?}", e);
                         }
-
                     },
                     None => {
                         debug!(node = %self.label, "multiplexer shutdown detected");
@@ -354,7 +353,7 @@ impl Worker {
                         match self.decrypt(round, enc_data).await {
                             Ok(s) => {
                                 if let Err(e) = obound.send(MultiplexMessage::Decrypt(s.clone())).await {
-                                    error!("failed write decrypted message to multiplexer: {:?}", e);
+                                    warn!("failed write decrypted message to multiplexer: {:?}", e);
                                     continue;
                                 }
                                 if let Err(e) = self.insert_shares(s) {
@@ -400,10 +399,10 @@ impl Worker {
                         debug!(node = %self.label, round  = %r, "missing ciphertext for cid: {:?}", cid);
                     }
                     DecryptError::MissingIndex(cid) => {
-                        debug!(node = %self.label, round  = %r, "missing index mapping for cid: {:?}", cid);
+                        warn!(node = %self.label, round  = %r, "missing index mapping for cid: {:?}", cid);
                     }
                     _ => {
-                        debug!(node = %self.label, round  = %r, "failed to decrypt shares for round {}: {:?}", r, e);
+                        warn!(node = %self.label, round  = %r, "failed to decrypt shares for round {}: {:?}", r, e);
                     }
                 },
                 _ => {}

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -35,6 +35,8 @@ use sort::Sorter;
 type Result<T> = std::result::Result<T, TimeboostError>;
 type Candidates = VecDeque<(RoundNumber, Vec<CandidateList>)>;
 
+const MAX_SIZE: usize = 100;
+
 #[derive(Debug)]
 pub struct SequencerConfig {
     priority_addr: Address,

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -205,7 +205,7 @@ impl Sequencer {
             keyset,
             cfg.dec_sk,
             dec_rx,
-            multiplex.tx().clone(),
+            multiplex.dec_tx().clone(),
         );
 
         let (tx, rx) = mpsc::channel(1024);
@@ -217,7 +217,12 @@ impl Sequencer {
             includer: Includer::new(committee.clone(), cfg.index),
             decrypter,
             sorter: Sorter::new(),
-            producer: BlockProducer::new(cfg.keypair, committee, block_rx, multiplex.tx().clone()),
+            producer: BlockProducer::new(
+                cfg.keypair,
+                committee,
+                block_rx,
+                multiplex.block_tx().clone(),
+            ),
             multiplex,
             output: tx,
             mode: Mode::Passive,

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -389,9 +389,15 @@ impl Task {
                 candidates.push((round, lists))
             }
             while let Some(action) = actions.pop_front() {
-                if let Action::Deliver(_) = action {
-                    actions.push_front(action);
-                    break;
+                match action {
+                    Action::Deliver(_) => {
+                        actions.push_front(action);
+                        break;
+                    }
+                    Action::Gc(r) => {
+                        self.multiplex.decrypt_gc(r).await;
+                    }
+                    _ => {}
                 }
                 if let Err(err) = self.sailfish.execute(action).await {
                     error!(node = %self.label, %err, "coordinator error");

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -35,6 +35,8 @@ use sort::Sorter;
 type Result<T> = std::result::Result<T, TimeboostError>;
 type Candidates = VecDeque<(RoundNumber, Vec<CandidateList>)>;
 
+/// Channel capacity between the Decrypter/Producer and Worker.
+/// Effectively, the length of the leash between Sailfish and Timeboost.
 const MAX_SIZE: usize = 100;
 
 #[derive(Debug)]

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -387,12 +387,9 @@ impl Task {
                 candidates.push((round, lists))
             }
             while let Some(action) = actions.pop_front() {
-                match action {
-                    Action::Deliver(_) => {
-                        actions.push_front(action);
-                        break;
-                    }
-                    _ => {}
+                if let Action::Deliver(_) = action {
+                    actions.push_front(action);
+                    break;
                 }
                 if let Err(err) = self.sailfish.execute(action).await {
                     error!(node = %self.label, %err, "coordinator error");

--- a/timeboost-sequencer/src/multiplex.rs
+++ b/timeboost-sequencer/src/multiplex.rs
@@ -1,116 +1,223 @@
 use bytes::{BufMut, BytesMut};
 use cliquenet::{
     Overlay, PEER_CAPACITY,
-    overlay::{Data, DataError},
+    overlay::{Bucket, Data, DataError},
 };
-use multisig::{Committee, Envelope, PublicKey, Unchecked};
-use serde::Serialize;
-use timeboost_types::{BlockHash, MultiplexMessage, ShareInfo};
-use tokio::sync::mpsc::{self, Receiver};
-use tracing::{debug, error};
+use multisig::{Committee, PublicKey};
+use sailfish::types::RoundNumber;
+use serde::{Deserialize, Serialize};
+use timeboost_types::{BlockInfo, BlockNumber, ShareInfo};
+use tokio::{
+    sync::mpsc::{self, Receiver, Sender},
+    task::JoinHandle,
+};
+use tracing::{debug, error, trace, warn};
+
+use crate::MAX_SIZE;
 
 type Result<T> = std::result::Result<T, MultiplexError>;
 type DecryptReceiver = Receiver<(PublicKey, ShareInfo)>;
-type BlockReceiver = Receiver<(PublicKey, Envelope<BlockHash, Unchecked>)>;
+type BlockReceiver = Receiver<(PublicKey, BlockInfo)>;
 
-#[derive(Debug)]
-pub struct Multiplex {
-    /// Public key of the node.
-    label: PublicKey,
-    /// Committee of the node.
-    committee: Committee,
-    /// Overlay network.
-    net: Overlay,
-    /// Sender for outbound messages to be multiplexed.
-    tx: mpsc::Sender<MultiplexMessage>,
-    /// Receiver for outbound messages to be multiplexed.
-    rx: mpsc::Receiver<MultiplexMessage>,
-}
+struct BlockBucket(u64);
 
-impl Multiplex {
-    pub fn new(label: PublicKey, committee: Committee, net: Overlay) -> Self {
-        // Channel for multiplexed messages to/from the overlay network.
-        let (obound_tx, obound_rx) = mpsc::channel(committee.size().get() * PEER_CAPACITY);
-        Self {
-            label,
-            committee,
-            net,
-            tx: obound_tx,
-            rx: obound_rx,
-        }
+impl From<u64> for BlockBucket {
+    fn from(value: u64) -> Self {
+        let mut bucket = value;
+        bucket ^= 1 << 63;
+        Self(bucket)
     }
 }
 
+impl From<BlockBucket> for Bucket {
+    fn from(bucket: BlockBucket) -> Self {
+        bucket.0.into()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum MultiplexMessage {
+    Decrypt(ShareInfo),
+    Block(BlockInfo),
+}
+
+#[derive(Debug)]
+pub struct Multiplex {
+    /// Label of the node.
+    label: PublicKey,
+    /// Sender to the multiplexer.
+    tx: Sender<MultiplexMessage>,
+    /// Sender to signal for gc.
+    gc_tx: Sender<Bucket>,
+    /// Join handle for worker.
+    jh: JoinHandle<()>,
+}
+
 impl Multiplex {
-    pub fn go(mut self) -> (DecryptReceiver, BlockReceiver) {
-        let capacity = self.committee.size().get() * PEER_CAPACITY;
+    pub fn new(
+        label: PublicKey,
+        committee: Committee,
+        net: Overlay,
+    ) -> (DecryptReceiver, BlockReceiver, Self) {
+        let capacity = committee.size().get() * PEER_CAPACITY;
+        // Channel for multiplexed messages to/from the overlay network.
+        let (tx, rx) = mpsc::channel(capacity);
         // Channel reserved for the decrypter
         let (dec_tx, dec_rx) = mpsc::channel(capacity);
         // Channel reserved for the block producer
         let (block_tx, block_rx) = mpsc::channel(capacity);
+        // Channel reserved for garbage collection signal.
+        let (gc_tx, gc_rx) = mpsc::channel(capacity);
 
-        tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    Some(message) = self.rx.recv() => {
-                        let data = match serialize(&message) {
-                            Ok(data) => data,
-                            Err(e) => {
-                                debug!(node = %self.label, "serialization error: {}", e);
-                                return;
-                            }
-                        };
-                        match self.net.broadcast(data).await {
-                            Ok(_seqid) => {
-                                // TODO: store seqids for garbage collection.
-                            }
-                            Err(e) => {
-                                debug!(node = %self.label, "network shutdown detected {}", e);
-                                return;
-                            }
-                        }
-                    }
+        let worker = Worker::new(label, net, dec_tx, block_tx, rx, gc_rx);
+        (
+            dec_rx,
+            block_rx,
+            Self {
+                label,
+                tx,
+                gc_tx,
+                jh: tokio::spawn(worker.go()),
+            },
+        )
+    }
 
-                    Ok((public_key, bytes)) = self.net.receive() => {
-                        if public_key == self.label {
+    pub fn tx(&self) -> &Sender<MultiplexMessage> {
+        &self.tx
+    }
+
+    pub async fn decrypt_gc(&mut self, round: RoundNumber) {
+        let bucket = Bucket::from(*round);
+        let gc_round: RoundNumber = round.saturating_sub(MAX_SIZE as u64).into();
+        if RoundNumber::genesis() < gc_round {
+            trace!(
+                node      = %self.label,
+                gc_round  = %gc_round,
+                "decrypt-gc"
+            );
+            if let Err(e) = self.gc_tx.send(bucket).await {
+                error!("failed to send gc signal: {}", e);
+            }
+        }
+    }
+
+    pub async fn block_gc(&mut self, block_num: BlockNumber) {
+        let bucket = BlockBucket::from(*block_num);
+        trace!(
+            node   = %self.label,
+            block  = %block_num,
+            bucket = %bucket.0,
+            "block-gc"
+        );
+        if let Err(e) = self.gc_tx.send(bucket.into()).await {
+            error!("failed to send gc signal: {}", e);
+        }
+    }
+}
+
+impl Drop for Multiplex {
+    fn drop(&mut self) {
+        self.jh.abort()
+    }
+}
+
+struct Worker {
+    /// Public key of the node.
+    label: PublicKey,
+    /// Overlay network.
+    net: Overlay,
+    /// Sender to decrypter.
+    dec_tx: Sender<(PublicKey, ShareInfo)>,
+    /// Sender to block producer.
+    block_tx: Sender<(PublicKey, BlockInfo)>,
+    /// Receiver for multiplexer.
+    rx: Receiver<MultiplexMessage>,
+    /// Receiver for gc signals.
+    gc_rx: Receiver<Bucket>,
+}
+
+impl Worker {
+    pub fn new(
+        label: PublicKey,
+        net: Overlay,
+        dec_tx: Sender<(PublicKey, ShareInfo)>,
+        block_tx: Sender<(PublicKey, BlockInfo)>,
+        rx: Receiver<MultiplexMessage>,
+        gc_rx: Receiver<Bucket>,
+    ) -> Self {
+        Self {
+            label,
+            net,
+            dec_tx,
+            block_tx,
+            rx,
+            gc_rx,
+        }
+    }
+    pub async fn go(mut self) {
+        loop {
+            tokio::select! {
+                Some(message) = self.rx.recv() => {
+                    let data = match serialize(&message) {
+                        Ok(data) => data,
+                        Err(e) => {
+                            warn!(node = %self.label, "serialization error: {}", e);
                             continue;
                         }
-                        let msg = match deserialize(&bytes) {
-                            Ok(message) => message,
-                            Err(e) => {
-                                error!("failed to deserialize message: {}", e);
-                                continue;
-                            }
-                        };
+                    };
 
-                        match msg {
-                            MultiplexMessage::Decrypt(share_info) => {
-                                if let Err(e) = dec_tx.send((public_key, share_info)).await {
-                                    error!("failed to send decrypt message: {}", e);
-                                }
-                            }
-                            MultiplexMessage::Block(envelope) => {
-                                if let Err(e) = block_tx.send((public_key, envelope)).await {
-                                    error!("failed to send block message: {}", e);
-                                }
-                            }
+                    let bucket = match &message {
+                        MultiplexMessage::Decrypt(share_info) => {
+                            Bucket::from(*share_info.round())
                         }
-                    } else => {
-                        debug!(node = %self.label, "network shutdown detected");
+                        MultiplexMessage::Block(block_info) => {
+                            BlockBucket::from(*block_info.number()).into()
+                        }
+                    };
+
+                    if let Err(e) = self.net.broadcast(bucket, data).await {
+                        error!(node = %self.label, "network broadcast error: {}", e);
                         return;
                     }
                 }
+
+                Ok((public_key, bytes)) = self.net.receive() => {
+                    if public_key == self.label {
+                        continue;
+                    }
+                    let msg = match deserialize(&bytes) {
+                        Ok(message) => message,
+                        Err(e) => {
+                            warn!("failed to deserialize message: {}", e);
+                            continue;
+                        }
+                    };
+
+                    match msg {
+                        MultiplexMessage::Decrypt(share_info) => {
+                            if let Err(e) = self.dec_tx.send((public_key, share_info)).await {
+                                error!("failed to send decrypt message: {}", e);
+                                return;
+                            }
+                        }
+                        MultiplexMessage::Block(envelope) => {
+                            if let Err(e) = self.block_tx.send((public_key, envelope)).await {
+                                error!("failed to send block message: {}", e);
+                                return;
+                            }
+                        }
+                    }
+                }
+                Some(bucket) = self.gc_rx.recv() => {
+                    trace!(node = %self.label, "received gc signal for bucket: {:?}", bucket);
+                    self.net.gc(bucket);
+                }
+                else => {
+                    debug!(node = %self.label, "network shutdown detected");
+                    return;
+                }
             }
-        });
-        (dec_rx, block_rx)
-    }
-
-    pub fn tx(&self) -> mpsc::Sender<MultiplexMessage> {
-        self.tx.clone()
-    }
-
-    pub fn _gc(&mut self) {
-        // TODO: garbage collect when interface stabilizes.
+        }
     }
 }
 

--- a/timeboost-sequencer/src/multiplex.rs
+++ b/timeboost-sequencer/src/multiplex.rs
@@ -1,0 +1,114 @@
+use bytes::{BufMut, BytesMut};
+use cliquenet::{
+    Overlay, PEER_CAPACITY,
+    overlay::{Data, DataError},
+};
+use multisig::{Committee, Envelope, PublicKey, Unchecked};
+use serde::Serialize;
+use timeboost_types::{BlockHash, MultiplexMessage, ShareInfo};
+use tokio::sync::mpsc::{self, Receiver};
+use tracing::{debug, error};
+
+type Result<T> = std::result::Result<T, MultiplexError>;
+type DecryptReceiver = Receiver<(PublicKey, ShareInfo)>;
+type BlockReceiver = Receiver<(PublicKey, Envelope<BlockHash, Unchecked>)>;
+
+#[derive(Debug)]
+pub struct Multiplex {
+    /// Sender for outbound messages to be multiplexed.
+    pub tx: mpsc::Sender<MultiplexMessage>,
+}
+
+impl Multiplex {
+    pub fn go(
+        label: PublicKey,
+        committee: Committee,
+        mut net: Overlay,
+    ) -> (DecryptReceiver, BlockReceiver, Self) {
+        let channel_size = committee.size().get() * PEER_CAPACITY;
+        // Channel for multiplexed messages to/from the overlay network.
+        let (obound_tx, mut obound_rx) = mpsc::channel(channel_size);
+        // Channel reserved for the decrypter
+        let (dec_tx, dec_rx) = mpsc::channel(channel_size);
+        // Channel reserved for the block producer
+        let (block_tx, block_rx) = mpsc::channel(channel_size);
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    Some(message) = obound_rx.recv() => {
+                        match serialize(&message) {
+                            Ok(data) => {
+                                if let Err(e) = net.broadcast(data).await {
+                                    debug!(node = %label, "network shutdown detected {}", e);
+                                    return;
+                                }
+                            }
+                            Err(e) => {
+                                error!("failed to serialize message: {}", e);
+                            }
+                        }
+                    }
+
+                    Ok((public_key, bytes)) = net.receive() => {
+                        if public_key == label {
+                            continue;
+                        }
+                        let msg = match deserialize(&bytes) {
+                            Ok(message) => message,
+                            Err(e) => {
+                                error!("failed to deserialize message: {}", e);
+                                continue;
+                            }
+                        };
+
+                        match msg {
+                            MultiplexMessage::Decrypt(share_info) => {
+                                if let Err(e) = dec_tx.send((public_key, share_info)).await {
+                                    error!("failed to send decrypt message: {}", e);
+                                }
+                            }
+                            MultiplexMessage::Block(envelope) => {
+                                if let Err(e) = block_tx.send((public_key, envelope)).await {
+                                    error!("failed to send block message: {}", e);
+                                }
+                            }
+                        }
+                    } else => {
+                        debug!(node = %label, "network shutdown detected");
+                        return;
+                    }
+                }
+            }
+        });
+
+        (dec_rx, block_rx, Self { tx: obound_tx })
+    }
+}
+
+/// Serialize a given data type into `Bytes`
+fn serialize<T: Serialize>(d: &T) -> Result<Data> {
+    let mut b = BytesMut::new().writer();
+    bincode::serde::encode_into_std_write(d, &mut b, bincode::config::standard())?;
+    Ok(b.into_inner().try_into()?)
+}
+
+/// Deserialize from `Bytes` into a given data type.
+fn deserialize<T: for<'de> serde::Deserialize<'de>>(d: &bytes::Bytes) -> Result<T> {
+    bincode::serde::decode_from_slice(d, bincode::config::standard())
+        .map(|(msg, _)| msg)
+        .map_err(Into::into)
+}
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum MultiplexError {
+    #[error("bincode encode error: {0}")]
+    BincodeEncode(#[from] bincode::error::EncodeError),
+
+    #[error("bincode decode error: {0}")]
+    BincodeDecode(#[from] bincode::error::DecodeError),
+
+    #[error("data error: {0}")]
+    DataError(#[from] DataError),
+}

--- a/timeboost-sequencer/src/multiplex.rs
+++ b/timeboost-sequencer/src/multiplex.rs
@@ -110,7 +110,7 @@ impl Multiplex {
     }
 
     pub fn _gc(&mut self) {
-        // TODO: garbage collect when interface stabilize.
+        // TODO: garbage collect when interface stabilizes.
     }
 }
 

--- a/timeboost-sequencer/src/multiplex.rs
+++ b/timeboost-sequencer/src/multiplex.rs
@@ -22,7 +22,7 @@ struct BlockBucket(u64);
 
 impl From<u64> for BlockBucket {
     fn from(value: u64) -> Self {
-        Self(value ^ (1 << 63))
+        Self(value | (1 << 63))
     }
 }
 

--- a/timeboost-sequencer/src/produce.rs
+++ b/timeboost-sequencer/src/produce.rs
@@ -1,27 +1,33 @@
 use multisig::{
-    Certificate, Committee, Envelope, Keypair, PublicKey, Signed, Unchecked, VoteAccumulator,
+    Certificate, Committee, Envelope, Keypair, PublicKey, Unchecked, Validated, VoteAccumulator,
 };
-use std::collections::VecDeque;
-use timeboost_types::{Block, BlockHash, MultiplexMessage, Timestamp, Transaction};
+use std::collections::{BTreeMap, VecDeque};
+use timeboost_types::{Block, BlockHash, BlockNumber, MultiplexMessage, Timestamp, Transaction};
 use tokio::spawn;
 use tokio::sync::mpsc::{Receiver, Sender, channel};
 use tokio::task::JoinHandle;
-use tracing::error;
+use tracing::{debug, error, trace};
 
 type Result<T> = std::result::Result<T, ProducerError>;
 
-struct WorkerRequest(usize, BlockHash);
+#[derive(Clone)]
+enum Status {
+    Uncertified(Block),
+    Certified(Certificate<BlockHash>, Block),
+}
+struct WorkerRequest(BlockNumber, BlockHash);
 
-struct WorkerResponse(Certificate<BlockHash>);
+struct WorkerResponse(BlockNumber, Certificate<BlockHash>);
 
 pub struct BlockProducer {
     /// Keypair of the node.
     label: Keypair,
     /// Incoming transactions
-    committee: Committee,
     queue: VecDeque<(Timestamp, Transaction)>,
-    /// Block count
-    count: usize,
+    /// Last block produced.
+    parent: Option<(BlockNumber, BlockHash)>,
+    /// block lists.
+    blocks: BTreeMap<(BlockNumber, BlockHash), Status>,
     /// Send worker request.
     block_tx: Sender<WorkerRequest>,
     /// Receive worker response
@@ -37,15 +43,15 @@ impl BlockProducer {
         rx: Receiver<(PublicKey, Envelope<BlockHash, Unchecked>)>,
         tx: Sender<MultiplexMessage>,
     ) -> Self {
-        let (block_tx, block_rx) = channel(100);
-        let (cert_tx, cert_rx) = channel(100);
+        let (block_tx, block_rx) = channel(1000);
+        let (cert_tx, cert_rx) = channel(1000);
         let certifier = Worker::new(label.clone(), committee.clone());
 
         Self {
             label,
-            count: 0,
-            committee,
             queue: VecDeque::new(),
+            parent: None,
+            blocks: BTreeMap::new(),
             block_tx,
             cert_rx,
             jh: spawn(certifier.go(block_rx, cert_tx, rx, tx)),
@@ -55,46 +61,82 @@ impl BlockProducer {
     pub async fn enqueue(&mut self, tx: (Timestamp, Transaction)) -> Result<()> {
         self.queue.push_back(tx);
 
+        // TODO: produce blocks deterministically according to specification.
+        // Useful links:
+        // https://github.com/OffchainLabs/nitro/blob/66acaf2ce12de4c55290fad85083f31b14cec3cf/execution/gethexec/sequencer.go#L1001
+        // https://github.com/OffchainLabs/nitro/blob/66acaf2ce12de4c55290fad85083f31b14cec3cf/arbos/block_processor.go#L164
         if self.queue.len() >= 10 {
-            let mut block_transactions = Vec::new();
+            let mut txs = Vec::new();
             for _ in 0..10 {
                 if let Some(transaction) = self.queue.pop_front() {
-                    block_transactions.push(transaction);
+                    txs.push(transaction);
                 }
             }
-
-            // TODO: use the real transactions and wrap them in a block
-            let block = Block::default();
-            let block_header = block.header.clone();
-            let block_hash = *block_header.hash_slow();
-            self.count += 1;
+            let (num, block) = if let Some((num, parent)) = self.parent {
+                let block = Block::new(parent, txs.into_iter().map(|(_, t)| t).collect());
+                (num + 1, block)
+            } else {
+                let block = Block::new(
+                    BlockHash::default(),
+                    txs.into_iter().map(|(_, t)| t).collect(),
+                );
+                (BlockNumber::genesis(), block)
+            };
+            let hash = BlockHash::from(*(block.hash_slow()));
+            self.blocks
+                .insert((num, hash), Status::Uncertified(block.clone()));
             self.block_tx
-                .send(WorkerRequest(self.count, block_hash.into()))
+                .send(WorkerRequest(num, hash))
                 .await
                 .map_err(|_| ProducerError::General)?;
+            self.parent = Some((num, hash));
+
+            trace!(
+                node  = %self.label.public_key(),
+                num   = %num,
+                block = ?hash,
+                "certifying"
+            );
         }
 
         Ok(())
     }
 
     pub async fn next(&mut self) -> Result<(Certificate<BlockHash>, Block)> {
-        // TODO: cheating certificate for now
-        let mut acc = VoteAccumulator::new(Committee::new(
-            self.committee
-                .entries()
-                .filter(|(_, public_key)| **public_key == self.label.public_key())
-                .map(|(key_id, public_key)| (key_id, *public_key))
-                .collect::<Vec<_>>(),
-        ));
-        let block = Block::default();
-        let block_header = block.header.clone();
-        let block_hash = BlockHash::from(*block_header.hash_slow());
-        let signed = Signed::new(block_hash, &self.label, true);
-        match acc.add(signed) {
-            Ok(Some(cert)) => Ok((cert.clone(), block)),
-            Ok(None) => Err(ProducerError::General),
-            Err(_) => Err(ProducerError::General),
+        while let Some(WorkerResponse(num, cert)) = self.cert_rx.recv().await {
+            trace!(
+                node = %self.label.public_key(),
+                num  = %num,
+                hash = ?cert.data(),
+                "certified"
+            );
+            if let Some(status) = self.blocks.get_mut(&(num, *cert.data())) {
+                if let Status::Uncertified(block) = status {
+                    *status = Status::Certified(cert, block.to_owned());
+                }
+            };
+
+            if let Some(entry) = self.blocks.first_entry() {
+                match entry.get() {
+                    Status::Certified(_, _) => {
+                        let (cert, block) = match entry.remove() {
+                            Status::Certified(cert, block) => (cert, block),
+                            _ => unreachable!(),
+                        };
+                        return Ok((cert, block));
+                    }
+                    Status::Uncertified(_) => {
+                        debug!(
+                            node = %self.label.public_key(),
+                            "received certified block {} but the next block num is {}",
+                            num,
+                            entry.key().0
+                        );
+                    }
+                }
+            }
         }
+        Err(ProducerError::General)
     }
 }
 
@@ -111,23 +153,115 @@ pub enum ProducerError {
     General,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum CertStatus {
+    Unknown,
+    Signed,
+    Certified,
+}
+
+struct Tracker {
+    votes: VoteAccumulator<BlockHash>,
+    num: Option<BlockNumber>,
+    status: CertStatus,
+}
+
 struct Worker {
     keypair: Keypair,
     committee: Committee,
+    trackers: BTreeMap<BlockHash, Tracker>,
 }
 
 impl Worker {
     pub fn new(keypair: Keypair, committee: Committee) -> Self {
-        Self { keypair, committee }
+        Self {
+            keypair,
+            committee,
+            trackers: BTreeMap::new(),
+        }
     }
 
     pub async fn go(
-        self,
-        _block_rx: Receiver<WorkerRequest>,
-        _cert_tx: Sender<WorkerResponse>,
-        _ibound: Receiver<(PublicKey, Envelope<BlockHash, Unchecked>)>,
-        _obound: Sender<MultiplexMessage>,
+        mut self,
+        mut block_rx: Receiver<WorkerRequest>,
+        cert_tx: Sender<WorkerResponse>,
+        mut ibound: Receiver<(PublicKey, Envelope<BlockHash, Unchecked>)>,
+        obound: Sender<MultiplexMessage>,
     ) {
-        todo!()
+        let label = self.keypair.public_key();
+        let mut recv_block: (Option<BlockNumber>, Envelope<BlockHash, Validated>);
+        loop {
+            tokio::select! {
+                val = ibound.recv() => match val {
+                    Some((remote, e)) => {
+                        trace!(
+                            node   = %label,
+                            vote   = ?e.data(),
+                            from   = %remote,
+                            "receive"
+                        );
+                        if let Some(e) = e.validated(&self.committee) {
+                            recv_block = (None, e);
+                        } else {
+                            continue;
+                        }
+                    }
+                    None => {
+                        debug!(node = %label, "multiplexer shutdown detected");
+                        return;
+                    }
+                },
+
+                val = block_rx.recv() => match val {
+                    Some(WorkerRequest(num, hash)) => {
+                        trace!(
+                            node = %label,
+                            hash = ?hash,
+                            "produced"
+                        );
+                        let env = Envelope::signed(hash, &self.keypair, false);
+                        recv_block = (Some(num), env.clone());
+                        obound.send(MultiplexMessage::Block(env.into())).await.ok();
+                    },
+                    None => {
+                        debug!(node = %label, "block request channel closed");
+                        return;
+                    }
+                },
+            }
+
+            let (block_num, block_hash) = recv_block;
+
+            let tracker = self
+                .trackers
+                .entry(*block_hash.data())
+                .or_insert_with(|| Tracker {
+                    votes: VoteAccumulator::new(self.committee.clone()),
+                    num: None,
+                    status: CertStatus::Unknown,
+                });
+            if let Some(num) = block_num {
+                tracker.num = Some(num);
+                tracker.status = CertStatus::Signed;
+            }
+
+            if tracker.status != CertStatus::Signed {
+                continue;
+            }
+
+            if let Ok(cert) = tracker.votes.add(block_hash.into_signed()) {
+                if let Some(cert) = cert {
+                    if let Some(num) = tracker.num {
+                        cert_tx.send(WorkerResponse(num, cert.clone())).await.ok();
+                        tracker.status = CertStatus::Certified;
+                    }
+                }
+            } else {
+                tracing::warn!(
+                    node = %label,
+                    "failed to add vote to tracker"
+                );
+            }
+        }
     }
 }

--- a/timeboost-sequencer/src/produce.rs
+++ b/timeboost-sequencer/src/produce.rs
@@ -1,0 +1,113 @@
+use multisig::{Certificate, Committee, Envelope, Keypair, PublicKey, Unchecked};
+use std::collections::VecDeque;
+use timeboost_types::{Block, BlockHash, MultiplexMessage, Timestamp, Transaction};
+use tokio::spawn;
+use tokio::sync::mpsc::{Receiver, Sender, channel};
+use tokio::task::JoinHandle;
+use tracing::error;
+
+type Result<T> = std::result::Result<T, ProducerError>;
+
+struct WorkerRequest(usize, BlockHash);
+
+struct WorkerResponse(Certificate<BlockHash>);
+
+pub struct BlockProducer {
+    /// Keypair of the node.
+    label: Keypair,
+    /// Incoming transactions
+    queue: VecDeque<(Timestamp, Transaction)>,
+    /// Block count
+    count: usize,
+    /// Send worker request.
+    block_tx: Sender<WorkerRequest>,
+    /// Receive worker response
+    cert_rx: Receiver<WorkerResponse>,
+    /// Worker task handle.
+    jh: JoinHandle<()>,
+}
+
+impl BlockProducer {
+    pub fn new(
+        label: Keypair,
+        committee: Committee,
+        rx: Receiver<(PublicKey, Envelope<BlockHash, Unchecked>)>,
+        tx: Sender<MultiplexMessage>,
+    ) -> Self {
+        let (block_tx, block_rx) = channel(100);
+        let (cert_tx, cert_rx) = channel(100);
+        let certifier = Worker::new(label.clone(), committee);
+
+        Self {
+            label,
+            count: 0,
+            queue: VecDeque::new(),
+            block_tx,
+            cert_rx,
+            jh: spawn(certifier.go(block_rx, cert_tx, rx, tx)),
+        }
+    }
+
+    pub async fn enqueue(&mut self, tx: (Timestamp, Transaction)) -> Result<()> {
+        self.queue.push_back(tx);
+
+        if self.queue.len() >= 10 {
+            let mut block_transactions = Vec::new();
+            for _ in 0..10 {
+                if let Some(transaction) = self.queue.pop_front() {
+                    block_transactions.push(transaction);
+                }
+            }
+
+            // TODO: use the real transactions and wrap them in a block
+            let block = Block::default();
+            let block_header = block.header.clone();
+            let block_hash = *block_header.hash_slow();
+            self.count += 1;
+            self.block_tx
+                .send(WorkerRequest(self.count, block_hash.into()))
+                .await
+                .map_err(|_| ProducerError::General)?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn next(&mut self) -> Result<(Certificate<BlockHash>, Block)> {
+        todo!()
+    }
+}
+
+impl Drop for BlockProducer {
+    fn drop(&mut self) {
+        self.jh.abort()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ProducerError {
+    #[error("an error occurred")]
+    General,
+}
+
+struct Worker {
+    keypair: Keypair,
+    committee: Committee,
+}
+
+impl Worker {
+    pub fn new(keypair: Keypair, committee: Committee) -> Self {
+        Self { keypair, committee }
+    }
+
+    pub async fn go(
+        self,
+        _block_rx: Receiver<WorkerRequest>,
+        _cert_tx: Sender<WorkerResponse>,
+        _ibound: Receiver<(PublicKey, Envelope<BlockHash, Unchecked>)>,
+        _obound: Sender<MultiplexMessage>,
+    ) {
+        todo!()
+    }
+}

--- a/timeboost-sequencer/src/produce.rs
+++ b/timeboost-sequencer/src/produce.rs
@@ -61,7 +61,7 @@ impl BlockProducer {
     pub async fn enqueue(&mut self, tx: (Timestamp, Transaction)) -> Result<()> {
         self.queue.push_back(tx);
 
-        // TODO: produce blocks deterministically according to specification.
+        // TODO: produce blocks deterministically according to spec.
         // Useful links:
         // https://github.com/OffchainLabs/nitro/blob/66acaf2ce12de4c55290fad85083f31b14cec3cf/execution/gethexec/sequencer.go#L1001
         // https://github.com/OffchainLabs/nitro/blob/66acaf2ce12de4c55290fad85083f31b14cec3cf/arbos/block_processor.go#L164

--- a/timeboost-sequencer/src/produce.rs
+++ b/timeboost-sequencer/src/produce.rs
@@ -8,6 +8,8 @@ use tokio::sync::mpsc::{Receiver, Sender, channel};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, trace};
 
+use crate::MAX_SIZE;
+
 type Result<T> = std::result::Result<T, ProducerError>;
 
 #[derive(Clone)]
@@ -43,8 +45,8 @@ impl BlockProducer {
         rx: Receiver<(PublicKey, Envelope<BlockHash, Unchecked>)>,
         tx: Sender<MultiplexMessage>,
     ) -> Self {
-        let (block_tx, block_rx) = channel(1000);
-        let (cert_tx, cert_rx) = channel(1000);
+        let (block_tx, block_rx) = channel(MAX_SIZE);
+        let (cert_tx, cert_rx) = channel(MAX_SIZE);
         let certifier = Worker::new(label.clone(), committee.clone());
 
         Self {

--- a/timeboost-sequencer/src/produce.rs
+++ b/timeboost-sequencer/src/produce.rs
@@ -1,7 +1,7 @@
 use bytes::{BufMut, BytesMut};
 use cliquenet::MAX_MESSAGE_SIZE;
 use cliquenet::overlay::{Data, DataError};
-use multisig::{Certificate, Committee, Envelope, Keypair, Validated, VoteAccumulator};
+use multisig::{Certificate, Committee, Envelope, Keypair, Unchecked, Validated, VoteAccumulator};
 use serde::Serialize;
 use std::collections::{BTreeMap, VecDeque};
 use timeboost_types::{
@@ -187,7 +187,7 @@ impl Worker {
             tokio::select! {
                 val = ibound.recv() => match val {
                     Some(BlockInbound{src, data}) => {
-                        let b = match deserialize::<BlockInfo>(&data) {
+                        let b = match deserialize::<BlockInfo<Unchecked>>(&data) {
                             Ok(block) => block,
                             Err(e) => {
                                 warn!("deserialization error: {}", e);
@@ -224,7 +224,7 @@ impl Worker {
                         );
                         let env = Envelope::signed(hash, &self.keypair, false);
                         recv_block = (Some(num), env.clone());
-                        let b = BlockInfo::new(num, env.into());
+                        let b = BlockInfo::new(num, env);
                         let data = match serialize(&b) {
                             Ok(data) => data,
                             Err(e) => {

--- a/timeboost-sequencer/tests/transaction-order.rs
+++ b/timeboost-sequencer/tests/transaction-order.rs
@@ -60,7 +60,7 @@ async fn transaction_order() {
                         Err(RecvError::Lagged(_)) => continue,
                         Err(err) => panic!("{err}")
                     },
-                    t = s.next_transaction() => {
+                    t = s.next_block() => {
                         debug!(node = %s.public_key(), transactions = %i);
                         i += 1;
                         tx.send(t.unwrap()).unwrap()
@@ -78,7 +78,7 @@ async fn transaction_order() {
         let first = rxs[0].recv().await.unwrap();
         for rx in &mut rxs[1..] {
             let t = rx.recv().await.unwrap();
-            assert_eq!(first.hash(), t.hash())
+            assert_eq!(first.0.commitment(), t.0.commitment())
         }
     }
 

--- a/timeboost-sequencer/tests/transaction-order.rs
+++ b/timeboost-sequencer/tests/transaction-order.rs
@@ -77,8 +77,8 @@ async fn transaction_order() {
     for _ in 0..NUM_OF_BLOCKS {
         let first = rxs[0].recv().await.unwrap();
         for rx in &mut rxs[1..] {
-            let t = rx.recv().await.unwrap();
-            assert_eq!(first.0.data(), t.0.data())
+            let b = rx.recv().await.unwrap();
+            assert_eq!(first.cert().data(), b.cert().data())
         }
     }
 

--- a/timeboost-sequencer/tests/transaction-order.rs
+++ b/timeboost-sequencer/tests/transaction-order.rs
@@ -78,7 +78,7 @@ async fn transaction_order() {
         let first = rxs[0].recv().await.unwrap();
         for rx in &mut rxs[1..] {
             let t = rx.recv().await.unwrap();
-            assert_eq!(first.0.commitment(), t.0.commitment())
+            assert_eq!(first.0.data(), t.0.data())
         }
     }
 

--- a/timeboost-sequencer/tests/transaction-order.rs
+++ b/timeboost-sequencer/tests/transaction-order.rs
@@ -44,7 +44,7 @@ async fn transaction_order() {
     // all of them. Each sequencer pushes the transaction it produced into an
     // unbounded channel which we later compare with each other.
     for c in cfg {
-        let (cert_tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::unbounded_channel();
         let mut brx = bcast.subscribe();
         tasks.spawn(async move {
             if c.is_recover() {
@@ -63,7 +63,7 @@ async fn transaction_order() {
                     b = s.next_block() => {
                         debug!(node = %s.public_key(), block = %i);
                         i += 1;
-                        cert_tx.send(b.unwrap()).unwrap()
+                        tx.send(b.unwrap()).unwrap()
                     }
                 }
             }

--- a/timeboost-types/Cargo.toml
+++ b/timeboost-types/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 [dependencies]
 alloy-consensus = { workspace = true }
 alloy-primitives = { workspace = true }
+alloy-eips = { workspace = true }
 alloy-rlp = { workspace = true }
 alloy-signer = { workspace = true }
 alloy-signer-local = { workspace = true }

--- a/timeboost-types/Cargo.toml
+++ b/timeboost-types/Cargo.toml
@@ -19,6 +19,7 @@ blake3 = { workspace = true }
 bytes = { workspace = true }
 committable = { workspace = true }
 ethereum_ssz = { workspace = true }
+multisig = { path = "../multisig" }
 sailfish-types = { path = "../sailfish-types" }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/timeboost-types/src/block.rs
+++ b/timeboost-types/src/block.rs
@@ -1,0 +1,27 @@
+use alloy_primitives::B256;
+use committable::{Commitment, Committable, RawCommitmentBuilder};
+use serde::{Deserialize, Serialize};
+
+use crate::Transaction;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Block(alloy_consensus::Block<Transaction>);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BlockHash(B256);
+
+impl std::ops::Deref for BlockHash {
+    type Target = B256;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Committable for BlockHash {
+    fn commit(&self) -> Commitment<Self> {
+        RawCommitmentBuilder::new("BlockHash")
+            .fixed_size_field("block-hash", &self.0)
+            .finalize()
+    }
+}

--- a/timeboost-types/src/block.rs
+++ b/timeboost-types/src/block.rs
@@ -4,7 +4,7 @@ use std::ops::{Add, Deref};
 use alloy_consensus::{Header, proofs::calculate_transaction_root};
 use alloy_primitives::{Address, B64, B256, Bloom};
 use committable::{Commitment, Committable, RawCommitmentBuilder};
-use multisig::{Certificate, Envelope, Unchecked};
+use multisig::{Certificate, Envelope};
 use serde::{Deserialize, Serialize};
 
 use crate::Transaction;
@@ -147,13 +147,13 @@ impl Committable for BlockHash {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct BlockInfo<S> {
+pub struct BlockInfo<S: Clone> {
     num: BlockNumber,
     envelope: Envelope<BlockHash, S>,
 }
 
-impl BlockInfo {
-    pub fn new(num: BlockNumber, signed: Envelope<BlockHash, Unchecked>) -> Self {
+impl<S: Clone> BlockInfo<S> {
+    pub fn new(num: BlockNumber, signed: Envelope<BlockHash, S>) -> Self {
         Self {
             num,
             envelope: signed,
@@ -164,11 +164,11 @@ impl BlockInfo {
         self.num
     }
 
-    pub fn envelope(&self) -> &Envelope<BlockHash, Unchecked> {
+    pub fn envelope(&self) -> &Envelope<BlockHash, S> {
         &self.envelope
     }
 
-    pub fn into_envelope(self) -> Envelope<BlockHash, Unchecked> {
+    pub fn into_envelope(self) -> Envelope<BlockHash, S> {
         self.envelope
     }
 }

--- a/timeboost-types/src/block.rs
+++ b/timeboost-types/src/block.rs
@@ -147,9 +147,9 @@ impl Committable for BlockHash {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct BlockInfo {
+pub struct BlockInfo<S> {
     num: BlockNumber,
-    envelope: Envelope<BlockHash, Unchecked>,
+    envelope: Envelope<BlockHash, S>,
 }
 
 impl BlockInfo {

--- a/timeboost-types/src/block.rs
+++ b/timeboost-types/src/block.rs
@@ -4,6 +4,7 @@ use std::ops::{Add, Deref};
 use alloy_consensus::{Header, proofs::calculate_transaction_root};
 use alloy_primitives::{Address, B64, B256, Bloom};
 use committable::{Commitment, Committable, RawCommitmentBuilder};
+use multisig::{Certificate, Envelope, Unchecked};
 use serde::{Deserialize, Serialize};
 
 use crate::Transaction;
@@ -142,5 +143,56 @@ impl Committable for BlockHash {
         RawCommitmentBuilder::new("BlockHash")
             .fixed_size_field("block-hash", &self.0)
             .finalize()
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BlockInfo {
+    num: BlockNumber,
+    envelope: Envelope<BlockHash, Unchecked>,
+}
+
+impl BlockInfo {
+    pub fn new(num: BlockNumber, signed: Envelope<BlockHash, Unchecked>) -> Self {
+        Self {
+            num,
+            envelope: signed,
+        }
+    }
+
+    pub fn number(&self) -> BlockNumber {
+        self.num
+    }
+
+    pub fn envelope(&self) -> &Envelope<BlockHash, Unchecked> {
+        &self.envelope
+    }
+
+    pub fn into_envelope(self) -> Envelope<BlockHash, Unchecked> {
+        self.envelope
+    }
+}
+
+pub struct CertifiedBlock {
+    num: BlockNumber,
+    cert: Certificate<BlockHash>,
+    data: Block,
+}
+
+impl CertifiedBlock {
+    pub fn new(num: BlockNumber, cert: Certificate<BlockHash>, data: Block) -> Self {
+        Self { num, cert, data }
+    }
+
+    pub fn num(&self) -> BlockNumber {
+        self.num
+    }
+
+    pub fn cert(&self) -> &Certificate<BlockHash> {
+        &self.cert
+    }
+
+    pub fn data(&self) -> &Block {
+        &self.data
     }
 }

--- a/timeboost-types/src/block.rs
+++ b/timeboost-types/src/block.rs
@@ -4,11 +4,25 @@ use serde::{Deserialize, Serialize};
 
 use crate::Transaction;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Block(alloy_consensus::Block<Transaction>);
+
+impl std::ops::Deref for Block {
+    type Target = alloy_consensus::Block<Transaction>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BlockHash(B256);
+
+impl From<[u8; 32]> for BlockHash {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(B256::from(bytes))
+    }
+}
 
 impl std::ops::Deref for BlockHash {
     type Target = B256;

--- a/timeboost-types/src/block.rs
+++ b/timeboost-types/src/block.rs
@@ -1,11 +1,116 @@
-use alloy_primitives::B256;
+use core::fmt;
+use std::ops::{Add, Deref};
+
+use alloy_consensus::{Header, proofs::calculate_transaction_root};
+use alloy_primitives::{Address, B64, B256, Bloom};
 use committable::{Commitment, Committable, RawCommitmentBuilder};
 use serde::{Deserialize, Serialize};
 
 use crate::Transaction;
 
+/// The genesis timeboost block number.
+pub const GENESIS_BLOCK: BlockNumber = BlockNumber::new(0);
+
+/// A timeboost block number.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct BlockNumber(u64);
+
+impl BlockNumber {
+    pub const fn new(val: u64) -> Self {
+        Self(val)
+    }
+
+    pub fn u64(&self) -> u64 {
+        self.0
+    }
+
+    pub fn genesis() -> Self {
+        GENESIS_BLOCK
+    }
+
+    pub fn is_genesis(self) -> bool {
+        self == GENESIS_BLOCK
+    }
+}
+
+impl From<u64> for BlockNumber {
+    fn from(val: u64) -> Self {
+        Self(val)
+    }
+}
+
+impl From<BlockNumber> for u64 {
+    fn from(val: BlockNumber) -> Self {
+        val.0
+    }
+}
+
+impl Add<u64> for BlockNumber {
+    type Output = BlockNumber;
+
+    fn add(self, rhs: u64) -> Self::Output {
+        Self(self.0 + rhs)
+    }
+}
+
+impl Deref for BlockNumber {
+    type Target = u64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Committable for BlockNumber {
+    fn commit(&self) -> Commitment<Self> {
+        let builder = RawCommitmentBuilder::new("Block Number Commitment");
+        builder.u64(self.0).finalize()
+    }
+}
+
+impl fmt::Display for BlockNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Block(alloy_consensus::Block<Transaction>);
+
+impl Block {
+    pub fn new(parent: BlockHash, txs: Vec<Transaction>) -> Self {
+        let body = alloy_consensus::BlockBody {
+            transactions: txs.clone(),
+            ommers: vec![],
+            withdrawals: None,
+        };
+        let tx_root = calculate_transaction_root(&txs);
+        let header = Header {
+            parent_hash: *parent,
+            ommers_hash: B256::ZERO,
+            beneficiary: Address::ZERO,
+            state_root: B256::ZERO,
+            transactions_root: tx_root,
+            receipts_root: B256::ZERO,
+            logs_bloom: Bloom::ZERO,
+            difficulty: B256::ZERO.into(),
+            number: 0,
+            gas_limit: 0,
+            gas_used: 0,
+            timestamp: 0,
+            extra_data: vec![].into(),
+            mix_hash: B256::ZERO,
+            nonce: B64::default(),
+            base_fee_per_gas: None,
+            withdrawals_root: None,
+            blob_gas_used: None,
+            excess_blob_gas: None,
+            parent_beacon_block_root: None,
+            requests_hash: None,
+        };
+        Self(alloy_consensus::Block { header, body })
+    }
+}
 
 impl std::ops::Deref for Block {
     type Target = alloy_consensus::Block<Transaction>;
@@ -15,7 +120,7 @@ impl std::ops::Deref for Block {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, Ord, PartialOrd, PartialEq, Eq)]
 pub struct BlockHash(B256);
 
 impl From<[u8; 32]> for BlockHash {

--- a/timeboost-types/src/lib.rs
+++ b/timeboost-types/src/lib.rs
@@ -11,8 +11,7 @@ mod time;
 
 pub mod math;
 
-pub use block::Block;
-pub use block::BlockHash;
+pub use block::{Block, BlockHash, BlockNumber};
 pub use bundle::{
     Address, Bundle, BundleVariant, ChainId, PriorityBundle, SignedPriorityBundle, Signer,
     Transaction,
@@ -22,12 +21,10 @@ pub use candidate_list::{CandidateList, CandidateListBytes};
 pub use decryption::{DecShareKey, DecryptionKey, ShareInfo};
 pub use delayed_inbox::DelayedInboxIndex;
 pub use inclusion_list::InclusionList;
-use multisig::Envelope;
-use multisig::Unchecked;
+use multisig::{Envelope, Unchecked};
 pub use retry_list::RetryList;
 pub use seqno::SeqNo;
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 pub use time::{Epoch, Timestamp};
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/timeboost-types/src/lib.rs
+++ b/timeboost-types/src/lib.rs
@@ -11,7 +11,7 @@ mod time;
 
 pub mod math;
 
-pub use block::{Block, BlockHash, BlockNumber};
+pub use block::{Block, BlockHash, BlockInfo, BlockNumber, CertifiedBlock};
 pub use bundle::{
     Address, Bundle, BundleVariant, ChainId, PriorityBundle, SignedPriorityBundle, Signer,
     Transaction,
@@ -21,14 +21,6 @@ pub use candidate_list::{CandidateList, CandidateListBytes};
 pub use decryption::{DecShareKey, DecryptionKey, ShareInfo};
 pub use delayed_inbox::DelayedInboxIndex;
 pub use inclusion_list::InclusionList;
-use multisig::{Envelope, Unchecked};
 pub use retry_list::RetryList;
 pub use seqno::SeqNo;
-use serde::{Deserialize, Serialize};
 pub use time::{Epoch, Timestamp};
-
-#[derive(Serialize, Deserialize, Debug)]
-pub enum MultiplexMessage {
-    Decrypt(ShareInfo),
-    Block(Envelope<BlockHash, Unchecked>),
-}

--- a/timeboost-types/src/lib.rs
+++ b/timeboost-types/src/lib.rs
@@ -1,3 +1,4 @@
+mod block;
 mod bundle;
 mod bytes;
 mod candidate_list;
@@ -10,6 +11,8 @@ mod time;
 
 pub mod math;
 
+pub use block::Block;
+pub use block::BlockHash;
 pub use bundle::{
     Address, Bundle, BundleVariant, ChainId, PriorityBundle, SignedPriorityBundle, Signer,
     Transaction,
@@ -19,6 +22,16 @@ pub use candidate_list::{CandidateList, CandidateListBytes};
 pub use decryption::{DecShareKey, DecryptionKey, ShareInfo};
 pub use delayed_inbox::DelayedInboxIndex;
 pub use inclusion_list::InclusionList;
+use multisig::Envelope;
+use multisig::Unchecked;
 pub use retry_list::RetryList;
 pub use seqno::SeqNo;
+use serde::Deserialize;
+use serde::Serialize;
 pub use time::{Epoch, Timestamp};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum MultiplexMessage {
+    Decrypt(ShareInfo),
+    Block(Envelope<BlockHash, Unchecked>),
+}

--- a/timeboost/src/lib.rs
+++ b/timeboost/src/lib.rs
@@ -129,7 +129,7 @@ impl Timeboost {
             select! { biased;
                 block = self.sequencer.next_block() => match block {
                     Ok(block) => {
-                        info!(node = %self.label, block = ?block.0.data(), "block");
+                        info!(node = %self.label, block = ?block.cert().data(), "block");
                     }
                     Err(err) => {
                         return Err(err.into())

--- a/timeboost/src/lib.rs
+++ b/timeboost/src/lib.rs
@@ -127,10 +127,9 @@ impl Timeboost {
 
         loop {
             select! { biased;
-                trx = self.sequencer.next_transaction() => match trx {
-                    Ok(trx) => {
-                        info!(node = %self.label, trx = %trx.tx().hash(), "transaction");
-                        // TODO: block building phase
+                block = self.sequencer.next_block() => match block {
+                    Ok(block) => {
+                        info!(node = %self.label, block = ?block.0.data(), "block");
                     }
                     Err(err) => {
                         return Err(err.into())


### PR DESCRIPTION
### Context
This PR introduces the Block Production Phase, which consumes a decrypted, timestamped transaction stream and produces deterministic, certified blocks. Once a block is constructed, the node signs and broadcasts it. Upon receiving $$t+1$$ signatures (including at least one honest signature), the block is considered certified.

### What’s Included
**Multiplexing Network Messages**
To avoid spinning up a separate Timeboost network instance for the Block Production Phase, this PR introduces a Multiplex component. It routes incoming Timeboost messages to the appropriate consumer (Decryption or Block Production), ensuring clean separation between protocol phases over a shared network layer.

**Block Production**
This PR adds a simple but deterministic block construction algorithm that batches exactly 10 transactions per block. A minimal Arbitrum/Ethereum-like block structure is created, including fields like parent, txs, and tx_root. The implementation references existing centralized sequencer code [here](https://github.com/EspressoSystems/timeboost/blob/65efbb07f6c27fd7dbada049a6d7ac7af33c4fea/timeboost-sequencer/src/produce.rs#L64-L67), offering context for future spec-aligned implementations.

### Additional Notes
~~**Garbage Collection**
GC is currently not implemented due to the incomplete GC interface in the Overlay network. As a result, un-ACKed Overlay messages are not garbage collected. This has no impact on current tests or demos. TODOs are left in the relevant places for future GC integration once the interface stabilizes.~~

**Timestamps & Block Format**
Per the [decentralized-timeboost spec](https://github.com/OffchainLabs/decentralized-timeboost-spec/blob/e314d70f9d0ebabccea17a59804e3b90ec96b936/README.md?plain=1#L166), each transaction now includes a timestamp in the Sorting Phase. While the current block construction doesn't yet use these timestamps, the groundwork is laid for future alignment with the finalized block format.

**Transaction Order Test**
The transaction-order test has been updated to reflect the new block-based output. It now verifies that all nodes produce identical certified blocks with matching hashes.