### PR TITLE
Use a custom bounded channel for peers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ either = "1.13.0"
 ethereum_ssz = "0.9.0"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 multiaddr = "0.18.2"
+nohash-hasher = "0.2"
 parking_lot = "0.12.3"
 portpicker = "0.1.1"
 prometheus = "0.14"

--- a/cliquenet/Cargo.toml
+++ b/cliquenet/Cargo.toml
@@ -11,6 +11,7 @@ bincode = { workspace = true }
 bytes = { workspace = true }
 metrics = { path = "../metrics" }
 multisig = { path = "../multisig" }
+nohash-hasher = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }
 snow = { workspace = true }

--- a/cliquenet/src/chan.rs
+++ b/cliquenet/src/chan.rs
@@ -1,0 +1,100 @@
+//! A channel implementation that keeps only a single copy of an item, as
+//! identified by its Id.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use nohash_hasher::IntSet;
+use parking_lot::Mutex;
+use tokio::sync::Notify;
+use tokio::sync::mpsc::error::TrySendError;
+
+use crate::Id;
+
+#[derive(Debug)]
+pub struct Sender<T>(Arc<Chan<T>>);
+
+#[derive(Debug)]
+pub struct Receiver<T>(Arc<Chan<T>>);
+
+#[derive(Debug)]
+struct Chan<T> {
+    /// Channel capacity.
+    cap: usize,
+    /// Notifier for receivers that are waiting for items.
+    sig: Notify,
+    /// The items currently in flight.
+    buf: Mutex<Buf<T>>,
+}
+
+#[derive(Debug)]
+struct Buf<T> {
+    /// Ordered queue of items.
+    xs: VecDeque<(Option<Id>, T)>,
+    /// The set of Ids in the queue.
+    ids: IntSet<Id>,
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+pub fn channel<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
+    let chan = Arc::new(Chan {
+        cap,
+        sig: Notify::new(),
+        buf: Mutex::new(Buf {
+            xs: VecDeque::new(),
+            ids: IntSet::default(),
+        }),
+    });
+    (Sender(chan.clone()), Receiver(chan))
+}
+
+impl<T> Sender<T> {
+    pub fn try_send(&self, id: Option<Id>, val: T) -> Result<(), TrySendError<T>> {
+        if let Some(id) = id {
+            let mut buf = self.0.buf.lock();
+            if buf.ids.contains(&id) {
+                return Ok(());
+            }
+            if buf.xs.len() == self.0.cap {
+                return Err(TrySendError::Full(val));
+            }
+            buf.xs.push_back((Some(id), val));
+            buf.ids.insert(id);
+        } else {
+            let mut buf = self.0.buf.lock();
+            if buf.xs.len() == self.0.cap {
+                return Err(TrySendError::Full(val));
+            }
+            buf.xs.push_back((None, val));
+        }
+        self.0.sig.notify_waiters();
+        Ok(())
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.0.cap
+    }
+}
+
+impl<T> Receiver<T> {
+    pub async fn recv(&self) -> Option<T> {
+        loop {
+            let future = self.0.sig.notified();
+            {
+                let mut buf = self.0.buf.lock();
+                if let Some((id, val)) = buf.xs.pop_front() {
+                    if let Some(id) = id {
+                        buf.ids.remove(&id);
+                    }
+                    return Some(val);
+                }
+            }
+            future.await;
+        }
+    }
+}

