### PR TITLE
Create gap between certification and gc for blocks

### DIFF
--- a/timeboost-sequencer/src/produce.rs
+++ b/timeboost-sequencer/src/produce.rs
@@ -22,6 +22,7 @@ enum Status {
     Uncertified(Block),
     Certified(Certificate<BlockHash>, Block),
 }
+
 struct WorkerRequest(BlockNumber, BlockHash);
 
 struct WorkerResponse(BlockNumber, Certificate<BlockHash>);
@@ -97,12 +98,7 @@ impl BlockProducer {
                 .map_err(|_| ProducerError::Shutdown)?;
             self.parent = Some((num, hash));
 
-            trace!(
-                node  = %self.label.public_key(),
-                num   = %num,
-                block = ?hash,
-                "certifying"
-            );
+            trace!(node = %self.label.public_key(), %num, block = ?hash, "certifying");
         }
 
         Ok(())
@@ -121,7 +117,6 @@ impl BlockProducer {
                     *status = Status::Certified(cert, block.to_owned());
                 }
             };
-
             if let Some((block_info, status)) = self.blocks.pop_first() {
                 if let Status::Certified(cert, block) = status {
                     return Ok(CertifiedBlock::new(num, cert, block));
@@ -149,7 +144,6 @@ impl Drop for BlockProducer {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum CertStatus {
     Unknown,
-    Signed,
     Certified,
 }
 
@@ -189,8 +183,8 @@ impl Worker {
                     Some(BlockInbound{src, data}) => {
                         let b = match deserialize::<BlockInfo<Unchecked>>(&data) {
                             Ok(block) => block,
-                            Err(e) => {
-                                warn!("deserialization error: {}", e);
+                            Err(err) => {
+                                warn!(node = %label, %err, "deserialization error");
                                 continue;
                             }
                         };
@@ -217,18 +211,14 @@ impl Worker {
 
                 val = block_rx.recv() => match val {
                     Some(WorkerRequest(num, hash)) => {
-                        trace!(
-                            node = %label,
-                            hash = ?hash,
-                            "produced"
-                        );
+                        trace!(node = %label, %num, hash = ?hash, "produced");
                         let env = Envelope::signed(hash, &self.keypair, false);
                         recv_block = (Some(num), env.clone());
                         let b = BlockInfo::new(num, env);
                         let data = match serialize(&b) {
                             Ok(data) => data,
-                            Err(e) => {
-                                warn!(node = %label, "serialization error: {}", e);
+                            Err(err) => {
+                                warn!(node = %label, %err, %num, ?hash, "serialization error");
                                 continue;
                             }
                         };
@@ -251,14 +241,14 @@ impl Worker {
                     num: None,
                     status: CertStatus::Unknown,
                 });
+
+            if tracker.status == CertStatus::Certified {
+                continue;
+            }
+
             if let Some(num) = block_num {
                 // Block number provided => block produced/signed by the local node.
                 tracker.num = Some(num);
-                tracker.status = CertStatus::Signed;
-            }
-
-            if tracker.status != CertStatus::Signed {
-                continue;
             }
 
             match tracker.votes.add(block_hash.into_signed()) {

--- a/timeboost-types/src/block.rs
+++ b/timeboost-types/src/block.rs
@@ -1,5 +1,5 @@
 use core::fmt;
-use std::ops::{Add, Deref};
+use std::ops::{Add, Deref, Sub};
 
 use alloy_consensus::{Header, proofs::calculate_transaction_root};
 use alloy_primitives::{Address, B64, B256, Bloom};
@@ -51,6 +51,14 @@ impl Add<u64> for BlockNumber {
 
     fn add(self, rhs: u64) -> Self::Output {
         Self(self.0 + rhs)
+    }
+}
+
+impl Sub<u64> for BlockNumber {
+    type Output = BlockNumber;
+
+    fn sub(self, rhs: u64) -> Self::Output {
+        Self(self.0 - rhs)
     }
 }
 


### PR DESCRIPTION
Currently the block messages are garbage collected immediately after a certificate is obtained on the block on that block. This is too aggressive and means that in some scenarios nodes will not receive the block in time.
This PR implements a gap between certification and garbage collection similar to the gap for garbage collecting decryption messages after the corresponding ciphertext has been decrypted.