### PR TITLE
Add proper `Trailer` type appended to the message.

### DIFF
--- a/cliquenet/Cargo.toml
+++ b/cliquenet/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 
 [dependencies]
 bimap = { workspace = true }
+bincode = { workspace = true }
 bytes = { workspace = true }
 metrics = { path = "../metrics" }
 multisig = { path = "../multisig" }

--- a/cliquenet/src/overlay.rs
+++ b/cliquenet/src/overlay.rs
@@ -3,6 +3,8 @@ use std::convert::Infallible;
 use std::ops::Deref;
 use std::sync::Arc;
 
+use bincode::config::{Configuration, Limit, LittleEndian, Varint};
+use bincode::{Decode, Encode};
 use bytes::{Bytes, BytesMut};
 use multisig::PublicKey;
 use parking_lot::Mutex;
@@ -29,7 +31,11 @@ type Result<T> = std::result::Result<T, NetworkDown>;
 ///
 /// Note that if malicious parties modify the trailer and have it point to a
 /// different message, they can only remove themselves from the set of parties
-/// the sender is expecting an acknowledgement from.
+/// the sender is expecting an acknowledgement from. However, if they change the
+/// tag of a message, client code may classify the data incorrectly. The tag
+/// can thus not be trusted and client code needs to be able to handle data that
+/// does not match its tag. It is best used for data that the sender can anyway
+/// easily produce.
 #[derive(Debug)]
 pub struct Overlay {
     this: PublicKey,
@@ -38,6 +44,7 @@ pub struct Overlay {
     parties: Vec<PublicKey>,
     id: Id,
     buffer: Buffer,
+    encoded: [u8; Trailer::MAX_LEN],
     retry: JoinHandle<Infallible>,
 }
 
@@ -53,15 +60,22 @@ impl Drop for Overlay {
 /// not be rejected by the network due to size violations (see the
 /// `TryFrom<BytesMut>` impl for details).
 #[derive(Debug, Clone)]
-pub struct Data(BytesMut);
+pub struct Data {
+    bytes: BytesMut,
+    tag: Tag,
+}
 
 /// Buckets conceptionally contain messages.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode)]
 pub struct Bucket(u64);
 
 /// A message ID uniquely identifies as message.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode)]
 struct Id(u64);
+
+/// A tag that can be attached to `Data` to allow classification.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode)]
+pub struct Tag(u8);
 
 /// Messages are associated with IDs and put into buckets.
 ///
@@ -83,6 +97,17 @@ struct Message {
     remaining: Vec<PublicKey>,
 }
 
+/// Meta information appended at the end of a message.
+#[derive(Debug, Encode, Decode)]
+struct Trailer {
+    /// The bucket number the message corresponds to.
+    bucket: Bucket,
+    /// The message ID.
+    id: Id,
+    /// The tag of a message.
+    tag: Tag,
+}
+
 impl Overlay {
     pub fn new(net: Network) -> Self {
         let buffer = Buffer::default();
@@ -93,6 +118,7 @@ impl Overlay {
             sender: net.sender(),
             net,
             buffer,
+            encoded: [0; Trailer::MAX_LEN],
             id: Id(0),
             retry,
         }
@@ -112,40 +138,39 @@ impl Overlay {
         self.send(b.into(), Some(to), data).await
     }
 
-    pub async fn receive(&mut self) -> Result<(PublicKey, Bytes)> {
+    pub async fn receive(&mut self) -> Result<(PublicKey, Bytes, Tag)> {
         loop {
             let (src, mut bytes) = self.net.receive().await.map_err(|_| NetworkDown(()))?;
 
-            if bytes.len() < 16 {
-                warn!(node = %self.this, "received unexpected message");
-                return Ok((src, bytes));
-            }
+            let Some(trailer_bytes) = Trailer::split_off(&mut bytes) else {
+                warn!(node = %self.this, "invalid trailer bytes");
+                continue;
+            };
 
-            let trailer: [u8; 16] = bytes
-                .split_off(bytes.len() - 16)
-                .as_ref()
-                .try_into()
-                .expect("bytes len checked above");
+            let trailer = match Trailer::decode(&trailer_bytes) {
+                Ok(t) => t,
+                Err(e) => {
+                    warn!(node = %self.this, err = %e, "invalid trailer");
+                    continue;
+                }
+            };
 
             if !bytes.is_empty() {
                 // Send the trailer back as acknowledgement:
-                let ack = Bytes::copy_from_slice(&trailer);
                 self.sender
-                    .send((Some(src), ack))
+                    .send((Some(src), trailer_bytes))
                     .await
                     .map_err(|_| NetworkDown(()))?;
-                return Ok((src, bytes));
+                return Ok((src, bytes, trailer.tag));
             }
-
-            let (b, i) = from_trailer(&trailer);
 
             let mut messages = self.buffer.0.lock();
 
-            if let Some(buckets) = messages.get_mut(&b) {
-                if let Some(m) = buckets.get_mut(&i) {
+            if let Some(buckets) = messages.get_mut(&trailer.bucket) {
+                if let Some(m) = buckets.get_mut(&trailer.id) {
                     m.remaining.retain(|k| *k != src);
                     if m.remaining.is_empty() {
-                        buckets.remove(&i);
+                        buckets.remove(&trailer.id);
                     }
                 }
             }
@@ -158,11 +183,20 @@ impl Overlay {
     }
 
     async fn send(&mut self, b: Bucket, to: Option<PublicKey>, data: Data) -> Result<()> {
-        let i = self.next_id();
+        let id = self.next_id();
 
-        let mut msg = data.0;
+        let trailer = Trailer {
+            bucket: b,
+            id,
+            tag: data.tag,
+        };
 
-        msg.extend_from_slice(&to_trailer(b, i));
+        let trailer_bytes = trailer.encode(&mut self.encoded);
+
+        let mut msg = data.bytes;
+
+        msg.extend_from_slice(trailer_bytes);
+        msg.extend_from_slice(&[trailer_bytes.len().try_into().expect("|trailer| <= 32")]);
         let msg = msg.freeze();
 
         let now = Instant::now();
@@ -182,7 +216,7 @@ impl Overlay {
         };
 
         self.buffer.0.lock().entry(b).or_default().insert(
-            i,
+            id,
             Message {
                 data: msg,
                 time: now,
@@ -199,21 +233,6 @@ impl Overlay {
         self.id = Id(self.id.0 + 1);
         id
     }
-}
-
-/// Serialize a `Bucket` and `Id`.
-fn to_trailer(b: Bucket, i: Id) -> [u8; 16] {
-    let mut t = [0; 16];
-    t[..8].copy_from_slice(&b.0.to_be_bytes());
-    t[8..].copy_from_slice(&i.0.to_be_bytes());
-    t
-}
-
-/// Deserialize into `Bucket` and `Id`.
-fn from_trailer(t: &[u8; 16]) -> (Bucket, Id) {
-    let b = u64::from_be_bytes(t[..8].try_into().expect("8 bytes"));
-    let i = u64::from_be_bytes(t[8..].try_into().expect("8 bytes"));
-    (Bucket(b), Id(i))
 }
 
 async fn retry(buf: Buffer, net: Sender<(Option<PublicKey>, Bytes)>) -> Infallible {
@@ -290,7 +309,10 @@ impl TryFrom<BytesMut> for Data {
         if val.len() > crate::MAX_MESSAGE_SIZE {
             return Err(DataError::MaxSize);
         }
-        Ok(Self(val))
+        Ok(Self {
+            bytes: val,
+            tag: Tag::default(),
+        })
     }
 }
 
@@ -298,12 +320,56 @@ impl Deref for Data {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
-        self.0.as_ref()
+        self.bytes.as_ref()
     }
 }
 
 impl From<u64> for Bucket {
     fn from(val: u64) -> Self {
-        Bucket(val)
+        Self(val)
+    }
+}
+
+impl From<u8> for Tag {
+    fn from(val: u8) -> Self {
+        Self(val)
+    }
+}
+
+impl Data {
+    pub fn tag(&self) -> Tag {
+        self.tag
+    }
+
+    pub fn set_tag(&mut self, t: Tag) {
+        self.tag = t
+    }
+}
+
+impl Trailer {
+    /// Max. byte length of a trailer.
+    pub const MAX_LEN: usize = 32;
+
+    const BINCONF: Configuration<LittleEndian, Varint, Limit<{ Self::MAX_LEN }>> =
+        bincode::config::standard().with_limit::<{ Self::MAX_LEN }>();
+
+    fn split_off(bytes: &mut Bytes) -> Option<Bytes> {
+        let len = usize::from(*bytes.last()?);
+
+        if bytes.len() < len + 1 {
+            return None;
+        }
+
+        Some(bytes.split_off(bytes.len() - (len + 1)))
+    }
+
+    fn decode(bytes: &[u8]) -> std::result::Result<Self, bincode::error::DecodeError> {
+        bincode::decode_from_slice(bytes, Self::BINCONF).map(|(t, _)| t)
+    }
+
+    fn encode<'a>(&self, buf: &'a mut [u8; Self::MAX_LEN]) -> &'a [u8] {
+        let len = bincode::encode_into_slice(self, buf, Self::BINCONF)
+            .expect("trailer encoding never fails");
+        &buf[..len]
     }
 }

--- a/cliquenet/tests/frame-handling.rs
+++ b/cliquenet/tests/frame-handling.rs
@@ -69,7 +69,7 @@ async fn send_recv(sender: PublicKey, net_a: &mut Overlay, net_b: &mut Overlay, 
         net_a.broadcast(0, data.clone()).await.unwrap();
 
         for net in [&mut *net_a, net_b] {
-            if let Ok(Ok((k, x))) = timeout(Duration::from_millis(5), net.receive()).await {
+            if let Ok(Ok((k, x, _))) = timeout(Duration::from_millis(5), net.receive()).await {
                 assert_eq!(k, sender);
                 if *x != *data {
                     continue 'main;

--- a/sailfish-rbc/src/abraham/worker.rs
+++ b/sailfish-rbc/src/abraham/worker.rs
@@ -180,7 +180,7 @@ impl<T: Clone + Committable + Serialize + DeserializeOwned> Worker<T> {
             tokio::select! {
                 val = self.comm.receive(), if self.tx.capacity() > 0 => {
                     match val {
-                        Ok((key, bytes)) => {
+                        Ok((key, bytes, _)) => {
                             match self.on_inbound(key, bytes).await {
                                 Ok(()) => {}
                                 Err(RbcError::Shutdown) => {

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -315,7 +315,7 @@ impl Worker {
             tokio::select! {
                 // received batch of decryption shares from remote node.
                 val = self.net.receive() => match val {
-                    Ok((remote_pk, bytes)) => {
+                    Ok((remote_pk, bytes, _)) => {
                         if remote_pk == self.label {
                             continue;
                         }


### PR DESCRIPTION
In addition to the bucket number and message Id also support adding a tag to allow clients to classify their messages.