--- a/cliquenet/src/id.rs
+++ b/cliquenet/src/id.rs
@@ -1,0 +1,24 @@
+use bincode::{Decode, Encode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
+pub struct Id(u64);
+
+impl From<u64> for Id {
+    fn from(n: u64) -> Self {
+        Self(n)
+    }
+}
+
+impl From<Id> for u64 {
+    fn from(n: Id) -> Self {
+        n.0
+    }
+}
+
+impl std::hash::Hash for Id {
+    fn hash<H: std::hash::Hasher>(&self, h: &mut H) {
+        h.write_u64(self.0)
+    }
+}
+
+impl nohash_hasher::IsEnabled for Id {}

--- a/cliquenet/src/lib.rs
+++ b/cliquenet/src/lib.rs
@@ -1,6 +1,8 @@
 mod addr;
+mod chan;
 mod error;
 mod frame;
+mod id;
 mod metrics;
 mod net;
 mod tcp;
@@ -10,6 +12,7 @@ pub mod overlay;
 
 pub use addr::{Address, InvalidAddress};
 pub use error::NetworkError;
+pub use id::Id;
 pub use metrics::NetworkMetrics;
 pub use net::Network;
 pub use overlay::Overlay;

--- a/cliquenet/src/overlay.rs
+++ b/cliquenet/src/overlay.rs
@@ -16,7 +16,7 @@ use tokio::task::JoinHandle;
 use tokio::time::{self, Duration, Instant};
 use tracing::warn;
 
-use crate::Network;
+use crate::{Id, Network};
 
 type Result<T> = std::result::Result<T, NetworkDown>;
 
@@ -47,7 +47,7 @@ pub const DEFAULT_TAG: Tag = Tag::new(0);
 pub struct Overlay {
     this: PublicKey,
     net: Network,
-    sender: Sender<(Option<PublicKey>, Bytes)>,
+    sender: Sender<(Option<PublicKey>, Option<Id>, Bytes)>,
     parties: Vec<PublicKey>,
     id: Id,
     buffer: Buffer,
@@ -75,10 +75,6 @@ pub struct Data {
 /// Buckets conceptionally contain messages.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode)]
 pub struct Bucket(u64);
-
-/// A message ID uniquely identifies as message.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode)]
-pub struct Id(u64);
 
 /// A tag that can be attached to `Data` to allow classification.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode)]
@@ -127,7 +123,7 @@ impl Overlay {
             net,
             buffer,
             encoded: [0; Trailer::MAX_LEN],
-            id: Id(0),
+            id: Id::from(0),
             retry,
         }
     }
@@ -166,7 +162,7 @@ impl Overlay {
             if !bytes.is_empty() {
                 // Send the trailer back as acknowledgement:
                 self.sender
-                    .send((Some(src), trailer_bytes))
+                    .send((Some(src), None, trailer_bytes))
                     .await
                     .map_err(|_| NetworkDown(()))?;
                 return Ok((src, bytes, trailer.tag));
@@ -221,13 +217,13 @@ impl Overlay {
 
         let rem = if let Some(to) = to {
             self.sender
-                .send((Some(to), msg.clone()))
+                .send((Some(to), Some(id), msg.clone()))
                 .await
                 .map_err(|_| NetworkDown(()))?;
             vec![to]
         } else {
             self.sender
-                .send((None, msg.clone()))
+                .send((None, Some(id), msg.clone()))
                 .await
                 .map_err(|_| NetworkDown(()))?;
             self.parties.clone()
@@ -253,12 +249,12 @@ impl Overlay {
 
     fn next_id(&mut self) -> Id {
         let id = self.id;
-        self.id = Id(self.id.0 + 1);
+        self.id = (u64::from(self.id) + 1).into();
         id
     }
 }
 
-async fn retry(buf: Buffer, net: Sender<(Option<PublicKey>, Bytes)>) -> Infallible {
+async fn retry(buf: Buffer, net: Sender<(Option<PublicKey>, Option<Id>, Bytes)>) -> Infallible {
     const DELAYS: [u64; 4] = [1, 3, 5, 15];
 
     let mut i = time::interval(Duration::from_secs(1));
@@ -307,7 +303,7 @@ async fn retry(buf: Buffer, net: Sender<(Option<PublicKey>, Bytes)>) -> Infallib
                 }
 
                 for p in remaining {
-                    let _ = net.send((Some(p), message.clone())).await;
+                    let _ = net.send((Some(p), Some(id), message.clone())).await;
                 }
             }
         }

--- a/sailfish-rbc/src/abraham/worker.rs
+++ b/sailfish-rbc/src/abraham/worker.rs
@@ -64,7 +64,7 @@ enum WorkerState {
     /// stored and once the round number barrier for participation has been
     /// reached, the deferred messages from that round number onwards will
     /// be sent out.
-    Recover(Nonce, Option<overlay::Id>, HashMap<PublicKey, RoundNumber>),
+    Recover(Nonce, Option<cliquenet::Id>, HashMap<PublicKey, RoundNumber>),
     /// This is the normal running state after round numbers have been collected.
     /// The barrier is the maximum of at least 2t + 1 reported round numbers and
     /// restricts when messages are eligible for sending.


### PR DESCRIPTION
Since layers above `Network` have to cope with message loss they usually perform retries (cf. `Overlay`), sending the same message until they received acknowledgements from peers. If the peer is slow, this may cause multiple identical copies of the message to appear in the queue and subsequently sent over the network. This commit keeps only a single message (as identified by its ID) in the channel. Either this message is eventually sent out or the channel is dropped when it overflows, or a timeout occurs (just like currently).