### PR TITLE
Precompute commit

### DIFF
--- a/timeboost-types/src/bundle.rs
+++ b/timeboost-types/src/bundle.rs
@@ -115,7 +115,10 @@ impl<'a> Arbitrary<'a> for Bundle {
 impl Committable for Bundle {
     fn commit(&self) -> Commitment<Self> {
         RawCommitmentBuilder::new("Bundle")
-            .var_size_field("digest", self.digest())
+            .field("chain", self.chain_id().commit())
+            .field("epoch", self.epoch().commit())
+            .var_size_field("data", self.data())
+            .field("keysetid", self.kid().unwrap_or_default().commit())
             .finalize()
     }
 }
@@ -278,7 +281,10 @@ impl SignedPriorityBundle {
 impl Committable for SignedPriorityBundle {
     fn commit(&self) -> Commitment<Self> {
         RawCommitmentBuilder::new("SignedPriorityBundle")
-            .var_size_field("digest", self.digest())
+            .field("bundle", self.bundle.commit())
+            .field("auction", self.auction.commit())
+            .field("seqno", self.seqno.commit())
+            .field("signature", self.signature().commit())
             .finalize()
     }
 }

--- a/timeboost-types/src/bundle.rs
+++ b/timeboost-types/src/bundle.rs
@@ -117,12 +117,6 @@ impl Committable for Bundle {
         RawCommitmentBuilder::new("Bundle")
             .var_size_field("digest", self.digest())
             .finalize()
-        // RawCommitmentBuilder::new("PriorityBundle")
-        //     .field("chain", self.chain_id().commit())
-        //     .field("epoch", self.epoch().commit())
-        //     .var_size_field("data", self.data())
-        //     .field("keysetid", self.kid().unwrap_or_default().commit())
-        //     .finalize()
     }
 }
 
@@ -286,12 +280,6 @@ impl Committable for SignedPriorityBundle {
         RawCommitmentBuilder::new("PriorityBundle")
             .var_size_field("digest", self.digest())
             .finalize()
-        // RawCommitmentBuilder::new("PriorityBundle")
-        //     .field("bundle", self.bundle.commit())
-        //     .field("auction", self.auction.commit())
-        //     .field("seqno", self.seqno.commit())
-        //     .field("signature", self.signature().commit())
-        //     .finalize()
     }
 }
 

--- a/timeboost-types/src/bundle.rs
+++ b/timeboost-types/src/bundle.rs
@@ -277,7 +277,7 @@ impl SignedPriorityBundle {
 
 impl Committable for SignedPriorityBundle {
     fn commit(&self) -> Commitment<Self> {
-        RawCommitmentBuilder::new("PriorityBundle")
+        RawCommitmentBuilder::new("SignedPriorityBundle")
             .var_size_field("digest", self.digest())
             .finalize()
     }

--- a/timeboost-types/src/bundle.rs
+++ b/timeboost-types/src/bundle.rs
@@ -114,12 +114,15 @@ impl<'a> Arbitrary<'a> for Bundle {
 
 impl Committable for Bundle {
     fn commit(&self) -> Commitment<Self> {
-        RawCommitmentBuilder::new("PriorityBundle")
-            .field("chain", self.chain_id().commit())
-            .field("epoch", self.epoch().commit())
-            .var_size_field("data", self.data())
-            .field("keysetid", self.kid().unwrap_or_default().commit())
+        RawCommitmentBuilder::new("Bundle")
+            .var_size_field("digest", self.digest())
             .finalize()
+        // RawCommitmentBuilder::new("PriorityBundle")
+        //     .field("chain", self.chain_id().commit())
+        //     .field("epoch", self.epoch().commit())
+        //     .var_size_field("data", self.data())
+        //     .field("keysetid", self.kid().unwrap_or_default().commit())
+        //     .finalize()
     }
 }
 
@@ -281,11 +284,14 @@ impl SignedPriorityBundle {
 impl Committable for SignedPriorityBundle {
     fn commit(&self) -> Commitment<Self> {
         RawCommitmentBuilder::new("PriorityBundle")
-            .field("bundle", self.bundle.commit())
-            .field("auction", self.auction.commit())
-            .field("seqno", self.seqno.commit())
-            .field("signature", self.signature().commit())
+            .var_size_field("digest", self.digest())
             .finalize()
+        // RawCommitmentBuilder::new("PriorityBundle")
+        //     .field("bundle", self.bundle.commit())
+        //     .field("auction", self.auction.commit())
+        //     .field("seqno", self.seqno.commit())
+        //     .field("signature", self.signature().commit())
+        //     .finalize()
     }
 }
 

--- a/timeboost-types/src/candidate_list.rs
+++ b/timeboost-types/src/candidate_list.rs
@@ -113,12 +113,12 @@ impl Committable for CandidateList {
             .0
             .priority
             .iter()
-            .fold(builder, |b, pb| b.var_size_bytes(pb.commit().as_ref()));
+            .fold(builder, |b, pb| b.var_size_bytes(pb.digest()));
         builder = builder.u64_field("regular", self.regular_bundles().len() as u64);
         self.0
             .regular
             .iter()
-            .fold(builder, |b, rb| b.var_size_bytes(rb.commit().as_ref()))
+            .fold(builder, |b, rb| b.var_size_bytes(rb.digest()))
             .finalize()
     }
 }

--- a/timeboost-types/src/candidate_list.rs
+++ b/timeboost-types/src/candidate_list.rs
@@ -113,12 +113,12 @@ impl Committable for CandidateList {
             .0
             .priority
             .iter()
-            .fold(builder, |b, pb| b.var_size_bytes(pb.digest()));
+            .fold(builder, |b, pb| b.var_size_bytes(pb.commit().as_ref()));
         builder = builder.u64_field("regular", self.regular_bundles().len() as u64);
         self.0
             .regular
             .iter()
-            .fold(builder, |b, rb| b.var_size_bytes(rb.digest()))
+            .fold(builder, |b, rb| b.var_size_bytes(rb.commit().as_ref()))
             .finalize()
     }
 }


### PR DESCRIPTION
Sailfish spends CPU time recomputing the digest of each transaction in the Vertex. This is usually not an issue but it manifests in inefficiencies when retries are done (for example when non-priority transactions are not included because it only appears in $$< t+1$$ candidate lists). This PR fixes this issue.