### PR TITLE
Create timeboost-builder crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "sailfish-types",
     "tests",
     "timeboost",
+    "timeboost-builder",
     "timeboost-sequencer",
     "timeboost-crypto",
     "timeboost-types",

--- a/cliquenet/src/addr.rs
+++ b/cliquenet/src/addr.rs
@@ -106,6 +106,14 @@ impl std::str::FromStr for Address {
     }
 }
 
+impl TryFrom<&str> for Address {
+    type Error = InvalidAddress;
+
+    fn try_from(val: &str) -> Result<Self, Self::Error> {
+        val.parse()
+    }
+}
+
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("invalid address")]
 pub struct InvalidAddress(());

--- a/cliquenet/src/metrics.rs
+++ b/cliquenet/src/metrics.rs
@@ -16,12 +16,12 @@ pub struct NetworkMetrics {
 
 impl Default for NetworkMetrics {
     fn default() -> Self {
-        Self::new(&NoMetrics, std::iter::empty())
+        Self::new("default", &NoMetrics, std::iter::empty())
     }
 }
 
 impl NetworkMetrics {
-    pub fn new<M: Metrics, P>(m: &M, parties: P) -> Self
+    pub fn new<M: Metrics, P>(label: &str, m: &M, parties: P) -> Self
     where
         P: IntoIterator<Item = PublicKey>,
     {
@@ -43,14 +43,18 @@ impl NetworkMetrics {
         ];
 
         Self {
-            latency: m.create_histogram("latency", Some("ms"), Some(latencies)),
-            connections: m.create_gauge("connections", None),
-            sent_message_len: m.create_histogram("sent_msg_len", Some("bytes"), Some(sizes)),
-            sent: m.create_counter("messages_sent", None),
-            received: m.create_counter("messages_received", None),
+            latency: m.create_histogram(&format!("{label}_latency"), Some("ms"), Some(latencies)),
+            connections: m.create_gauge(&format!("{label}_connections"), None),
+            sent_message_len: m.create_histogram(
+                &format!("{label}_sent_msg_len"),
+                Some("bytes"),
+                Some(sizes),
+            ),
+            sent: m.create_counter(&format!("{label}_messages_sent"), None),
+            received: m.create_counter(&format!("{label}_messages_received"), None),
             connects: parties
                 .into_iter()
-                .map(|k| (k, m.create_counter(&format!("peer_id_{k}"), None)))
+                .map(|k| (k, m.create_counter(&format!("{label}_peer_id_{k}"), None)))
                 .collect(),
         }
     }

--- a/cliquenet/tests/frame-handling.rs
+++ b/cliquenet/tests/frame-handling.rs
@@ -26,6 +26,7 @@ async fn multiple_frames() {
 
     let mut net_a = Overlay::new(
         Network::create(
+            "f1",
             all_parties[0].1,
             party_a,
             all_parties,
@@ -36,6 +37,7 @@ async fn multiple_frames() {
     );
     let mut net_b = Overlay::new(
         Network::create(
+            "f2",
             all_parties[1].1,
             party_b,
             all_parties,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,23 +4,15 @@ services:
     command:
       [
         "/app/timeboost",
-        "--id",
-        "0",
-        "--sailfish-addr",
-        "0.0.0.0:8000",
-        "--decrypt-addr",
-        "0.0.0.0:10000",
-        "--producer-addr",
-        "0.0.0.0:11000",
-        "--rpc-port",
-        "8800",
-        "--metrics-port",
-        "9000",
-        "--keyset-file",
-        "docker.json",
-         "--stamp",
-        "/tmp/stamp",
-        "--ignore-stamp"
+        "--id", "0",
+        "--nodes", "5",
+        "--sailfish-addr", "0.0.0.0:8000",
+        "--decrypt-addr", "0.0.0.0:8001",
+        "--producer-addr", "0.0.0.0:8002",
+        "--rpc-port", "8800",
+        "--metrics-port", "9000",
+        "--keyset-file", "docker.json",
+        "--stamp", "/tmp/timeboost.stamp"
       ]
     networks:
       timeboost:
@@ -28,184 +20,148 @@ services:
     environment:
       - RUST_LOG=timeboost=info,sailfish=info,cliquenet=info
       - TIMEBOOST_SAILFISH_PORT=8000
-      - TIMEBOOST_DECRYPT_PORT=10000
-      - TIMEBOOST_PRODUCER_PORT=11000
       - TIMEBOOST_RPC_PORT=8800
       - TIMEBOOST_METRICS_PORT=9000
       - TIMEBOOST_SIGNATURE_PRIVATE_KEY=$TIMEBOOST_DEMO_SIGNATURE_PRIVATE_KEY_0
       - TIMEBOOST_DECRYPTION_PRIVATE_KEY=$TIMEBOOST_DEMO_DECRYPTION_PRIVATE_KEY_0
     ports:
       - "8000:8000"
+      - "8030:8001"
+      - "8060:8002"
       - "8800:8800"
       - "9000:9000"
-      - "10000:10000"
-      - "11000:11000"
   node1:
     image: timeboost:latest
     command:
       [
         "/app/timeboost",
-        "--id",
-        "1",
-        "--sailfish-addr",
-        "0.0.0.0:8001",
-        "--decrypt-addr",
-        "0.0.0.0:10001",
-        "--producer-addr",
-        "0.0.0.0:11001",
-        "--rpc-port",
-        "8801",
-        "--metrics-port",
-        "9001",
-        "--keyset-file",
-        "docker.json",
-        "--stamp",
-        "/tmp/stamp",
-        "--ignore-stamp"
+        "--id", "1",
+        "--nodes", "5",
+        "--sailfish-addr", "0.0.0.0:8000",
+        "--decrypt-addr", "0.0.0.0:8001",
+        "--producer-addr", "0.0.0.0:8002",
+        "--rpc-port", "8800",
+        "--metrics-port", "9000",
+        "--keyset-file", "docker.json",
+        "--stamp", "/tmp/timeboost.stamp"
       ]
     networks:
       timeboost:
         ipv4_address: 172.20.0.3
     environment:
       - RUST_LOG=timeboost=info,sailfish=info,cliquenet=info
-      - TIMEBOOST_SAILFISH_PORT=8001
-      - TIMEBOOST_DECRYPT_PORT=10001
-      - TIMEBOOST_PRODUCER_PORT=11001
-      - TIMEBOOST_RPC_PORT=8801
-      - TIMEBOOST_METRICS_PORT=9001
+      - TIMEBOOST_SAILFISH_PORT=8000
+      - TIMEBOOST_DECRYPT_PORT=8001
+      - TIMEBOOST_PRODUCER_PORT=8002
+      - TIMEBOOST_RPC_PORT=8800
+      - TIMEBOOST_METRICS_PORT=9000
       - TIMEBOOST_SIGNATURE_PRIVATE_KEY=$TIMEBOOST_DEMO_SIGNATURE_PRIVATE_KEY_1
       - TIMEBOOST_DECRYPTION_PRIVATE_KEY=$TIMEBOOST_DEMO_DECRYPTION_PRIVATE_KEY_1
     ports:
-      - "8001:8001"
-      - "8801:8801"
-      - "9001:9001"
-      - "10001:10001"
-      - "11001:11001"
+      - "8001:8000"
+      - "8031:8001"
+      - "8061:8002"
+      - "8801:8800"
+      - "9001:9000"
   node2:
     image: timeboost:latest
     command:
       [
         "/app/timeboost",
-        "--id",
-        "2",
-        "--sailfish-addr",
-        "0.0.0.0:8002",
-        "--decrypt-addr",
-        "0.0.0.0:10002",
-        "--producer-addr",
-        "0.0.0.0:11002",
-        "--rpc-port",
-        "8802",
-        "--metrics-port",
-        "9002",
-        "--keyset-file",
-        "docker.json",
-        "--stamp",
-        "/tmp/stamp",
-        "--ignore-stamp"
+        "--id", "2",
+        "--nodes", "5",
+        "--sailfish-addr", "0.0.0.0:8000",
+        "--decrypt-addr", "0.0.0.0:8001",
+        "--producer-addr", "0.0.0.0:8002",
+        "--rpc-port", "8800",
+        "--metrics-port", "9000",
+        "--keyset-file", "docker.json",
+        "--stamp", "/tmp/timeboost.stamp"
       ]
     networks:
       timeboost:
         ipv4_address: 172.20.0.4
     environment:
       - RUST_LOG=timeboost=info,sailfish=info,cliquenet=info
-      - TIMEBOOST_SAILFISH_PORT=8002
-      - TIMEBOOST_DECRYPT_PORT=10002
-      - TIMEBOOST_PRODUCER_PORT=11002
-      - TIMEBOOST_RPC_PORT=8802
-      - TIMEBOOST_METRICS_PORT=9002
+      - TIMEBOOST_SAILFISH_PORT=8000
+      - TIMEBOOST_DECRYPT_PORT=8001
+      - TIMEBOOST_PRODUCER_PORT=8002
+      - TIMEBOOST_RPC_PORT=8800
+      - TIMEBOOST_METRICS_PORT=9000
       - TIMEBOOST_SIGNATURE_PRIVATE_KEY=$TIMEBOOST_DEMO_SIGNATURE_PRIVATE_KEY_2
       - TIMEBOOST_DECRYPTION_PRIVATE_KEY=$TIMEBOOST_DEMO_DECRYPTION_PRIVATE_KEY_2
     ports:
-      - "8002:8002"
-      - "8802:8802"
-      - "9002:9002"
-      - "10002:10002"
-      - "11002:11002"
+      - "8002:8000"
+      - "8032:8001"
+      - "8062:8002"
+      - "8802:8800"
+      - "9002:9000"
   node3:
     image: timeboost:latest
     command:
       [
         "/app/timeboost",
-        "--id",
-        "3",
-        "--sailfish-addr",
-        "0.0.0.0:8003",
-        "--decrypt-addr",
-        "0.0.0.0:10003",
-        "--producer-addr",
-        "0.0.0.0:11003",
-        "--rpc-port",
-        "8803",
-        "--metrics-port",
-        "9003",
-        "--keyset-file",
-        "docker.json",
-        "--stamp",
-        "/tmp/stamp",
-        "--ignore-stamp"
+        "--id", "3",
+        "--nodes", "5",
+        "--sailfish-addr", "0.0.0.0:8000",
+        "--decrypt-addr", "0.0.0.0:8001",
+        "--producer-addr", "0.0.0.0:8002",
+        "--rpc-port", "8800",
+        "--metrics-port", "9000",
+        "--keyset-file", "docker.json",
+        "--stamp", "/tmp/timeboost.stamp"
       ]
     networks:
       timeboost:
         ipv4_address: 172.20.0.5
     environment:
       - RUST_LOG=timeboost=info,sailfish=info,cliquenet=info
-      - TIMEBOOST_SAILFISH_PORT=8003
-      - TIMEBOOST_DECRYPT_PORT=10003
-      - TIMEBOOST_PRODUCER_PORT=11003
-      - TIMEBOOST_RPC_PORT=8803
-      - TIMEBOOST_METRICS_PORT=9003
+      - TIMEBOOST_SAILFISH_PORT=8000
+      - TIMEBOOST_DECRYPT_PORT=8001
+      - TIMEBOOST_PRODUCER_PORT=8002
+      - TIMEBOOST_RPC_PORT=8800
+      - TIMEBOOST_METRICS_PORT=9000
       - TIMEBOOST_SIGNATURE_PRIVATE_KEY=$TIMEBOOST_DEMO_SIGNATURE_PRIVATE_KEY_3
       - TIMEBOOST_DECRYPTION_PRIVATE_KEY=$TIMEBOOST_DEMO_DECRYPTION_PRIVATE_KEY_3
     ports:
-      - "8003:8003"
-      - "8803:8803"
-      - "9003:9003"
-      - "10003:10003"
-      - "11003:11003"
-
+      - "8003:8000"
+      - "8033:8001"
+      - "8063:8002"
+      - "8803:8800"
+      - "9003:9000"
   node4:
     image: timeboost:latest
     command:
       [
         "/app/timeboost",
-        "--id",
-        "4",
-        "--sailfish-addr",
-        "0.0.0.0:8004",
-        "--decrypt-addr",
-        "0.0.0.0:10004",
-        "--producer-addr",
-        "0.0.0.0:11004",
-        "--rpc-port",
-        "8804",
-        "--metrics-port",
-        "9004",
-        "--keyset-file",
-        "docker.json",
-        "--stamp",
-        "/tmp/stamp",
-        "--ignore-stamp"
+        "--id", "4",
+        "--nodes", "5",
+        "--sailfish-addr", "0.0.0.0:8000",
+        "--decrypt-addr", "0.0.0.0:8001",
+        "--producer-addr", "0.0.0.0:8002",
+        "--rpc-port", "8800",
+        "--metrics-port", "9000",
+        "--keyset-file", "docker.json",
+        "--stamp", "/tmp/timeboost.stamp"
       ]
     networks:
       timeboost:
         ipv4_address: 172.20.0.6
     environment:
       - RUST_LOG=timeboost=info,sailfish=info,cliquenet=info
-      - TIMEBOOST_SAILFISH_PORT=8004
-      - TIMEBOOST_DECRYPT_PORT=10004
-      - TIMEBOOST_PRODUCER_PORT=11004
-      - TIMEBOOST_RPC_PORT=8804
-      - TIMEBOOST_METRICS_PORT=9004
+      - TIMEBOOST_SAILFISH_PORT=8000
+      - TIMEBOOST_DECRYPT_PORT=8001
+      - TIMEBOOST_PRODUCER_PORT=8002
+      - TIMEBOOST_RPC_PORT=8800
+      - TIMEBOOST_METRICS_PORT=9000
       - TIMEBOOST_SIGNATURE_PRIVATE_KEY=$TIMEBOOST_DEMO_SIGNATURE_PRIVATE_KEY_4
       - TIMEBOOST_DECRYPTION_PRIVATE_KEY=$TIMEBOOST_DEMO_DECRYPTION_PRIVATE_KEY_4
-
     ports:
-      - "8004:8004"
-      - "8804:8804"
-      - "9004:9004"
-      - "10004:10004"
-      - "11004:11004"
+      - "8004:8000"
+      - "8034:8001"
+      - "8064:8002"
+      - "8804:8800"
+      - "9004:9000"
   nitro-dev:
     image: offchainlabs/nitro-node:v3.2.1-d81324d
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,21 +6,30 @@ services:
         "/app/timeboost",
         "--id",
         "0",
-        "--port",
-        "8000",
+        "--sailfish-addr",
+        "0.0.0.0:8000",
+        "--decrypt-addr",
+        "0.0.0.0:10000",
+        "--producer-addr",
+        "0.0.0.0:11000",
         "--rpc-port",
         "8800",
         "--metrics-port",
         "9000",
         "--keyset-file",
         "docker.json",
+         "--stamp",
+        "/tmp/stamp",
+        "--ignore-stamp"
       ]
     networks:
       timeboost:
         ipv4_address: 172.20.0.2
     environment:
       - RUST_LOG=timeboost=info,sailfish=info,cliquenet=info
-      - TIMEBOOST_PORT=8000
+      - TIMEBOOST_SAILFISH_PORT=8000
+      - TIMEBOOST_DECRYPT_PORT=10000
+      - TIMEBOOST_PRODUCER_PORT=11000
       - TIMEBOOST_RPC_PORT=8800
       - TIMEBOOST_METRICS_PORT=9000
       - TIMEBOOST_SIGNATURE_PRIVATE_KEY=$TIMEBOOST_DEMO_SIGNATURE_PRIVATE_KEY_0
@@ -29,6 +38,8 @@ services:
       - "8000:8000"
       - "8800:8800"
       - "9000:9000"
+      - "10000:10000"
+      - "11000:11000"
   node1:
     image: timeboost:latest
     command:
@@ -36,21 +47,30 @@ services:
         "/app/timeboost",
         "--id",
         "1",
-        "--port",
-        "8001",
+        "--sailfish-addr",
+        "0.0.0.0:8001",
+        "--decrypt-addr",
+        "0.0.0.0:10001",
+        "--producer-addr",
+        "0.0.0.0:11001",
         "--rpc-port",
         "8801",
         "--metrics-port",
         "9001",
         "--keyset-file",
         "docker.json",
+        "--stamp",
+        "/tmp/stamp",
+        "--ignore-stamp"
       ]
     networks:
       timeboost:
         ipv4_address: 172.20.0.3
     environment:
       - RUST_LOG=timeboost=info,sailfish=info,cliquenet=info
-      - TIMEBOOST_PORT=8001
+      - TIMEBOOST_SAILFISH_PORT=8001
+      - TIMEBOOST_DECRYPT_PORT=10001
+      - TIMEBOOST_PRODUCER_PORT=11001
       - TIMEBOOST_RPC_PORT=8801
       - TIMEBOOST_METRICS_PORT=9001
       - TIMEBOOST_SIGNATURE_PRIVATE_KEY=$TIMEBOOST_DEMO_SIGNATURE_PRIVATE_KEY_1
@@ -59,6 +79,8 @@ services:
       - "8001:8001"
       - "8801:8801"
       - "9001:9001"
+      - "10001:10001"
+      - "11001:11001"
   node2:
     image: timeboost:latest
     command:
@@ -66,21 +88,30 @@ services:
         "/app/timeboost",
         "--id",
         "2",
-        "--port",
-        "8002",
+        "--sailfish-addr",
+        "0.0.0.0:8002",
+        "--decrypt-addr",
+        "0.0.0.0:10002",
+        "--producer-addr",
+        "0.0.0.0:11002",
         "--rpc-port",
         "8802",
         "--metrics-port",
         "9002",
         "--keyset-file",
         "docker.json",
+        "--stamp",
+        "/tmp/stamp",
+        "--ignore-stamp"
       ]
     networks:
       timeboost:
         ipv4_address: 172.20.0.4
     environment:
       - RUST_LOG=timeboost=info,sailfish=info,cliquenet=info
-      - TIMEBOOST_PORT=8002
+      - TIMEBOOST_SAILFISH_PORT=8002
+      - TIMEBOOST_DECRYPT_PORT=10002
+      - TIMEBOOST_PRODUCER_PORT=11002
       - TIMEBOOST_RPC_PORT=8802
       - TIMEBOOST_METRICS_PORT=9002
       - TIMEBOOST_SIGNATURE_PRIVATE_KEY=$TIMEBOOST_DEMO_SIGNATURE_PRIVATE_KEY_2
@@ -89,6 +120,8 @@ services:
       - "8002:8002"
       - "8802:8802"
       - "9002:9002"
+      - "10002:10002"
+      - "11002:11002"
   node3:
     image: timeboost:latest
     command:
@@ -96,21 +129,30 @@ services:
         "/app/timeboost",
         "--id",
         "3",
-        "--port",
-        "8003",
+        "--sailfish-addr",
+        "0.0.0.0:8003",
+        "--decrypt-addr",
+        "0.0.0.0:10003",
+        "--producer-addr",
+        "0.0.0.0:11003",
         "--rpc-port",
         "8803",
         "--metrics-port",
         "9003",
         "--keyset-file",
         "docker.json",
+        "--stamp",
+        "/tmp/stamp",
+        "--ignore-stamp"
       ]
     networks:
       timeboost:
         ipv4_address: 172.20.0.5
     environment:
       - RUST_LOG=timeboost=info,sailfish=info,cliquenet=info
-      - TIMEBOOST_PORT=8003
+      - TIMEBOOST_SAILFISH_PORT=8003
+      - TIMEBOOST_DECRYPT_PORT=10003
+      - TIMEBOOST_PRODUCER_PORT=11003
       - TIMEBOOST_RPC_PORT=8803
       - TIMEBOOST_METRICS_PORT=9003
       - TIMEBOOST_SIGNATURE_PRIVATE_KEY=$TIMEBOOST_DEMO_SIGNATURE_PRIVATE_KEY_3
@@ -119,6 +161,8 @@ services:
       - "8003:8003"
       - "8803:8803"
       - "9003:9003"
+      - "10003:10003"
+      - "11003:11003"
 
   node4:
     image: timeboost:latest
@@ -127,21 +171,30 @@ services:
         "/app/timeboost",
         "--id",
         "4",
-        "--port",
-        "8004",
+        "--sailfish-addr",
+        "0.0.0.0:8004",
+        "--decrypt-addr",
+        "0.0.0.0:10004",
+        "--producer-addr",
+        "0.0.0.0:11004",
         "--rpc-port",
         "8804",
         "--metrics-port",
         "9004",
         "--keyset-file",
         "docker.json",
+        "--stamp",
+        "/tmp/stamp",
+        "--ignore-stamp"
       ]
     networks:
       timeboost:
         ipv4_address: 172.20.0.6
     environment:
       - RUST_LOG=timeboost=info,sailfish=info,cliquenet=info
-      - TIMEBOOST_PORT=8004
+      - TIMEBOOST_SAILFISH_PORT=8004
+      - TIMEBOOST_DECRYPT_PORT=10004
+      - TIMEBOOST_PRODUCER_PORT=11004
       - TIMEBOOST_RPC_PORT=8804
       - TIMEBOOST_METRICS_PORT=9004
       - TIMEBOOST_SIGNATURE_PRIVATE_KEY=$TIMEBOOST_DEMO_SIGNATURE_PRIVATE_KEY_4
@@ -151,6 +204,8 @@ services:
       - "8004:8004"
       - "8804:8804"
       - "9004:9004"
+      - "10004:10004"
+      - "11004:11004"
   nitro-dev:
     image: offchainlabs/nitro-node:v3.2.1-d81324d
     ports:

--- a/docker/timeboost.Dockerfile
+++ b/docker/timeboost.Dockerfile
@@ -5,9 +5,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN cargo install just
-
-RUN just build_release
+RUN cargo build --release --bin timeboost
 
 # Non-root app container stage
 FROM debian:bullseye-slim
@@ -17,15 +15,12 @@ WORKDIR /app
 # Create non-root user and group
 RUN groupadd -r appgroup && useradd -r -g appgroup timeboostuser
 
-# Copy binary and just
+# Copy binary
 COPY --from=builder /app/target/release/timeboost .
 COPY --from=builder /app/test-configs .
 
 # Set ownership of application files and make binary executable
 RUN chown -R timeboostuser:appgroup /app && chmod +x /app/timeboost
-
-# We need curl for the healthcheck
-RUN apt update && apt install -yqq curl
 
 # Switch to non-root user
 USER timeboostuser
@@ -33,7 +28,9 @@ USER timeboostuser
 # Set the log level to debug by default
 ENV RUST_LOG=${RUST_LOG:-sailfish=debug,timeboost=debug,cliquenet=error}
 
-EXPOSE ${TIMEBOOST_PORT}
+EXPOSE ${TIMEBOOST_SAILFISH_PORT}
+EXPOSE ${TIMEBOOST_DECRYPT_PORT}
+EXPOSE ${TIMEBOOST_PRODUCER_PORT}
 EXPOSE ${TIMEBOOST_RPC_PORT}
 EXPOSE ${TIMEBOOST_METRICS_PORT}
 

--- a/justfile
+++ b/justfile
@@ -88,7 +88,7 @@ test *ARGS:
   @if [ "{{ARGS}}" == "" ]; then cargo test --doc; fi
 
 test_ci *ARGS:
-  env {{LOG_LEVELS}} NO_COLOR=1 cargo nextest run --workspace --retries 3 {{ARGS}}
+  env {{LOG_LEVELS}} NO_COLOR=1 cargo nextest run --workspace {{ARGS}}
   env {{LOG_LEVELS}} NO_COLOR=1 cargo test --doc {{ARGS}}
 
 test-individually:

--- a/scripts/run-timeboost-demo
+++ b/scripts/run-timeboost-demo
@@ -68,7 +68,9 @@ for i in $(seq 0 $((nodes - 1))); do
     TIMEBOOST_DECRYPTION_PRIVATE_KEY=${!DECRYPTION_PRIVATE_KEY} \
     ./target/release/timeboost \
         --id $i \
-        --port $((8000 + $i)) \
+        --sailfish-addr \"0.0.0.0:$((8000 + $i))\"
+        --decrypt-addr \"0.0.0.0:$((9500 + $i))\"
+        --producer-addr \"0.0.0.0:$((10000 + $i))\"
         --rpc-port $((8800 + $i)) \
         --metrics-port $((9000 + $i)) \
         --until 300 \

--- a/scripts/run-timeboost-demo
+++ b/scripts/run-timeboost-demo
@@ -69,8 +69,8 @@ for i in $(seq 0 $((nodes - 1))); do
     ./target/release/timeboost \
         --id $i \
         --sailfish-addr \"0.0.0.0:$((8000 + $i))\"
-        --decrypt-addr \"0.0.0.0:$((9500 + $i))\"
-        --producer-addr \"0.0.0.0:$((10000 + $i))\"
+        --decrypt-addr \"0.0.0.0:$((10000 + $i))\"
+        --producer-addr \"0.0.0.0:$((11000 + $i))\"
         --rpc-port $((8800 + $i)) \
         --metrics-port $((9000 + $i)) \
         --until 300 \

--- a/scripts/runit
+++ b/scripts/runit
@@ -87,7 +87,9 @@ for (( i=0; i<$nodes; i++ )); do
     dec_priv_key="TIMEBOOST_DEMO_DECRYPTION_PRIVATE_KEY_$i"
     cmd=(target/release/timeboost
         --id $i
-        --port $((8000 + $i))
+        --sailfish-addr "127.0.0.1:$((8000 + $i))"
+        --decrypt-addr "127.0.0.1:$((9500 + $i))"
+        --producer-addr "127.0.0.1:$((10000 + $i))"
         --rpc-port $((8800 + $i))
         --metrics-port $((9000 + $i))
         --until $rounds

--- a/scripts/runit
+++ b/scripts/runit
@@ -88,8 +88,8 @@ for (( i=0; i<$nodes; i++ )); do
     cmd=(target/release/timeboost
         --id $i
         --sailfish-addr "127.0.0.1:$((8000 + $i))"
-        --decrypt-addr "127.0.0.1:$((9500 + $i))"
-        --producer-addr "127.0.0.1:$((10000 + $i))"
+        --decrypt-addr "127.0.0.1:$((10000 + $i))"
+        --producer-addr "127.0.0.1:$((11000 + $i))"
         --rpc-port $((8800 + $i))
         --metrics-port $((9000 + $i))
         --until $rounds

--- a/test-configs/cloud_multi.json
+++ b/test-configs/cloud_multi.json
@@ -1,121 +1,161 @@
 {
     "keyset": [
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8000",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8000",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10000",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11000",
             "pubkey": "HCVAkbpaXjt4NqHem1Qz2mHqKRbGFCHUf4VMbiB7jAYE",
             "sig_pk": "24f9BtAxuZziE4BWMYA6FvyBuedxU9SVsgsoVcyw3aEWagH8eXsV6zi2jLnSvRVjpZkf79HDJNicXSF6FpRWkCXg",
             "dec_pk": "j3XAf69dZ6PN58ancTgfX1LCX35km7eUNGnYFV7GyHqUJT"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8001",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8001",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10001",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11001",
             "pubkey": "6v8B9RK6Noa6SX8rE6RXK972v6KFfVaLjC5sbCT9VoJn",
             "sig_pk": "2gtHurFq5yeJ8HGD5mHUPqniHbpEE83ELLpPqhxEvKhPJFcjMnUwdH2YsdhngMmQTqHo9B1Qna6uM13ug2Pir97k",
             "dec_pk": "jLKYA3vULHfFmF5bSDxqyyAvEFLTB7PeCpoyaeWeZCvhRz"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8002",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8002",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10002",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11002",
             "pubkey": "7MMmoPcqd8DnqD5Ji1xNUgkvkCtNoFEHwRPuYBqeF8Ni",
             "sig_pk": "4Y7yyg11MBYJaeD2UWCh5cto8wizJoUCqFm7YjMbY3hXyWSWVPgi7y1D9e7D78a1NcWdE4k59D6vK9f6eCpzVkbQ",
             "dec_pk": "k5iait3tEdnSQaTa4ziLK34qGchx4QJf9ZcvkU92zZm1Ud"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8003",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8003",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10003",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11003",
             "pubkey": "EofyDbHJGLFNG8D1J6xKj9XpSfooKTim982RU726Qnn4",
             "sig_pk": "zrjZDknq9nPhiBXKeG2PeotwxAayYkv2UFmxc2UsCGHsdu5vCsjqxn8ko2Rh2fWts76u6eCJYjDgKEaveutVhjW",
             "dec_pk": "jDTVzaaC872g4mYJ1GTPppb5kkiriza2wTKULgTtr8smKY"
         },
         {
-            "url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:8004",
+            "sailfish_url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:8004",
+            "decrypt_url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:10004",
+            "producer_url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:11004",
             "pubkey": "86R3D2VHNUTN1eNS1SiPQiegDs88PKUewqc1zizH6vVD",
             "sig_pk": "jW98dJM94zuvhRCA1bGLiPjakePTc1CYPP2V5iCswfayZiYujGYdSoE1MYDa61dHCyzPdEvGNBDmnFHS6jf83Km",
             "dec_pk": "kGRPGBJAtH7FVhLJF3LgZXvjJBwxXDVuyFa739yQu3cQNo"
         },
         {
-            "url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:8005",
+            "sailfish_url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:8005",
+            "decrypt_url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:10005",
+            "producer_url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:11005",
             "pubkey": "24pdM4mDRSHnk5d7uzztwmCT3e8jzYTafGMTVUmsYvEU",
             "sig_pk": "ijaVc89vBQ4GELRMcstZamxpYUbXdt4PvfkfzWTwKUsqL88M5Abt2TnX3c9URrQ4LmZMNtzd1WzoC5BSmDNscCp",
             "dec_pk": "jppK4wUHDKapUCoWXZiogJ9HmppDPG7LBsVD82GD4RQWeQ"
         },
         {
-            "url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:8006",
+            "sailfish_url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:8006",
+            "decrypt_url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:10006",
+            "producer_url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:11006",
             "pubkey": "HTuCvHG1CADdKsuLSZ1TWBL9QmFAXGWdgzmbBtYMWM2G",
             "sig_pk": "EDtsvA2haRC8mnSmcf2dsjCBq2vXT2Tru6uNR45kMwvMBLQ6HVL3XP985WcVQCfduNgeMi23QEZfSKkMDZu599r",
             "dec_pk": "k1kweWkWi2ZKSaKpgxczM2o6mKFViZz2rxNjk8zATafHyP"
         },
         {
-            "url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:8007",
+            "sailfish_url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:8007",
+            "decrypt_url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:10007",
+            "producer_url": "timeboost-lb-0d364c185da81754.elb.us-west-2.amazonaws.com:11007",
             "pubkey": "G9SsebpexnFLMqWkzCBDVKhPHHn8JdsFq6PgQAFBTXfP",
             "sig_pk": "4X3NnCJXbA8qSL6EeTm2atTKfos9WsPGETdqPvR9igt9KsXkqWC9WZkqpV9MsMPtdZsrtNeTu73VxGjbmL8uaC17",
             "dec_pk": "ji43FKt1iarZZXdvu2EvJTanXvJzrqbBScPpevzCjRKaW2"
         },
         {
-            "url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:8008",
+            "sailfish_url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:8008",
+            "decrypt_url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:10008",
+            "producer_url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:11008",
             "pubkey": "47P5dRX6aHpw17zjkXPXWVyy5aaUBc1CCT2ukM1RSAcy",
             "sig_pk": "Tr38rPDWZhzGxGvU1TFHXUfTLLzJJ4ZUVeLChWBZBuiL3zBNcpA4hhV6bwD5o8KDwqRYhXrQMBaqAmFmyQf6HaH",
             "dec_pk": "jTyChK47ysDarEAUsNq43srvbZWbG2bJCHFgAEFXLq6PkB"
         },
         {
-            "url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:8009",
+            "sailfish_url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:8009",
+            "decrypt_url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:10009",
+            "producer_url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:11009",
             "pubkey": "DNFTMMt6CCAponjhLdHJMdEhPteVXTXPbT1gC125Vfg6",
             "sig_pk": "2w9mvYRetk3rNq6aMiouZfvrsX1tbwvbdGoZVhFyTPudeS2zAN2wahspvRHDGFRwTHqaX87itY2qyQqyYSxCnKMC",
             "dec_pk": "kBkpi7XrEigAZ6tm3bREZ9tGb2AXL4h7ceNL4mfaGES7yi"
         },
         {
-            "url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:8010",
+            "sailfish_url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:8010",
+            "decrypt_url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:10010",
+            "producer_url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:11010",
             "pubkey": "2TpRWBrURjjCDEMTdoF2hicyhKUT7M39W6oxNzp99chd",
             "sig_pk": "53VLuybEeX9cASQFv2cKjGH2J4esvRYXMHwBDpXw3S5YAKViUnbHPGjMQca1MmMAqdGXnTLypumtxNkXPtdREhGs",
             "dec_pk": "k3MqzGMbfm28SY6LiXR972atiodCRRzoCMDHYWteg8Rzy7"
         },
         {
-            "url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:8011",
+            "sailfish_url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:8011",
+            "decrypt_url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:10011",
+            "producer_url": "timeboost-lb-db5c0565e599345e.elb.eu-north-1.amazonaws.com:11011",
             "pubkey": "DGbaGsY2THd4oHxTKBRJBEurGKb9KgQeLFY13eMapinC",
             "sig_pk": "2KedEUxvFGruLjswMLqs693cwAzCZs5ABLk15igFDWTxo5wQsMCpdNdueBgM5EnnxyNMmkpYHwvx7j3RTyL7KSet",
             "dec_pk": "j1nqGwevuVtLFonHmsNqfxpdt6GopZX4xJ31UCfDjS5Wst"
         },
         {
-            "url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:8012",
+            "sailfish_url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:8012",
+            "decrypt_url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:10012",
+            "producer_url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:11012",
             "pubkey": "2x23JLWVwNbjNxM8snwKYUdKtoHgj7zN1gyPHbgsUazd",
             "sig_pk": "2BsrUMBJCEqLmhY9nh5y5bmd9TSPuD9D5pLCCDZVFgHjdDgKi6cgnzkMpMBVx78J8ibcn4CGaAzYttRUBWaAnpg1",
             "dec_pk": "jZdxHS4Zr7fkfoKphDzdSJi639KdyUkDWdVn1Ehanefnqy"
         },
         {
-            "url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:8013",
+            "sailfish_url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:8013",
+            "decrypt_url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:10013",
+            "producer_url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:11013",
             "pubkey": "CX51n5zs2kuQteiNRUVR25KZF9kA27UeWccFodfbLMWS",
             "sig_pk": "fkSkZs97mZsk9zdpmYvyjf9YdcwEX8fcYZhwWCd8gxvxBHvU2zLpX6pCMtevD5T76NXCkqbBBMWAbuKbUj2WYQi",
             "dec_pk": "izRcUhmMJtjy6AN3tovBLH6gsUjGQvnuNLfcsKAAAsmcDA"
         },
         {
-            "url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:8014",
+            "sailfish_url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:8014",
+            "decrypt_url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:10014",
+            "producer_url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:11014",
             "pubkey": "9owjFAaWhFcT9GqJ9c3idqndxHXcfyVPQrNnEvxG72Hs",
             "sig_pk": "58hqMbmozZPhKpDHek2PoSdnj1PRPgAA2CT8iUYNysWFVpg8MufpEvKdqHhFzp9diQB4zhsfw8tbgqYUMvSupUtd",
             "dec_pk": "jhHjyWcXWxumgfA7vic1juwPi5fYKyJxRUT1k1ccryYVq7"
         },
         {
-            "url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:8015",
+            "sailfish_url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:8015",
+            "decrypt_url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:10015",
+            "producer_url": "timeboost-lb-2ac74543b8da9a68.elb.ap-northeast-1.amazonaws.com:11015",
             "pubkey": "8jTeAaPGTxkPwrFkqTUj5fMP57BLLdeuLmwx2ZxvHdPt",
             "sig_pk": "14zvFYrD41HK8bw9gfP5Fs5LfNdFWziKHUaxyv95f4avhtYCEZo8Wg8QaUqdvm5T1ZpvrbD1XFUViNLgddFLQJ2",
             "dec_pk": "jLFzJnwKuC3KnXcZgepSZD2CLQnr21DfwA1zpt1L5dnHQJ"
         },
         {
-            "url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:8016",
+            "sailfish_url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:8016",
+            "decrypt_url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:10016",
+            "producer_url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:11016",
             "pubkey": "D4WziQyUH5TFGhu5f33wvRzhTatRFb5v9x1H58NWmRVJ",
             "sig_pk": "5HtH2r6mFn4F2ZSMySipA4dhEfxdu5MjuPeykWELgAZyZJ1F72ZLwTavjcNCCbYsGF6rMBvQLBQVTVr9ACRy4xnt",
             "dec_pk": "j6VXo1ik1Kf4ffMMctbrL1LRQo9FHr82DMb3BgsNHgxWjq"
         },
         {
-            "url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:8017",
+            "sailfish_url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:8017",
+            "decrypt_url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:10017",
+            "producer_url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:11017",
             "pubkey": "2iHXCZwkerF3JtWG4Q633dfjHnmruJ23hgKNATTsFFkZ",
             "sig_pk": "ro7W8TtXQzWDSwZcHGeTTThUauw2nkE8Syrivo8YEwfY1KDsuuo7db4EBHtiRMH8t7EEwZ2MCagAbUsKz2fkd2d",
             "dec_pk": "jjJ1ev6mFqC67FetREzeeSsSjTzqTGeNM7SHa1E6dFmRCt"
         },
         {
-            "url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:8018",
+            "sailfish_url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:8018",
+            "decrypt_url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:10018",
+            "producer_url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:11018",
             "pubkey": "5qP4wyDetRcVzQZs3qcxyafxXYowBTdcSVQJbHXcZsji",
             "sig_pk": "kCewFsRMYVPQ59rKCQUtEqjnrezJpZH82GqDYtwCZMWD35fgJhFV535YXrNzE1hLXgfXdD5o1DHsnvHwNwweLX6",
             "dec_pk": "kEaesywh1xhXjUe7fzYPnNHJo9i4kFwdN3paA569MpbuLu"
         },
         {
-            "url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:8019",
+            "sailfish_url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:8019",
+            "decrypt_url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:10019",
+            "producer_url": "timeboost-lb-58994ad767e6f67b.elb.ap-southeast-2.amazonaws.com:11019",
             "pubkey": "8ajJBphKsQHeWBLm1dzySBJPJcdt7aFS77sFDVUK5vE4",
             "sig_pk": "2dfAfFK4S92TyCdW7zTHtgKp3P9xTMP2T4csTtejo5uCW2w8bY83SYqWXXmW1czVKCscEmu2drJkaMj2ABoGdfwe",
             "dec_pk": "k1a2mXM3LhYGjUa3rzGg1zRYbDvDeWQ6TdkTWznBwFLWZg"

--- a/test-configs/cloud_single.json
+++ b/test-configs/cloud_single.json
@@ -1,121 +1,161 @@
 {
     "keyset": [
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8000",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8000",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10000",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11000",
             "pubkey": "HCVAkbpaXjt4NqHem1Qz2mHqKRbGFCHUf4VMbiB7jAYE",
             "sig_pk": "24f9BtAxuZziE4BWMYA6FvyBuedxU9SVsgsoVcyw3aEWagH8eXsV6zi2jLnSvRVjpZkf79HDJNicXSF6FpRWkCXg",
             "dec_pk": "j3XAf69dZ6PN58ancTgfX1LCX35km7eUNGnYFV7GyHqUJT"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8001",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8001",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10001",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11001",
             "pubkey": "6v8B9RK6Noa6SX8rE6RXK972v6KFfVaLjC5sbCT9VoJn",
             "sig_pk": "2gtHurFq5yeJ8HGD5mHUPqniHbpEE83ELLpPqhxEvKhPJFcjMnUwdH2YsdhngMmQTqHo9B1Qna6uM13ug2Pir97k",
             "dec_pk": "jLKYA3vULHfFmF5bSDxqyyAvEFLTB7PeCpoyaeWeZCvhRz"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8002",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8002",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10002",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11002",
             "pubkey": "7MMmoPcqd8DnqD5Ji1xNUgkvkCtNoFEHwRPuYBqeF8Ni",
             "sig_pk": "4Y7yyg11MBYJaeD2UWCh5cto8wizJoUCqFm7YjMbY3hXyWSWVPgi7y1D9e7D78a1NcWdE4k59D6vK9f6eCpzVkbQ",
             "dec_pk": "k5iait3tEdnSQaTa4ziLK34qGchx4QJf9ZcvkU92zZm1Ud"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8003",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8003",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10003",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11003",
             "pubkey": "EofyDbHJGLFNG8D1J6xKj9XpSfooKTim982RU726Qnn4",
             "sig_pk": "zrjZDknq9nPhiBXKeG2PeotwxAayYkv2UFmxc2UsCGHsdu5vCsjqxn8ko2Rh2fWts76u6eCJYjDgKEaveutVhjW",
             "dec_pk": "jDTVzaaC872g4mYJ1GTPppb5kkiriza2wTKULgTtr8smKY"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8004",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8004",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10004",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11004",
             "pubkey": "86R3D2VHNUTN1eNS1SiPQiegDs88PKUewqc1zizH6vVD",
             "sig_pk": "jW98dJM94zuvhRCA1bGLiPjakePTc1CYPP2V5iCswfayZiYujGYdSoE1MYDa61dHCyzPdEvGNBDmnFHS6jf83Km",
             "dec_pk": "kGRPGBJAtH7FVhLJF3LgZXvjJBwxXDVuyFa739yQu3cQNo"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8005",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8005",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10005",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11005",
             "pubkey": "24pdM4mDRSHnk5d7uzztwmCT3e8jzYTafGMTVUmsYvEU",
             "sig_pk": "ijaVc89vBQ4GELRMcstZamxpYUbXdt4PvfkfzWTwKUsqL88M5Abt2TnX3c9URrQ4LmZMNtzd1WzoC5BSmDNscCp",
             "dec_pk": "jppK4wUHDKapUCoWXZiogJ9HmppDPG7LBsVD82GD4RQWeQ"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8006",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8006",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10006",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11006",
             "pubkey": "HTuCvHG1CADdKsuLSZ1TWBL9QmFAXGWdgzmbBtYMWM2G",
             "sig_pk": "EDtsvA2haRC8mnSmcf2dsjCBq2vXT2Tru6uNR45kMwvMBLQ6HVL3XP985WcVQCfduNgeMi23QEZfSKkMDZu599r",
             "dec_pk": "k1kweWkWi2ZKSaKpgxczM2o6mKFViZz2rxNjk8zATafHyP"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8007",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8007",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10007",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11007",
             "pubkey": "G9SsebpexnFLMqWkzCBDVKhPHHn8JdsFq6PgQAFBTXfP",
             "sig_pk": "4X3NnCJXbA8qSL6EeTm2atTKfos9WsPGETdqPvR9igt9KsXkqWC9WZkqpV9MsMPtdZsrtNeTu73VxGjbmL8uaC17",
             "dec_pk": "ji43FKt1iarZZXdvu2EvJTanXvJzrqbBScPpevzCjRKaW2"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8008",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8008",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10008",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11008",
             "pubkey": "47P5dRX6aHpw17zjkXPXWVyy5aaUBc1CCT2ukM1RSAcy",
             "sig_pk": "Tr38rPDWZhzGxGvU1TFHXUfTLLzJJ4ZUVeLChWBZBuiL3zBNcpA4hhV6bwD5o8KDwqRYhXrQMBaqAmFmyQf6HaH",
             "dec_pk": "jTyChK47ysDarEAUsNq43srvbZWbG2bJCHFgAEFXLq6PkB"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8009",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8009",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10009",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11009",
             "pubkey": "DNFTMMt6CCAponjhLdHJMdEhPteVXTXPbT1gC125Vfg6",
             "sig_pk": "2w9mvYRetk3rNq6aMiouZfvrsX1tbwvbdGoZVhFyTPudeS2zAN2wahspvRHDGFRwTHqaX87itY2qyQqyYSxCnKMC",
             "dec_pk": "kBkpi7XrEigAZ6tm3bREZ9tGb2AXL4h7ceNL4mfaGES7yi"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8010",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8010",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10010",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11010",
             "pubkey": "2TpRWBrURjjCDEMTdoF2hicyhKUT7M39W6oxNzp99chd",
             "sig_pk": "53VLuybEeX9cASQFv2cKjGH2J4esvRYXMHwBDpXw3S5YAKViUnbHPGjMQca1MmMAqdGXnTLypumtxNkXPtdREhGs",
             "dec_pk": "k3MqzGMbfm28SY6LiXR972atiodCRRzoCMDHYWteg8Rzy7"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8011",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8011",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10011",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11011",
             "pubkey": "DGbaGsY2THd4oHxTKBRJBEurGKb9KgQeLFY13eMapinC",
             "sig_pk": "2KedEUxvFGruLjswMLqs693cwAzCZs5ABLk15igFDWTxo5wQsMCpdNdueBgM5EnnxyNMmkpYHwvx7j3RTyL7KSet",
             "dec_pk": "j1nqGwevuVtLFonHmsNqfxpdt6GopZX4xJ31UCfDjS5Wst"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8012",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8012",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10012",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11012",
             "pubkey": "2x23JLWVwNbjNxM8snwKYUdKtoHgj7zN1gyPHbgsUazd",
             "sig_pk": "2BsrUMBJCEqLmhY9nh5y5bmd9TSPuD9D5pLCCDZVFgHjdDgKi6cgnzkMpMBVx78J8ibcn4CGaAzYttRUBWaAnpg1",
             "dec_pk": "jZdxHS4Zr7fkfoKphDzdSJi639KdyUkDWdVn1Ehanefnqy"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8013",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8013",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10013",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11013",
             "pubkey": "CX51n5zs2kuQteiNRUVR25KZF9kA27UeWccFodfbLMWS",
             "sig_pk": "fkSkZs97mZsk9zdpmYvyjf9YdcwEX8fcYZhwWCd8gxvxBHvU2zLpX6pCMtevD5T76NXCkqbBBMWAbuKbUj2WYQi",
             "dec_pk": "izRcUhmMJtjy6AN3tovBLH6gsUjGQvnuNLfcsKAAAsmcDA"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8014",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8014",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10014",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11014",
             "pubkey": "9owjFAaWhFcT9GqJ9c3idqndxHXcfyVPQrNnEvxG72Hs",
             "sig_pk": "58hqMbmozZPhKpDHek2PoSdnj1PRPgAA2CT8iUYNysWFVpg8MufpEvKdqHhFzp9diQB4zhsfw8tbgqYUMvSupUtd",
             "dec_pk": "jhHjyWcXWxumgfA7vic1juwPi5fYKyJxRUT1k1ccryYVq7"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8015",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8015",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10015",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11015",
             "pubkey": "8jTeAaPGTxkPwrFkqTUj5fMP57BLLdeuLmwx2ZxvHdPt",
             "sig_pk": "14zvFYrD41HK8bw9gfP5Fs5LfNdFWziKHUaxyv95f4avhtYCEZo8Wg8QaUqdvm5T1ZpvrbD1XFUViNLgddFLQJ2",
             "dec_pk": "jLFzJnwKuC3KnXcZgepSZD2CLQnr21DfwA1zpt1L5dnHQJ"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8016",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8016",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10016",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11016",
             "pubkey": "D4WziQyUH5TFGhu5f33wvRzhTatRFb5v9x1H58NWmRVJ",
             "sig_pk": "5HtH2r6mFn4F2ZSMySipA4dhEfxdu5MjuPeykWELgAZyZJ1F72ZLwTavjcNCCbYsGF6rMBvQLBQVTVr9ACRy4xnt",
             "dec_pk": "j6VXo1ik1Kf4ffMMctbrL1LRQo9FHr82DMb3BgsNHgxWjq"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8017",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8017",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10017",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11017",
             "pubkey": "2iHXCZwkerF3JtWG4Q633dfjHnmruJ23hgKNATTsFFkZ",
             "sig_pk": "ro7W8TtXQzWDSwZcHGeTTThUauw2nkE8Syrivo8YEwfY1KDsuuo7db4EBHtiRMH8t7EEwZ2MCagAbUsKz2fkd2d",
             "dec_pk": "jjJ1ev6mFqC67FetREzeeSsSjTzqTGeNM7SHa1E6dFmRCt"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8018",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8018",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10018",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11018",
             "pubkey": "5qP4wyDetRcVzQZs3qcxyafxXYowBTdcSVQJbHXcZsji",
             "sig_pk": "kCewFsRMYVPQ59rKCQUtEqjnrezJpZH82GqDYtwCZMWD35fgJhFV535YXrNzE1hLXgfXdD5o1DHsnvHwNwweLX6",
             "dec_pk": "kEaesywh1xhXjUe7fzYPnNHJo9i4kFwdN3paA569MpbuLu"
         },
         {
-            "url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8019",
+            "sailfish_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:8019",
+            "decrypt_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:10019",
+            "producer_url": "timeboost-lb-50d346419d44f480.elb.us-east-2.amazonaws.com:11019",
             "pubkey": "8ajJBphKsQHeWBLm1dzySBJPJcdt7aFS77sFDVUK5vE4",
             "sig_pk": "2dfAfFK4S92TyCdW7zTHtgKp3P9xTMP2T4csTtejo5uCW2w8bY83SYqWXXmW1czVKCscEmu2drJkaMj2ABoGdfwe",
             "dec_pk": "k1a2mXM3LhYGjUa3rzGg1zRYbDvDeWQ6TdkTWznBwFLWZg"

--- a/test-configs/docker.json
+++ b/test-configs/docker.json
@@ -1,83 +1,123 @@
 {
     "keyset": [
         {
-            "url": "172.20.0.2:8000",
+            "sailfish_url": "172.20.0.2:8000",
+            "decrypt_url": "172.20.0.2:10000",
+            "producer_url": "172.20.0.2:11000",
             "pubkey": "HCVAkbpaXjt4NqHem1Qz2mHqKRbGFCHUf4VMbiB7jAYE"
         },
         {
-            "url": "172.20.0.3:8001",
+            "sailfish_url": "172.20.0.3:8001",
+            "decrypt_url": "172.20.0.3:10001",
+            "producer_url": "172.20.0.3:11001",
             "pubkey": "6v8B9RK6Noa6SX8rE6RXK972v6KFfVaLjC5sbCT9VoJn"
         },
         {
-            "url": "172.20.0.4:8002",
+            "sailfish_url": "172.20.0.4:8002",
+            "decrypt_url": "172.20.0.4:10002",
+            "producer_url": "172.20.0.4:11002",
             "pubkey": "7MMmoPcqd8DnqD5Ji1xNUgkvkCtNoFEHwRPuYBqeF8Ni"
         },
         {
-            "url": "172.20.0.5:8003",
+            "sailfish_url": "172.20.0.5:8003",
+            "decrypt_url": "172.20.0.5:10003",
+            "producer_url": "172.20.0.5:11003",
             "pubkey": "EofyDbHJGLFNG8D1J6xKj9XpSfooKTim982RU726Qnn4"
         },
         {
-            "url": "172.20.0.6:8004",
+            "sailfish_url": "172.20.0.6:8004",
+            "decrypt_url": "172.20.0.6:10004",
+            "producer_url": "172.20.0.6:11004",
             "pubkey": "86R3D2VHNUTN1eNS1SiPQiegDs88PKUewqc1zizH6vVD"
         },
         {
-            "url": "172.20.0.7:8005",
+            "sailfish_url": "172.20.0.7:8005",
+            "decrypt_url": "172.20.0.7:10005",
+            "producer_url": "172.20.0.7:11005",
             "pubkey": "24pdM4mDRSHnk5d7uzztwmCT3e8jzYTafGMTVUmsYvEU"
         },
         {
-            "url": "172.20.0.8:8006",
+            "sailfish_url": "172.20.0.8:8006",
+            "decrypt_url": "172.20.0.8:10006",
+            "producer_url": "172.20.0.8:11006",
             "pubkey": "HTuCvHG1CADdKsuLSZ1TWBL9QmFAXGWdgzmbBtYMWM2G"
         },
         {
-            "url": "172.20.0.9:8007",
+            "sailfish_url": "172.20.0.9:8007",
+            "decrypt_url": "172.20.0.9:10007",
+            "producer_url": "172.20.0.9:11007",
             "pubkey": "G9SsebpexnFLMqWkzCBDVKhPHHn8JdsFq6PgQAFBTXfP"
         },
         {
-            "url": "172.20.0.10:8008",
+            "sailfish_url": "172.20.0.10:8008",
+            "decrypt_url": "172.20.0.10:10008",
+            "producer_url": "172.20.0.10:11008",
             "pubkey": "47P5dRX6aHpw17zjkXPXWVyy5aaUBc1CCT2ukM1RSAcy"
         },
         {
-            "url": "172.20.0.11:8009",
+            "sailfish_url": "172.20.0.11:8009",
+            "decrypt_url": "172.20.0.11:10009",
+            "producer_url": "172.20.0.11:11009",
             "pubkey": "DNFTMMt6CCAponjhLdHJMdEhPteVXTXPbT1gC125Vfg6"
         },
         {
-            "url": "172.20.0.12:8010",
+            "sailfish_url": "172.20.0.12:8010",
+            "decrypt_url": "172.20.0.12:10010",
+            "producer_url": "172.20.0.12:11010",
             "pubkey": "2TpRWBrURjjCDEMTdoF2hicyhKUT7M39W6oxNzp99chd"
         },
         {
-            "url": "172.20.0.13:8011",
+            "sailfish_url": "172.20.0.13:8011",
+            "decrypt_url": "172.20.0.13:10011",
+            "producer_url": "172.20.0.13:11011",
             "pubkey": "DGbaGsY2THd4oHxTKBRJBEurGKb9KgQeLFY13eMapinC"
         },
         {
-            "url": "172.20.0.14:8012",
+            "sailfish_url": "172.20.0.14:8012",
+            "decrypt_url": "172.20.0.14:10012",
+            "producer_url": "172.20.0.14:11012",
             "pubkey": "2x23JLWVwNbjNxM8snwKYUdKtoHgj7zN1gyPHbgsUazd"
         },
         {
-            "url": "172.20.0.15:8013",
+            "sailfish_url": "172.20.0.15:8013",
+            "decrypt_url": "172.20.0.15:10013",
+            "producer_url": "172.20.0.15:11013",
             "pubkey": "CX51n5zs2kuQteiNRUVR25KZF9kA27UeWccFodfbLMWS"
         },
         {
-            "url": "172.20.0.16:8014",
+            "sailfish_url": "172.20.0.16:8014",
+            "decrypt_url": "172.20.0.16:10014",
+            "producer_url": "172.20.0.16:11014",
             "pubkey": "9owjFAaWhFcT9GqJ9c3idqndxHXcfyVPQrNnEvxG72Hs"
         },
         {
-            "url": "172.20.0.17:8015",
+            "sailfish_url": "172.20.0.17:8015",
+            "decrypt_url": "172.20.0.17:10015",
+            "producer_url": "172.20.0.17:11015",
             "pubkey": "8jTeAaPGTxkPwrFkqTUj5fMP57BLLdeuLmwx2ZxvHdPt"
         },
         {
-            "url": "172.20.0.18:8016",
+            "sailfish_url": "172.20.0.18:8016",
+            "decrypt_url": "172.20.0.18:10016",
+            "producer_url": "172.20.0.18:11016",
             "pubkey": "D4WziQyUH5TFGhu5f33wvRzhTatRFb5v9x1H58NWmRVJ"
         },
         {
-            "url": "172.20.0.19:8017",
+            "sailfish_url": "172.20.0.19:8017",
+            "decrypt_url": "172.20.0.19:10017",
+            "producer_url": "172.20.0.19:11017",
             "pubkey": "2iHXCZwkerF3JtWG4Q633dfjHnmruJ23hgKNATTsFFkZ"
         },
         {
-            "url": "172.20.0.20:8018",
+            "sailfish_url": "172.20.0.20:8018",
+            "decrypt_url": "172.20.0.20:10018",
+            "producer_url": "172.20.0.20:11018",
             "pubkey": "5qP4wyDetRcVzQZs3qcxyafxXYowBTdcSVQJbHXcZsji"
         },
         {
-            "url": "172.20.0.21:8019",
+            "sailfish_url": "172.20.0.21:8019",
+            "decrypt_url": "172.20.0.21:10019",
+            "producer_url": "172.20.0.21:11019",
             "pubkey": "8ajJBphKsQHeWBLm1dzySBJPJcdt7aFS77sFDVUK5vE4"
         }
     ],

--- a/test-configs/docker.json
+++ b/test-configs/docker.json
@@ -2,122 +2,122 @@
     "keyset": [
         {
             "sailfish_url": "172.20.0.2:8000",
-            "decrypt_url": "172.20.0.2:10000",
-            "producer_url": "172.20.0.2:11000",
+            "decrypt_url": "172.20.0.2:8001",
+            "producer_url": "172.20.0.2:8002",
             "pubkey": "HCVAkbpaXjt4NqHem1Qz2mHqKRbGFCHUf4VMbiB7jAYE"
         },
         {
-            "sailfish_url": "172.20.0.3:8001",
-            "decrypt_url": "172.20.0.3:10001",
-            "producer_url": "172.20.0.3:11001",
+            "sailfish_url": "172.20.0.3:8000",
+            "decrypt_url": "172.20.0.3:8001",
+            "producer_url": "172.20.0.3:8002",
             "pubkey": "6v8B9RK6Noa6SX8rE6RXK972v6KFfVaLjC5sbCT9VoJn"
         },
         {
-            "sailfish_url": "172.20.0.4:8002",
-            "decrypt_url": "172.20.0.4:10002",
-            "producer_url": "172.20.0.4:11002",
+            "sailfish_url": "172.20.0.4:8000",
+            "decrypt_url": "172.20.0.4:8001",
+            "producer_url": "172.20.0.4:8002",
             "pubkey": "7MMmoPcqd8DnqD5Ji1xNUgkvkCtNoFEHwRPuYBqeF8Ni"
         },
         {
-            "sailfish_url": "172.20.0.5:8003",
-            "decrypt_url": "172.20.0.5:10003",
-            "producer_url": "172.20.0.5:11003",
+            "sailfish_url": "172.20.0.5:8000",
+            "decrypt_url": "172.20.0.5:8001",
+            "producer_url": "172.20.0.5:8002",
             "pubkey": "EofyDbHJGLFNG8D1J6xKj9XpSfooKTim982RU726Qnn4"
         },
         {
-            "sailfish_url": "172.20.0.6:8004",
-            "decrypt_url": "172.20.0.6:10004",
-            "producer_url": "172.20.0.6:11004",
+            "sailfish_url": "172.20.0.6:8000",
+            "decrypt_url": "172.20.0.6:8001",
+            "producer_url": "172.20.0.6:8002",
             "pubkey": "86R3D2VHNUTN1eNS1SiPQiegDs88PKUewqc1zizH6vVD"
         },
         {
-            "sailfish_url": "172.20.0.7:8005",
-            "decrypt_url": "172.20.0.7:10005",
-            "producer_url": "172.20.0.7:11005",
+            "sailfish_url": "172.20.0.7:8000",
+            "decrypt_url": "172.20.0.7:8001",
+            "producer_url": "172.20.0.7:8002",
             "pubkey": "24pdM4mDRSHnk5d7uzztwmCT3e8jzYTafGMTVUmsYvEU"
         },
         {
-            "sailfish_url": "172.20.0.8:8006",
-            "decrypt_url": "172.20.0.8:10006",
-            "producer_url": "172.20.0.8:11006",
+            "sailfish_url": "172.20.0.8:8000",
+            "decrypt_url": "172.20.0.8:8001",
+            "producer_url": "172.20.0.8:8002",
             "pubkey": "HTuCvHG1CADdKsuLSZ1TWBL9QmFAXGWdgzmbBtYMWM2G"
         },
         {
-            "sailfish_url": "172.20.0.9:8007",
-            "decrypt_url": "172.20.0.9:10007",
-            "producer_url": "172.20.0.9:11007",
+            "sailfish_url": "172.20.0.9:8000",
+            "decrypt_url": "172.20.0.9:8001",
+            "producer_url": "172.20.0.9:8002",
             "pubkey": "G9SsebpexnFLMqWkzCBDVKhPHHn8JdsFq6PgQAFBTXfP"
         },
         {
-            "sailfish_url": "172.20.0.10:8008",
-            "decrypt_url": "172.20.0.10:10008",
-            "producer_url": "172.20.0.10:11008",
+            "sailfish_url": "172.20.0.10:8000",
+            "decrypt_url": "172.20.0.10:8001",
+            "producer_url": "172.20.0.10:8002",
             "pubkey": "47P5dRX6aHpw17zjkXPXWVyy5aaUBc1CCT2ukM1RSAcy"
         },
         {
-            "sailfish_url": "172.20.0.11:8009",
-            "decrypt_url": "172.20.0.11:10009",
-            "producer_url": "172.20.0.11:11009",
+            "sailfish_url": "172.20.0.11:8000",
+            "decrypt_url": "172.20.0.11:8001",
+            "producer_url": "172.20.0.11:8002",
             "pubkey": "DNFTMMt6CCAponjhLdHJMdEhPteVXTXPbT1gC125Vfg6"
         },
         {
-            "sailfish_url": "172.20.0.12:8010",
-            "decrypt_url": "172.20.0.12:10010",
-            "producer_url": "172.20.0.12:11010",
+            "sailfish_url": "172.20.0.12:8000",
+            "decrypt_url": "172.20.0.12:8001",
+            "producer_url": "172.20.0.12:8002",
             "pubkey": "2TpRWBrURjjCDEMTdoF2hicyhKUT7M39W6oxNzp99chd"
         },
         {
-            "sailfish_url": "172.20.0.13:8011",
-            "decrypt_url": "172.20.0.13:10011",
-            "producer_url": "172.20.0.13:11011",
+            "sailfish_url": "172.20.0.13:8000",
+            "decrypt_url": "172.20.0.13:8001",
+            "producer_url": "172.20.0.13:8002",
             "pubkey": "DGbaGsY2THd4oHxTKBRJBEurGKb9KgQeLFY13eMapinC"
         },
         {
-            "sailfish_url": "172.20.0.14:8012",
-            "decrypt_url": "172.20.0.14:10012",
-            "producer_url": "172.20.0.14:11012",
+            "sailfish_url": "172.20.0.14:8000",
+            "decrypt_url": "172.20.0.14:8001",
+            "producer_url": "172.20.0.14:8002",
             "pubkey": "2x23JLWVwNbjNxM8snwKYUdKtoHgj7zN1gyPHbgsUazd"
         },
         {
-            "sailfish_url": "172.20.0.15:8013",
-            "decrypt_url": "172.20.0.15:10013",
-            "producer_url": "172.20.0.15:11013",
+            "sailfish_url": "172.20.0.15:8000",
+            "decrypt_url": "172.20.0.15:8001",
+            "producer_url": "172.20.0.15:8002",
             "pubkey": "CX51n5zs2kuQteiNRUVR25KZF9kA27UeWccFodfbLMWS"
         },
         {
-            "sailfish_url": "172.20.0.16:8014",
-            "decrypt_url": "172.20.0.16:10014",
-            "producer_url": "172.20.0.16:11014",
+            "sailfish_url": "172.20.0.16:8000",
+            "decrypt_url": "172.20.0.16:8001",
+            "producer_url": "172.20.0.16:8002",
             "pubkey": "9owjFAaWhFcT9GqJ9c3idqndxHXcfyVPQrNnEvxG72Hs"
         },
         {
-            "sailfish_url": "172.20.0.17:8015",
-            "decrypt_url": "172.20.0.17:10015",
-            "producer_url": "172.20.0.17:11015",
+            "sailfish_url": "172.20.0.17:8000",
+            "decrypt_url": "172.20.0.17:8001",
+            "producer_url": "172.20.0.17:8002",
             "pubkey": "8jTeAaPGTxkPwrFkqTUj5fMP57BLLdeuLmwx2ZxvHdPt"
         },
         {
-            "sailfish_url": "172.20.0.18:8016",
-            "decrypt_url": "172.20.0.18:10016",
-            "producer_url": "172.20.0.18:11016",
+            "sailfish_url": "172.20.0.18:8000",
+            "decrypt_url": "172.20.0.18:8001",
+            "producer_url": "172.20.0.18:8002",
             "pubkey": "D4WziQyUH5TFGhu5f33wvRzhTatRFb5v9x1H58NWmRVJ"
         },
         {
-            "sailfish_url": "172.20.0.19:8017",
-            "decrypt_url": "172.20.0.19:10017",
-            "producer_url": "172.20.0.19:11017",
+            "sailfish_url": "172.20.0.19:8000",
+            "decrypt_url": "172.20.0.19:8001",
+            "producer_url": "172.20.0.19:8002",
             "pubkey": "2iHXCZwkerF3JtWG4Q633dfjHnmruJ23hgKNATTsFFkZ"
         },
         {
-            "sailfish_url": "172.20.0.20:8018",
-            "decrypt_url": "172.20.0.20:10018",
-            "producer_url": "172.20.0.20:11018",
+            "sailfish_url": "172.20.0.20:8000",
+            "decrypt_url": "172.20.0.20:80001",
+            "producer_url": "172.20.0.20:8002",
             "pubkey": "5qP4wyDetRcVzQZs3qcxyafxXYowBTdcSVQJbHXcZsji"
         },
         {
-            "sailfish_url": "172.20.0.21:8019",
-            "decrypt_url": "172.20.0.21:10019",
-            "producer_url": "172.20.0.21:11019",
+            "sailfish_url": "172.20.0.21:8000",
+            "decrypt_url": "172.20.0.21:8001",
+            "producer_url": "172.20.0.21:8002",
             "pubkey": "8ajJBphKsQHeWBLm1dzySBJPJcdt7aFS77sFDVUK5vE4"
         }
     ],

--- a/test-configs/local.json
+++ b/test-configs/local.json
@@ -1,121 +1,161 @@
 {
     "keyset": [
         {
-            "url": "127.0.0.1:8000",
+            "sailfish_url": "127.0.0.1:8000",
+            "decrypt_url": "127.0.0.1:9000",
+            "producer_url": "127.0.0.1:10000",
             "pubkey": "HCVAkbpaXjt4NqHem1Qz2mHqKRbGFCHUf4VMbiB7jAYE",
             "sig_pk": "24f9BtAxuZziE4BWMYA6FvyBuedxU9SVsgsoVcyw3aEWagH8eXsV6zi2jLnSvRVjpZkf79HDJNicXSF6FpRWkCXg",
             "dec_pk": "jMbTDiLo8tgyERv92mGrCAe1s3KnnnyqhQeSYte6vUhZy1"
         },
         {
-            "url": "127.0.0.1:8001",
+            "sailfish_url": "127.0.0.1:8001",
+            "decrypt_url": "127.0.0.1:9001",
+            "producer_url": "127.0.0.1:10001",
             "pubkey": "6v8B9RK6Noa6SX8rE6RXK972v6KFfVaLjC5sbCT9VoJn",
             "sig_pk": "2gtHurFq5yeJ8HGD5mHUPqniHbpEE83ELLpPqhxEvKhPJFcjMnUwdH2YsdhngMmQTqHo9B1Qna6uM13ug2Pir97k",
             "dec_pk": "jysmvvvwSHu872gmxkejPP8RxUDpSpKChnkPMVeXyRibwN"
         },
         {
-            "url": "127.0.0.1:8002",
+            "sailfish_url": "127.0.0.1:8002",
+            "decrypt_url": "127.0.0.1:9002",
+            "producer_url": "127.0.0.1:10002",
             "pubkey": "7MMmoPcqd8DnqD5Ji1xNUgkvkCtNoFEHwRPuYBqeF8Ni",
             "sig_pk": "4Y7yyg11MBYJaeD2UWCh5cto8wizJoUCqFm7YjMbY3hXyWSWVPgi7y1D9e7D78a1NcWdE4k59D6vK9f6eCpzVkbQ",
             "dec_pk": "kCioHtYdX7pUVXJLceFFKx7j4czcqDjjS52FYbvy2AuyQV"
         },
         {
-            "url": "127.0.0.1:8003",
+            "sailfish_url": "127.0.0.1:8003",
+            "decrypt_url": "127.0.0.1:9003",
+            "producer_url": "127.0.0.1:10003",
             "pubkey": "EofyDbHJGLFNG8D1J6xKj9XpSfooKTim982RU726Qnn4",
             "sig_pk": "zrjZDknq9nPhiBXKeG2PeotwxAayYkv2UFmxc2UsCGHsdu5vCsjqxn8ko2Rh2fWts76u6eCJYjDgKEaveutVhjW",
             "dec_pk": "jVEU8hbv7uUntaDt4GgDxUKgoCu8UCXugx1coMeiVfn31L"
         },
         {
-            "url": "127.0.0.1:8004",
+            "sailfish_url": "127.0.0.1:8004",
+            "decrypt_url": "127.0.0.1:9004",
+            "producer_url": "127.0.0.1:10004",
             "pubkey": "86R3D2VHNUTN1eNS1SiPQiegDs88PKUewqc1zizH6vVD",
             "sig_pk": "jW98dJM94zuvhRCA1bGLiPjakePTc1CYPP2V5iCswfayZiYujGYdSoE1MYDa61dHCyzPdEvGNBDmnFHS6jf83Km",
             "dec_pk": "jUzpdPzgxn2zpaLXaHJiWJ2jbbD3scsP8YqscA1uZGhPfZ"
         },
         {
-            "url": "127.0.0.1:8005",
+            "sailfish_url": "127.0.0.1:8005",
+            "decrypt_url": "127.0.0.1:9005",
+            "producer_url": "127.0.0.1:10005",
             "pubkey": "24pdM4mDRSHnk5d7uzztwmCT3e8jzYTafGMTVUmsYvEU",
             "sig_pk": "ijaVc89vBQ4GELRMcstZamxpYUbXdt4PvfkfzWTwKUsqL88M5Abt2TnX3c9URrQ4LmZMNtzd1WzoC5BSmDNscCp",
             "dec_pk": "jppK4wUHDKapUCoWXZiogJ9HmppDPG7LBsVD82GD4RQWeQ"
         },
         {
-            "url": "127.0.0.1:8006",
+            "sailfish_url": "127.0.0.1:8006",
+            "decrypt_url": "127.0.0.1:9006",
+            "producer_url": "127.0.0.1:10006",
             "pubkey": "HTuCvHG1CADdKsuLSZ1TWBL9QmFAXGWdgzmbBtYMWM2G",
             "sig_pk": "EDtsvA2haRC8mnSmcf2dsjCBq2vXT2Tru6uNR45kMwvMBLQ6HVL3XP985WcVQCfduNgeMi23QEZfSKkMDZu599r",
             "dec_pk": "k1kweWkWi2ZKSaKpgxczM2o6mKFViZz2rxNjk8zATafHyP"
         },
         {
-            "url": "127.0.0.1:8007",
+            "sailfish_url": "127.0.0.1:8007",
+            "decrypt_url": "127.0.0.1:9007",
+            "producer_url": "127.0.0.1:10007",
             "pubkey": "G9SsebpexnFLMqWkzCBDVKhPHHn8JdsFq6PgQAFBTXfP",
             "sig_pk": "4X3NnCJXbA8qSL6EeTm2atTKfos9WsPGETdqPvR9igt9KsXkqWC9WZkqpV9MsMPtdZsrtNeTu73VxGjbmL8uaC17",
             "dec_pk": "ji43FKt1iarZZXdvu2EvJTanXvJzrqbBScPpevzCjRKaW2"
         },
         {
-            "url": "127.0.0.1:8008",
+            "sailfish_url": "127.0.0.1:8008",
+            "decrypt_url": "127.0.0.1:9008",
+            "producer_url": "127.0.0.1:10008",
             "pubkey": "47P5dRX6aHpw17zjkXPXWVyy5aaUBc1CCT2ukM1RSAcy",
             "sig_pk": "Tr38rPDWZhzGxGvU1TFHXUfTLLzJJ4ZUVeLChWBZBuiL3zBNcpA4hhV6bwD5o8KDwqRYhXrQMBaqAmFmyQf6HaH",
             "dec_pk": "jTyChK47ysDarEAUsNq43srvbZWbG2bJCHFgAEFXLq6PkB"
         },
         {
-            "url": "127.0.0.1:8009",
+            "sailfish_url": "127.0.0.1:8009",
+            "decrypt_url": "127.0.0.1:9009",
+            "producer_url": "127.0.0.1:10009",
             "pubkey": "DNFTMMt6CCAponjhLdHJMdEhPteVXTXPbT1gC125Vfg6",
             "sig_pk": "2w9mvYRetk3rNq6aMiouZfvrsX1tbwvbdGoZVhFyTPudeS2zAN2wahspvRHDGFRwTHqaX87itY2qyQqyYSxCnKMC",
             "dec_pk": "kBkpi7XrEigAZ6tm3bREZ9tGb2AXL4h7ceNL4mfaGES7yi"
         },
         {
-            "url": "127.0.0.1:8010",
+            "sailfish_url": "127.0.0.1:8010",
+            "decrypt_url": "127.0.0.1:9010",
+            "producer_url": "127.0.0.1:10010",
             "pubkey": "2TpRWBrURjjCDEMTdoF2hicyhKUT7M39W6oxNzp99chd",
             "sig_pk": "53VLuybEeX9cASQFv2cKjGH2J4esvRYXMHwBDpXw3S5YAKViUnbHPGjMQca1MmMAqdGXnTLypumtxNkXPtdREhGs",
             "dec_pk": "k3MqzGMbfm28SY6LiXR972atiodCRRzoCMDHYWteg8Rzy7"
         },
         {
-            "url": "127.0.0.1:8011",
+            "sailfish_url": "127.0.0.1:8011",
+            "decrypt_url": "127.0.0.1:9011",
+            "producer_url": "127.0.0.1:10011",
             "pubkey": "DGbaGsY2THd4oHxTKBRJBEurGKb9KgQeLFY13eMapinC",
             "sig_pk": "2KedEUxvFGruLjswMLqs693cwAzCZs5ABLk15igFDWTxo5wQsMCpdNdueBgM5EnnxyNMmkpYHwvx7j3RTyL7KSet",
             "dec_pk": "j1nqGwevuVtLFonHmsNqfxpdt6GopZX4xJ31UCfDjS5Wst"
         },
         {
-            "url": "127.0.0.1:8012",
+            "sailfish_url": "127.0.0.1:8012",
+            "decrypt_url": "127.0.0.1:9012",
+            "producer_url": "127.0.0.1:10012",
             "pubkey": "2x23JLWVwNbjNxM8snwKYUdKtoHgj7zN1gyPHbgsUazd",
             "sig_pk": "2BsrUMBJCEqLmhY9nh5y5bmd9TSPuD9D5pLCCDZVFgHjdDgKi6cgnzkMpMBVx78J8ibcn4CGaAzYttRUBWaAnpg1",
             "dec_pk": "jZdxHS4Zr7fkfoKphDzdSJi639KdyUkDWdVn1Ehanefnqy"
         },
         {
-            "url": "127.0.0.1:8013",
+            "sailfish_url": "127.0.0.1:8013",
+            "decrypt_url": "127.0.0.1:9013",
+            "producer_url": "127.0.0.1:10013",
             "pubkey": "CX51n5zs2kuQteiNRUVR25KZF9kA27UeWccFodfbLMWS",
             "sig_pk": "fkSkZs97mZsk9zdpmYvyjf9YdcwEX8fcYZhwWCd8gxvxBHvU2zLpX6pCMtevD5T76NXCkqbBBMWAbuKbUj2WYQi",
             "dec_pk": "izRcUhmMJtjy6AN3tovBLH6gsUjGQvnuNLfcsKAAAsmcDA"
         },
         {
-            "url": "127.0.0.1:8014",
+            "sailfish_url": "127.0.0.1:8014",
+            "decrypt_url": "127.0.0.1:9014",
+            "producer_url": "127.0.0.1:10014",
             "pubkey": "9owjFAaWhFcT9GqJ9c3idqndxHXcfyVPQrNnEvxG72Hs",
             "sig_pk": "58hqMbmozZPhKpDHek2PoSdnj1PRPgAA2CT8iUYNysWFVpg8MufpEvKdqHhFzp9diQB4zhsfw8tbgqYUMvSupUtd",
             "dec_pk": "jhHjyWcXWxumgfA7vic1juwPi5fYKyJxRUT1k1ccryYVq7"
         },
         {
-            "url": "127.0.0.1:8015",
+            "sailfish_url": "127.0.0.1:8015",
+            "decrypt_url": "127.0.0.1:9015",
+            "producer_url": "127.0.0.1:10015",
             "pubkey": "8jTeAaPGTxkPwrFkqTUj5fMP57BLLdeuLmwx2ZxvHdPt",
             "sig_pk": "14zvFYrD41HK8bw9gfP5Fs5LfNdFWziKHUaxyv95f4avhtYCEZo8Wg8QaUqdvm5T1ZpvrbD1XFUViNLgddFLQJ2",
             "dec_pk": "jLFzJnwKuC3KnXcZgepSZD2CLQnr21DfwA1zpt1L5dnHQJ"
         },
         {
-            "url": "127.0.0.1:8016",
+            "sailfish_url": "127.0.0.1:8016",
+            "decrypt_url": "127.0.0.1:9016",
+            "producer_url": "127.0.0.1:10016",
             "pubkey": "D4WziQyUH5TFGhu5f33wvRzhTatRFb5v9x1H58NWmRVJ",
             "sig_pk": "5HtH2r6mFn4F2ZSMySipA4dhEfxdu5MjuPeykWELgAZyZJ1F72ZLwTavjcNCCbYsGF6rMBvQLBQVTVr9ACRy4xnt",
             "dec_pk": "j6VXo1ik1Kf4ffMMctbrL1LRQo9FHr82DMb3BgsNHgxWjq"
         },
         {
-            "url": "127.0.0.1:8017",
+            "sailfish_url": "127.0.0.1:8017",
+            "decrypt_url": "127.0.0.1:9017",
+            "producer_url": "127.0.0.1:10017",
             "pubkey": "2iHXCZwkerF3JtWG4Q633dfjHnmruJ23hgKNATTsFFkZ",
             "sig_pk": "ro7W8TtXQzWDSwZcHGeTTThUauw2nkE8Syrivo8YEwfY1KDsuuo7db4EBHtiRMH8t7EEwZ2MCagAbUsKz2fkd2d",
             "dec_pk": "jjJ1ev6mFqC67FetREzeeSsSjTzqTGeNM7SHa1E6dFmRCt"
         },
         {
-            "url": "127.0.0.1:8018",
+            "sailfish_url": "127.0.0.1:8018",
+            "decrypt_url": "127.0.0.1:9018",
+            "producer_url": "127.0.0.1:10018",
             "pubkey": "5qP4wyDetRcVzQZs3qcxyafxXYowBTdcSVQJbHXcZsji",
             "sig_pk": "kCewFsRMYVPQ59rKCQUtEqjnrezJpZH82GqDYtwCZMWD35fgJhFV535YXrNzE1hLXgfXdD5o1DHsnvHwNwweLX6",
             "dec_pk": "kEaesywh1xhXjUe7fzYPnNHJo9i4kFwdN3paA569MpbuLu"
         },
         {
-            "url": "127.0.0.1:8019",
+            "sailfish_url": "127.0.0.1:8019",
+            "decrypt_url": "127.0.0.1:9019",
+            "producer_url": "127.0.0.1:10019",
             "pubkey": "8ajJBphKsQHeWBLm1dzySBJPJcdt7aFS77sFDVUK5vE4",
             "sig_pk": "2dfAfFK4S92TyCdW7zTHtgKp3P9xTMP2T4csTtejo5uCW2w8bY83SYqWXXmW1czVKCscEmu2drJkaMj2ABoGdfwe",
             "dec_pk": "k1a2mXM3LhYGjUa3rzGg1zRYbDvDeWQ6TdkTWznBwFLWZg"

--- a/test-configs/local.json
+++ b/test-configs/local.json
@@ -2,160 +2,160 @@
     "keyset": [
         {
             "sailfish_url": "127.0.0.1:8000",
-            "decrypt_url": "127.0.0.1:9000",
-            "producer_url": "127.0.0.1:10000",
+            "decrypt_url": "127.0.0.1:10000",
+            "producer_url": "127.0.0.1:11000",
             "pubkey": "HCVAkbpaXjt4NqHem1Qz2mHqKRbGFCHUf4VMbiB7jAYE",
             "sig_pk": "24f9BtAxuZziE4BWMYA6FvyBuedxU9SVsgsoVcyw3aEWagH8eXsV6zi2jLnSvRVjpZkf79HDJNicXSF6FpRWkCXg",
             "dec_pk": "jMbTDiLo8tgyERv92mGrCAe1s3KnnnyqhQeSYte6vUhZy1"
         },
         {
             "sailfish_url": "127.0.0.1:8001",
-            "decrypt_url": "127.0.0.1:9001",
-            "producer_url": "127.0.0.1:10001",
+            "decrypt_url": "127.0.0.1:10001",
+            "producer_url": "127.0.0.1:11001",
             "pubkey": "6v8B9RK6Noa6SX8rE6RXK972v6KFfVaLjC5sbCT9VoJn",
             "sig_pk": "2gtHurFq5yeJ8HGD5mHUPqniHbpEE83ELLpPqhxEvKhPJFcjMnUwdH2YsdhngMmQTqHo9B1Qna6uM13ug2Pir97k",
             "dec_pk": "jysmvvvwSHu872gmxkejPP8RxUDpSpKChnkPMVeXyRibwN"
         },
         {
             "sailfish_url": "127.0.0.1:8002",
-            "decrypt_url": "127.0.0.1:9002",
-            "producer_url": "127.0.0.1:10002",
+            "decrypt_url": "127.0.0.1:10002",
+            "producer_url": "127.0.0.1:11002",
             "pubkey": "7MMmoPcqd8DnqD5Ji1xNUgkvkCtNoFEHwRPuYBqeF8Ni",
             "sig_pk": "4Y7yyg11MBYJaeD2UWCh5cto8wizJoUCqFm7YjMbY3hXyWSWVPgi7y1D9e7D78a1NcWdE4k59D6vK9f6eCpzVkbQ",
             "dec_pk": "kCioHtYdX7pUVXJLceFFKx7j4czcqDjjS52FYbvy2AuyQV"
         },
         {
             "sailfish_url": "127.0.0.1:8003",
-            "decrypt_url": "127.0.0.1:9003",
-            "producer_url": "127.0.0.1:10003",
+            "decrypt_url": "127.0.0.1:10003",
+            "producer_url": "127.0.0.1:11003",
             "pubkey": "EofyDbHJGLFNG8D1J6xKj9XpSfooKTim982RU726Qnn4",
             "sig_pk": "zrjZDknq9nPhiBXKeG2PeotwxAayYkv2UFmxc2UsCGHsdu5vCsjqxn8ko2Rh2fWts76u6eCJYjDgKEaveutVhjW",
             "dec_pk": "jVEU8hbv7uUntaDt4GgDxUKgoCu8UCXugx1coMeiVfn31L"
         },
         {
             "sailfish_url": "127.0.0.1:8004",
-            "decrypt_url": "127.0.0.1:9004",
-            "producer_url": "127.0.0.1:10004",
+            "decrypt_url": "127.0.0.1:10004",
+            "producer_url": "127.0.0.1:11004",
             "pubkey": "86R3D2VHNUTN1eNS1SiPQiegDs88PKUewqc1zizH6vVD",
             "sig_pk": "jW98dJM94zuvhRCA1bGLiPjakePTc1CYPP2V5iCswfayZiYujGYdSoE1MYDa61dHCyzPdEvGNBDmnFHS6jf83Km",
             "dec_pk": "jUzpdPzgxn2zpaLXaHJiWJ2jbbD3scsP8YqscA1uZGhPfZ"
         },
         {
             "sailfish_url": "127.0.0.1:8005",
-            "decrypt_url": "127.0.0.1:9005",
-            "producer_url": "127.0.0.1:10005",
+            "decrypt_url": "127.0.0.1:10005",
+            "producer_url": "127.0.0.1:11005",
             "pubkey": "24pdM4mDRSHnk5d7uzztwmCT3e8jzYTafGMTVUmsYvEU",
             "sig_pk": "ijaVc89vBQ4GELRMcstZamxpYUbXdt4PvfkfzWTwKUsqL88M5Abt2TnX3c9URrQ4LmZMNtzd1WzoC5BSmDNscCp",
             "dec_pk": "jppK4wUHDKapUCoWXZiogJ9HmppDPG7LBsVD82GD4RQWeQ"
         },
         {
             "sailfish_url": "127.0.0.1:8006",
-            "decrypt_url": "127.0.0.1:9006",
-            "producer_url": "127.0.0.1:10006",
+            "decrypt_url": "127.0.0.1:10006",
+            "producer_url": "127.0.0.1:11006",
             "pubkey": "HTuCvHG1CADdKsuLSZ1TWBL9QmFAXGWdgzmbBtYMWM2G",
             "sig_pk": "EDtsvA2haRC8mnSmcf2dsjCBq2vXT2Tru6uNR45kMwvMBLQ6HVL3XP985WcVQCfduNgeMi23QEZfSKkMDZu599r",
             "dec_pk": "k1kweWkWi2ZKSaKpgxczM2o6mKFViZz2rxNjk8zATafHyP"
         },
         {
             "sailfish_url": "127.0.0.1:8007",
-            "decrypt_url": "127.0.0.1:9007",
-            "producer_url": "127.0.0.1:10007",
+            "decrypt_url": "127.0.0.1:10007",
+            "producer_url": "127.0.0.1:11007",
             "pubkey": "G9SsebpexnFLMqWkzCBDVKhPHHn8JdsFq6PgQAFBTXfP",
             "sig_pk": "4X3NnCJXbA8qSL6EeTm2atTKfos9WsPGETdqPvR9igt9KsXkqWC9WZkqpV9MsMPtdZsrtNeTu73VxGjbmL8uaC17",
             "dec_pk": "ji43FKt1iarZZXdvu2EvJTanXvJzrqbBScPpevzCjRKaW2"
         },
         {
             "sailfish_url": "127.0.0.1:8008",
-            "decrypt_url": "127.0.0.1:9008",
-            "producer_url": "127.0.0.1:10008",
+            "decrypt_url": "127.0.0.1:10008",
+            "producer_url": "127.0.0.1:11008",
             "pubkey": "47P5dRX6aHpw17zjkXPXWVyy5aaUBc1CCT2ukM1RSAcy",
             "sig_pk": "Tr38rPDWZhzGxGvU1TFHXUfTLLzJJ4ZUVeLChWBZBuiL3zBNcpA4hhV6bwD5o8KDwqRYhXrQMBaqAmFmyQf6HaH",
             "dec_pk": "jTyChK47ysDarEAUsNq43srvbZWbG2bJCHFgAEFXLq6PkB"
         },
         {
             "sailfish_url": "127.0.0.1:8009",
-            "decrypt_url": "127.0.0.1:9009",
-            "producer_url": "127.0.0.1:10009",
+            "decrypt_url": "127.0.0.1:10009",
+            "producer_url": "127.0.0.1:11009",
             "pubkey": "DNFTMMt6CCAponjhLdHJMdEhPteVXTXPbT1gC125Vfg6",
             "sig_pk": "2w9mvYRetk3rNq6aMiouZfvrsX1tbwvbdGoZVhFyTPudeS2zAN2wahspvRHDGFRwTHqaX87itY2qyQqyYSxCnKMC",
             "dec_pk": "kBkpi7XrEigAZ6tm3bREZ9tGb2AXL4h7ceNL4mfaGES7yi"
         },
         {
             "sailfish_url": "127.0.0.1:8010",
-            "decrypt_url": "127.0.0.1:9010",
-            "producer_url": "127.0.0.1:10010",
+            "decrypt_url": "127.0.0.1:10010",
+            "producer_url": "127.0.0.1:11010",
             "pubkey": "2TpRWBrURjjCDEMTdoF2hicyhKUT7M39W6oxNzp99chd",
             "sig_pk": "53VLuybEeX9cASQFv2cKjGH2J4esvRYXMHwBDpXw3S5YAKViUnbHPGjMQca1MmMAqdGXnTLypumtxNkXPtdREhGs",
             "dec_pk": "k3MqzGMbfm28SY6LiXR972atiodCRRzoCMDHYWteg8Rzy7"
         },
         {
             "sailfish_url": "127.0.0.1:8011",
-            "decrypt_url": "127.0.0.1:9011",
-            "producer_url": "127.0.0.1:10011",
+            "decrypt_url": "127.0.0.1:10011",
+            "producer_url": "127.0.0.1:11011",
             "pubkey": "DGbaGsY2THd4oHxTKBRJBEurGKb9KgQeLFY13eMapinC",
             "sig_pk": "2KedEUxvFGruLjswMLqs693cwAzCZs5ABLk15igFDWTxo5wQsMCpdNdueBgM5EnnxyNMmkpYHwvx7j3RTyL7KSet",
             "dec_pk": "j1nqGwevuVtLFonHmsNqfxpdt6GopZX4xJ31UCfDjS5Wst"
         },
         {
             "sailfish_url": "127.0.0.1:8012",
-            "decrypt_url": "127.0.0.1:9012",
-            "producer_url": "127.0.0.1:10012",
+            "decrypt_url": "127.0.0.1:10012",
+            "producer_url": "127.0.0.1:11012",
             "pubkey": "2x23JLWVwNbjNxM8snwKYUdKtoHgj7zN1gyPHbgsUazd",
             "sig_pk": "2BsrUMBJCEqLmhY9nh5y5bmd9TSPuD9D5pLCCDZVFgHjdDgKi6cgnzkMpMBVx78J8ibcn4CGaAzYttRUBWaAnpg1",
             "dec_pk": "jZdxHS4Zr7fkfoKphDzdSJi639KdyUkDWdVn1Ehanefnqy"
         },
         {
             "sailfish_url": "127.0.0.1:8013",
-            "decrypt_url": "127.0.0.1:9013",
-            "producer_url": "127.0.0.1:10013",
+            "decrypt_url": "127.0.0.1:10013",
+            "producer_url": "127.0.0.1:11013",
             "pubkey": "CX51n5zs2kuQteiNRUVR25KZF9kA27UeWccFodfbLMWS",
             "sig_pk": "fkSkZs97mZsk9zdpmYvyjf9YdcwEX8fcYZhwWCd8gxvxBHvU2zLpX6pCMtevD5T76NXCkqbBBMWAbuKbUj2WYQi",
             "dec_pk": "izRcUhmMJtjy6AN3tovBLH6gsUjGQvnuNLfcsKAAAsmcDA"
         },
         {
             "sailfish_url": "127.0.0.1:8014",
-            "decrypt_url": "127.0.0.1:9014",
-            "producer_url": "127.0.0.1:10014",
+            "decrypt_url": "127.0.0.1:10014",
+            "producer_url": "127.0.0.1:11014",
             "pubkey": "9owjFAaWhFcT9GqJ9c3idqndxHXcfyVPQrNnEvxG72Hs",
             "sig_pk": "58hqMbmozZPhKpDHek2PoSdnj1PRPgAA2CT8iUYNysWFVpg8MufpEvKdqHhFzp9diQB4zhsfw8tbgqYUMvSupUtd",
             "dec_pk": "jhHjyWcXWxumgfA7vic1juwPi5fYKyJxRUT1k1ccryYVq7"
         },
         {
             "sailfish_url": "127.0.0.1:8015",
-            "decrypt_url": "127.0.0.1:9015",
-            "producer_url": "127.0.0.1:10015",
+            "decrypt_url": "127.0.0.1:10015",
+            "producer_url": "127.0.0.1:11015",
             "pubkey": "8jTeAaPGTxkPwrFkqTUj5fMP57BLLdeuLmwx2ZxvHdPt",
             "sig_pk": "14zvFYrD41HK8bw9gfP5Fs5LfNdFWziKHUaxyv95f4avhtYCEZo8Wg8QaUqdvm5T1ZpvrbD1XFUViNLgddFLQJ2",
             "dec_pk": "jLFzJnwKuC3KnXcZgepSZD2CLQnr21DfwA1zpt1L5dnHQJ"
         },
         {
             "sailfish_url": "127.0.0.1:8016",
-            "decrypt_url": "127.0.0.1:9016",
-            "producer_url": "127.0.0.1:10016",
+            "decrypt_url": "127.0.0.1:10016",
+            "producer_url": "127.0.0.1:11016",
             "pubkey": "D4WziQyUH5TFGhu5f33wvRzhTatRFb5v9x1H58NWmRVJ",
             "sig_pk": "5HtH2r6mFn4F2ZSMySipA4dhEfxdu5MjuPeykWELgAZyZJ1F72ZLwTavjcNCCbYsGF6rMBvQLBQVTVr9ACRy4xnt",
             "dec_pk": "j6VXo1ik1Kf4ffMMctbrL1LRQo9FHr82DMb3BgsNHgxWjq"
         },
         {
             "sailfish_url": "127.0.0.1:8017",
-            "decrypt_url": "127.0.0.1:9017",
-            "producer_url": "127.0.0.1:10017",
+            "decrypt_url": "127.0.0.1:10017",
+            "producer_url": "127.0.0.1:11017",
             "pubkey": "2iHXCZwkerF3JtWG4Q633dfjHnmruJ23hgKNATTsFFkZ",
             "sig_pk": "ro7W8TtXQzWDSwZcHGeTTThUauw2nkE8Syrivo8YEwfY1KDsuuo7db4EBHtiRMH8t7EEwZ2MCagAbUsKz2fkd2d",
             "dec_pk": "jjJ1ev6mFqC67FetREzeeSsSjTzqTGeNM7SHa1E6dFmRCt"
         },
         {
             "sailfish_url": "127.0.0.1:8018",
-            "decrypt_url": "127.0.0.1:9018",
-            "producer_url": "127.0.0.1:10018",
+            "decrypt_url": "127.0.0.1:10018",
+            "producer_url": "127.0.0.1:11018",
             "pubkey": "5qP4wyDetRcVzQZs3qcxyafxXYowBTdcSVQJbHXcZsji",
             "sig_pk": "kCewFsRMYVPQ59rKCQUtEqjnrezJpZH82GqDYtwCZMWD35fgJhFV535YXrNzE1hLXgfXdD5o1DHsnvHwNwweLX6",
             "dec_pk": "kEaesywh1xhXjUe7fzYPnNHJo9i4kFwdN3paA569MpbuLu"
         },
         {
             "sailfish_url": "127.0.0.1:8019",
-            "decrypt_url": "127.0.0.1:9019",
-            "producer_url": "127.0.0.1:10019",
+            "decrypt_url": "127.0.0.1:10019",
+            "producer_url": "127.0.0.1:11019",
             "pubkey": "8ajJBphKsQHeWBLm1dzySBJPJcdt7aFS77sFDVUK5vE4",
             "sig_pk": "2dfAfFK4S92TyCdW7zTHtgKp3P9xTMP2T4csTtejo5uCW2w8bY83SYqWXXmW1czVKCscEmu2drJkaMj2ABoGdfwe",
             "dec_pk": "k1a2mXM3LhYGjUa3rzGg1zRYbDvDeWQ6TdkTWznBwFLWZg"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,6 +10,7 @@ async-trait = { workspace = true }
 cliquenet = { path = "../cliquenet", features = ["turmoil"] }
 committable = { workspace = true }
 crossbeam-queue = { workspace = true }
+metrics = { path = "../metrics" }
 multisig = { path = "../multisig" }
 portpicker = { workspace = true }
 rand = { workspace = true }
@@ -17,6 +18,10 @@ sailfish = { path = "../sailfish", features = ["test"] }
 sailfish-types = { path = "../sailfish-types" }
 serde = { workspace = true }
 timeboost = { path = "../timeboost" }
+timeboost-builder = { path = "../timeboost-builder" }
+timeboost-crypto = { path = "../timeboost-crypto" }
+timeboost-sequencer = { path = "../timeboost-sequencer" }
+timeboost-types = { path = "../timeboost-types" }
 timeboost-utils = { path = "../timeboost-utils", features = ["test"] }
 tokio = { workspace = true }
 turmoil = { workspace = true }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -4,6 +4,9 @@ use std::net::{Ipv4Addr, SocketAddr};
 use multisig::{Committee, Keypair, PublicKey};
 use timeboost_utils::unsafe_zero_keypair;
 
+#[cfg(test)]
+mod tests;
+
 #[allow(unused)]
 pub(crate) mod prelude {
     use committable::{Commitment, Committable, RawCommitmentBuilder};
@@ -45,9 +48,6 @@ pub(crate) mod prelude {
         }
     }
 }
-
-#[cfg(test)]
-mod tests;
 
 pub struct Group {
     pub size: usize,

--- a/tests/src/tests/network/external.rs
+++ b/tests/src/tests/network/external.rs
@@ -54,6 +54,7 @@ impl TestableNetwork for BasicNetworkTest {
                 .get(&kpr.public_key())
                 .expect("own public key to be present");
             let net = Network::create(
+                "test",
                 addr,
                 kpr.clone(),
                 self.group.peers.clone(),

--- a/tests/src/tests/rbc.rs
+++ b/tests/src/tests/rbc.rs
@@ -52,7 +52,8 @@ fn mk_host<A, const N: usize>(
         let a = addr.clone();
         let p = peers.clone();
         async move {
-            let comm = Network::create_turmoil(a, k.clone(), p, NetworkMetrics::default()).await?;
+            let comm =
+                Network::create_turmoil("test", a, k.clone(), p, NetworkMetrics::default()).await?;
             let cfg = RbcConfig::new(k.clone(), c.clone()).recover(false);
             let rbc = Rbc::new(Overlay::new(comm), cfg);
             let cons = Consensus::new(k, c, EmptyBlocks);
@@ -98,7 +99,7 @@ fn small_committee() {
 
     sim.client("C", async move {
         let addr = (UNSPECIFIED, ports[2]);
-        let comm = Network::create_turmoil(addr, k.clone(), peers, NetworkMetrics::default()).await?;
+        let comm = Network::create_turmoil("C", addr, k.clone(), peers, NetworkMetrics::default()).await?;
         let cfg = RbcConfig::new(k.clone(), c.clone()).recover(false);
         let rbc = Rbc::new(Overlay::new(comm), cfg);
         let cons = Consensus::new(k, c, EmptyBlocks);
@@ -155,7 +156,7 @@ fn medium_committee() {
 
     sim.client("E", async move {
         let addr = (UNSPECIFIED, ports[4]);
-        let comm = Network::create_turmoil(addr, k.clone(), peers, NetworkMetrics::default()).await?;
+        let comm = Network::create_turmoil("E", addr, k.clone(), peers, NetworkMetrics::default()).await?;
         let cfg = RbcConfig::new(k.clone(), c.clone()).recover(false);
         let rbc = Rbc::new(Overlay::new(comm), cfg);
         let cons = Consensus::new(k, c, EmptyBlocks);
@@ -211,7 +212,7 @@ fn medium_committee_partition_network() {
 
     sim.client("E", async move {
         let addr = (UNSPECIFIED, ports[4]);
-        let comm = Network::create_turmoil(addr, k.clone(), peers, NetworkMetrics::default()).await?;
+        let comm = Network::create_turmoil("E", addr, k.clone(), peers, NetworkMetrics::default()).await?;
         let cfg = RbcConfig::new(k.clone(), c.clone()).recover(false);
         let rbc = Rbc::new(Overlay::new(comm), cfg);
         let cons = Consensus::new(k, c, EmptyBlocks);

--- a/tests/src/tests/timeboost.rs
+++ b/tests/src/tests/timeboost.rs
@@ -1,1 +1,91 @@
-pub mod test_timeboost_startup;
+mod block_order;
+mod test_timeboost_startup;
+mod transaction_order;
+
+use std::net::Ipv4Addr;
+
+use cliquenet::Address;
+use multisig::Keypair;
+use timeboost_builder::BlockProducerConfig;
+use timeboost_crypto::DecryptionScheme;
+use timeboost_crypto::TrustedKeyMaterial;
+use timeboost_crypto::traits::threshold_enc::ThresholdEncScheme;
+use timeboost_sequencer::SequencerConfig;
+use timeboost_types::BundleVariant;
+use timeboost_types::DecryptionKey;
+use timeboost_utils::load_generation::make_bundle;
+use tokio::sync::broadcast;
+use tokio::time::{Duration, sleep};
+use tracing::warn;
+
+fn make_configs<R>(
+    (pubkey, combkey, shares): &TrustedKeyMaterial,
+    recover_index: R,
+) -> Vec<(SequencerConfig, BlockProducerConfig)>
+where
+    R: Into<Option<usize>>,
+{
+    let parts = shares
+        .iter()
+        .cloned()
+        .map(|s| {
+            let p1 = portpicker::pick_unused_port().unwrap();
+            let p2 = portpicker::pick_unused_port().unwrap();
+            let p3 = portpicker::pick_unused_port().unwrap();
+            let a1 = Address::from((Ipv4Addr::LOCALHOST, p1));
+            let a2 = Address::from((Ipv4Addr::LOCALHOST, p2));
+            let a3 = Address::from((Ipv4Addr::LOCALHOST, p3));
+            (Keypair::generate(), a1, a2, a3, s)
+        })
+        .collect::<Vec<_>>();
+
+    let sailfish_peers = parts
+        .iter()
+        .map(|(kp, sa, ..)| (kp.public_key(), sa.clone()))
+        .collect::<Vec<_>>();
+
+    let decrypt_peers = parts
+        .iter()
+        .map(|(kp, _, da, ..)| (kp.public_key(), da.clone()))
+        .collect::<Vec<_>>();
+
+    let produce_peers = parts
+        .iter()
+        .map(|(kp, _, _, pa, ..)| (kp.public_key(), pa.clone()))
+        .collect::<Vec<_>>();
+
+    let mut cfgs = Vec::new();
+    let recover_index = recover_index.into();
+
+    for (i, (kpair, sa, da, pa, share)) in parts.iter().cloned().enumerate() {
+        let dkey = DecryptionKey::new(pubkey.clone(), combkey.clone(), share.clone());
+        let mut cfg = SequencerConfig::new(kpair.clone(), dkey, sa, da)
+            .with_sailfish_peers(sailfish_peers.clone())
+            .with_decrypt_peers(decrypt_peers.clone());
+        if let Some(r) = recover_index {
+            cfg = cfg.recover(i == r);
+        }
+        let pcf = BlockProducerConfig::new(kpair, pa).with_peers(produce_peers.clone());
+        cfgs.push((cfg, pcf));
+    }
+
+    cfgs
+}
+
+/// Generate random bundles at a fixed frequency.
+async fn gen_bundles(
+    pubkey: <DecryptionScheme as ThresholdEncScheme>::PublicKey,
+    tx: broadcast::Sender<BundleVariant>,
+) {
+    loop {
+        let Ok(b) = make_bundle(&pubkey) else {
+            warn!("Failed to generate bundle");
+            continue;
+        };
+        if tx.send(b).is_err() {
+            warn!("Failed to broadcast bundle");
+            return;
+        }
+        sleep(Duration::from_millis(10)).await
+    }
+}

--- a/tests/src/tests/timeboost/block_order.rs
+++ b/tests/src/tests/timeboost/block_order.rs
@@ -1,0 +1,88 @@
+use std::iter::once;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Duration;
+
+use metrics::NoMetrics;
+use timeboost_builder::BlockProducer;
+use timeboost_crypto::DecryptionScheme;
+use timeboost_sequencer::Sequencer;
+use timeboost_utils::types::logging::init_logging;
+use tokio::select;
+use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::{Barrier, broadcast, mpsc};
+use tokio::task::JoinSet;
+use tokio::time::sleep;
+use tracing::{debug, info};
+
+use super::{gen_bundles, make_configs};
+
+const NUM_OF_BLOCKS: usize = 50;
+const RECOVER_INDEX: usize = 2;
+
+#[tokio::test]
+async fn block_order() {
+    init_logging();
+
+    let num = NonZeroUsize::new(5).unwrap();
+    let dec = DecryptionScheme::trusted_keygen(num);
+    let cfg = make_configs(&dec, RECOVER_INDEX);
+
+    let mut rxs = Vec::new();
+    let mut tasks = JoinSet::new();
+    let (bcast, _) = broadcast::channel(3);
+    let finish = Arc::new(Barrier::new(5));
+
+    for (c, b) in cfg {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut brx = bcast.subscribe();
+        let finish = finish.clone();
+        tasks.spawn(async move {
+            if c.is_recover() {
+                // delay start of a recovering node:
+                sleep(Duration::from_secs(5)).await
+            }
+            let mut s = Sequencer::new(c, &NoMetrics).await.unwrap();
+            let mut p = BlockProducer::new(b, &NoMetrics).await.unwrap();
+            let mut i = 0;
+            while i < NUM_OF_BLOCKS {
+                select! {
+                    t = brx.recv() => match t {
+                        Ok(trx) => s.add_bundles(once(trx)),
+                        Err(RecvError::Lagged(_)) => continue,
+                        Err(err) => panic!("{err}")
+                    },
+                    t = s.next_transaction() => {
+                        p.enqueue(t.expect("transaction")).await.unwrap()
+                    }
+                    b = p.next_block() => {
+                        debug!(node = %s.public_key(), blocks = %i);
+                        let b = b.expect("block");
+                        i += 1;
+                        p.gc(b.num()).await.unwrap();
+                        tx.send(b).unwrap()
+                    }
+                }
+            }
+            finish.wait().await;
+            info!(node = %s.public_key(), "done")
+        });
+        rxs.push(rx)
+    }
+
+    tasks.spawn(gen_bundles(dec.0, bcast.clone()));
+
+    for _ in 0..NUM_OF_BLOCKS {
+        let first = rxs[0].recv().await.unwrap();
+        for rx in &mut rxs[1..] {
+            let b = rx.recv().await.unwrap();
+            assert_eq!(first.cert().data(), b.cert().data())
+        }
+    }
+
+    while let Some(result) = tasks.join_next().await {
+        if let Err(err) = result {
+            panic!("task panic: {err}")
+        }
+    }
+}

--- a/timeboost-builder/Cargo.toml
+++ b/timeboost-builder/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "timeboost-builder"
+description = "Timeboost block builder"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+alloy-consensus = { workspace = true }
+blake3 = { workspace = true }
+bincode = { workspace = true }
+bimap = { workspace = true }
+bytes = { workspace = true }
+cliquenet = { path = "../cliquenet" }
+ethereum_ssz = { workspace = true }
+metrics = { path = "../metrics" }
+multisig = { path = "../multisig" }
+parking_lot = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+timeboost-crypto = { path = "../timeboost-crypto" }
+timeboost-types = { path = "../timeboost-types" }
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+ark-std = { workspace = true }
+bs58 = { workspace = true }
+portpicker = { workspace = true }
+timeboost-utils = { path = "../timeboost-utils" }

--- a/timeboost-builder/Cargo.toml
+++ b/timeboost-builder/Cargo.toml
@@ -6,25 +6,14 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-alloy-consensus = { workspace = true }
-blake3 = { workspace = true }
 bincode = { workspace = true }
-bimap = { workspace = true }
 bytes = { workspace = true }
 cliquenet = { path = "../cliquenet" }
-ethereum_ssz = { workspace = true }
 metrics = { path = "../metrics" }
 multisig = { path = "../multisig" }
-parking_lot = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
-timeboost-crypto = { path = "../timeboost-crypto" }
 timeboost-types = { path = "../timeboost-types" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
-[dev-dependencies]
-ark-std = { workspace = true }
-bs58 = { workspace = true }
-portpicker = { workspace = true }
-timeboost-utils = { path = "../timeboost-utils" }

--- a/timeboost-builder/src/config.rs
+++ b/timeboost-builder/src/config.rs
@@ -1,0 +1,31 @@
+use cliquenet as net;
+use multisig::{Keypair, PublicKey};
+
+#[derive(Debug)]
+pub struct BlockProducerConfig {
+    pub(crate) keypair: Keypair,
+    pub(crate) peers: Vec<(PublicKey, net::Address)>,
+    pub(crate) bind: net::Address,
+}
+
+impl BlockProducerConfig {
+    pub fn new<A>(keyp: Keypair, bind: A) -> Self
+    where
+        A: Into<net::Address>,
+    {
+        Self {
+            keypair: keyp,
+            peers: Vec::new(),
+            bind: bind.into(),
+        }
+    }
+
+    pub fn with_peers<I, A>(mut self, it: I) -> Self
+    where
+        I: IntoIterator<Item = (PublicKey, A)>,
+        A: Into<net::Address>,
+    {
+        self.peers = it.into_iter().map(|(k, a)| (k, a.into())).collect();
+        self
+    }
+}

--- a/timeboost-builder/src/lib.rs
+++ b/timeboost-builder/src/lib.rs
@@ -1,0 +1,5 @@
+mod config;
+mod produce;
+
+pub use config::BlockProducerConfig;
+pub use produce::{BlockProducer, ProducerDown, ProducerError};

--- a/timeboost-builder/src/produce.rs
+++ b/timeboost-builder/src/produce.rs
@@ -1,20 +1,18 @@
 use bytes::{BufMut, BytesMut};
-use cliquenet::MAX_MESSAGE_SIZE;
 use cliquenet::overlay::{Data, DataError, NetworkDown, Overlay};
+use cliquenet::{MAX_MESSAGE_SIZE, Network, NetworkError, NetworkMetrics};
 use multisig::{Certificate, Committee, Envelope, Keypair, Unchecked, Validated, VoteAccumulator};
 use serde::Serialize;
 use std::collections::{BTreeMap, VecDeque};
-use timeboost_types::{
-    Block, BlockHash, BlockInfo, BlockNumber, CertifiedBlock, Timestamp, Transaction,
-};
+use timeboost_types::{Block, BlockHash, BlockInfo, BlockNumber, CertifiedBlock, Transaction};
 use tokio::spawn;
 use tokio::sync::mpsc::{Receiver, Sender, channel};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, trace, warn};
 
-type Result<T> = std::result::Result<T, ProducerError>;
+use crate::BlockProducerConfig;
 
-const MAX_ROUNDS: usize = 100;
+const MAX_BLOCKS: usize = 100;
 
 #[derive(Clone)]
 enum Status {
@@ -33,7 +31,7 @@ pub struct BlockProducer {
     /// Keypair of the node.
     label: Keypair,
     /// Incoming transactions
-    queue: VecDeque<(Timestamp, Transaction)>,
+    queue: VecDeque<Transaction>,
     /// Last block produced.
     parent: Option<(BlockNumber, BlockHash)>,
     /// Blocks subject to certification.
@@ -47,30 +45,52 @@ pub struct BlockProducer {
 }
 
 impl BlockProducer {
-    pub fn new(label: Keypair, net: Overlay, committee: Committee) -> Self {
-        let (block_tx, block_rx) = channel(MAX_ROUNDS);
-        let (cert_tx, cert_rx) = channel(MAX_ROUNDS);
-        let worker = Worker::new(label.clone(), net, committee.clone());
+    pub async fn new<M>(cfg: BlockProducerConfig, metrics: &M) -> Result<Self, ProducerError>
+    where
+        M: metrics::Metrics,
+    {
+        let (block_tx, block_rx) = channel(MAX_BLOCKS);
+        let (cert_tx, cert_rx) = channel(MAX_BLOCKS);
 
-        Self {
-            label,
+        let committee = Committee::new(
+            cfg.peers
+                .iter()
+                .map(|(k, _)| *k)
+                .enumerate()
+                .map(|(i, key)| (i as u8, key)),
+        );
+
+        let net_metrics = NetworkMetrics::new(metrics, cfg.peers.iter().map(|(k, _)| *k));
+
+        let net = Network::create(
+            cfg.bind.clone(),
+            cfg.keypair.clone(),
+            cfg.peers.clone(),
+            net_metrics,
+        )
+        .await?;
+
+        let worker = Worker::new(cfg.keypair.clone(), Overlay::new(net), committee);
+
+        Ok(Self {
+            label: cfg.keypair,
             queue: VecDeque::new(),
             parent: None,
             blocks: BTreeMap::new(),
             block_tx,
             cert_rx,
             jh: spawn(worker.go(block_rx, cert_tx)),
-        }
+        })
     }
 
-    pub async fn gc(&mut self, r: BlockNumber) -> Result<()> {
+    pub async fn gc(&mut self, r: BlockNumber) -> Result<(), ProducerDown> {
         self.block_tx
             .send(WorkerCommand::Gc(r))
             .await
-            .map_err(|_| ProducerError::Shutdown)
+            .map_err(|_| ProducerDown(()))
     }
 
-    pub async fn enqueue(&mut self, tx: (Timestamp, Transaction)) -> Result<()> {
+    pub async fn enqueue(&mut self, tx: Transaction) -> Result<(), ProducerDown> {
         self.queue.push_back(tx);
 
         // TODO: produce blocks deterministically according to spec.
@@ -80,7 +100,7 @@ impl BlockProducer {
         const BLOCK_SIZE: usize = 10;
 
         if self.queue.len() >= BLOCK_SIZE {
-            let txs: Vec<_> = self.queue.drain(..BLOCK_SIZE).map(|(_, t)| t).collect();
+            let txs: Vec<_> = self.queue.drain(..BLOCK_SIZE).collect();
 
             let (num, block) = match self.parent {
                 Some((num, parent)) => {
@@ -99,7 +119,7 @@ impl BlockProducer {
             self.block_tx
                 .send(WorkerCommand::Send(num, hash))
                 .await
-                .map_err(|_| ProducerError::Shutdown)?;
+                .map_err(|_| ProducerDown(()))?;
             self.parent = Some((num, hash));
 
             trace!(node = %self.label.public_key(), %num, block = ?hash, "certifying");
@@ -108,7 +128,7 @@ impl BlockProducer {
         Ok(())
     }
 
-    pub async fn next(&mut self) -> Result<CertifiedBlock> {
+    pub async fn next_block(&mut self) -> Result<CertifiedBlock, ProducerDown> {
         while let Some(WorkerResponse(num, cert)) = self.cert_rx.recv().await {
             trace!(
                 node = %self.label.public_key(),
@@ -135,7 +155,7 @@ impl BlockProducer {
                 }
             }
         }
-        Err(ProducerError::Shutdown)
+        Err(ProducerDown(()))
     }
 }
 
@@ -230,7 +250,7 @@ impl Worker {
                         self.net.broadcast(*num, data).await.ok();
                     },
                     Some(WorkerCommand::Gc(num)) => {
-                        let num = num.saturating_sub(MAX_ROUNDS as u64);
+                        let num = num.saturating_sub(MAX_BLOCKS as u64);
                         if num > 0 {
                             self.net.gc(num)
                         }
@@ -286,14 +306,14 @@ impl Worker {
     }
 }
 
-fn serialize<T: Serialize>(d: &T) -> Result<Data> {
+fn serialize<T: Serialize>(d: &T) -> Result<Data, ProducerError> {
     let mut b = BytesMut::new().writer();
     bincode::serde::encode_into_std_write(d, &mut b, bincode::config::standard())?;
     let bytes = b.into_inner();
     Ok(Data::try_from(bytes)?)
 }
 
-fn deserialize<T: for<'de> serde::Deserialize<'de>>(d: &bytes::Bytes) -> Result<T> {
+fn deserialize<T: for<'de> serde::Deserialize<'de>>(d: &bytes::Bytes) -> Result<T, ProducerError> {
     bincode::serde::decode_from_slice(
         d,
         bincode::config::standard().with_limit::<MAX_MESSAGE_SIZE>(),
@@ -303,8 +323,15 @@ fn deserialize<T: for<'de> serde::Deserialize<'de>>(d: &bytes::Bytes) -> Result<
 }
 
 #[derive(Debug, thiserror::Error)]
+#[error("producer down")]
+pub struct ProducerDown(());
+
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum ProducerError {
+    #[error("network error: {0}")]
+    Net(#[from] NetworkError),
+
     #[error("bincode encode error: {0}")]
     BincodeEncode(#[from] bincode::error::EncodeError),
 
@@ -313,7 +340,4 @@ pub enum ProducerError {
 
     #[error("data error: {0}")]
     DataError(#[from] DataError),
-
-    #[error("an error occurred")]
-    Shutdown,
 }

--- a/timeboost-builder/src/produce.rs
+++ b/timeboost-builder/src/produce.rs
@@ -60,7 +60,7 @@ impl BlockProducer {
                 .map(|(i, key)| (i as u8, key)),
         );
 
-        let net_metrics = NetworkMetrics::new(metrics, cfg.peers.iter().map(|(k, _)| *k));
+        let net_metrics = NetworkMetrics::new("block", metrics, cfg.peers.iter().map(|(k, _)| *k));
 
         let net = Network::create(
             cfg.bind.clone(),

--- a/timeboost-builder/src/produce.rs
+++ b/timeboost-builder/src/produce.rs
@@ -149,7 +149,7 @@ impl BlockProducer {
                         node  = %self.label.public_key(),
                         block = %num,
                         next  = %block_info.0,
-                        "received future certified block",
+                        "received certified block of future round",
                     );
                     self.blocks.insert(block_info, status);
                 }

--- a/timeboost-builder/src/produce.rs
+++ b/timeboost-builder/src/produce.rs
@@ -63,6 +63,7 @@ impl BlockProducer {
         let net_metrics = NetworkMetrics::new("block", metrics, cfg.peers.iter().map(|(k, _)| *k));
 
         let net = Network::create(
+            "block",
             cfg.bind.clone(),
             cfg.keypair.clone(),
             cfg.peers.clone(),

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -764,6 +764,7 @@ mod tests {
             let (_, addr) = peers[i];
 
             let network = Network::create(
+                "decrypt",
                 addr,
                 sig_key.clone().into(),
                 peers.clone(),

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -182,7 +182,7 @@ impl Decrypter {
                         node  = %self.label,
                         round = %r,
                         next  = %round,
-                        "received decrypted txns future round",
+                        "received decrypted txns of future round",
                     );
                     self.incls.insert(round, status);
                 }

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -171,6 +171,7 @@ impl Sequencer {
             );
 
             let net = Network::create(
+                "sailfish",
                 cfg.sailfish_bind,
                 cfg.keypair.clone(),
                 cfg.sailfish_peers,
@@ -197,6 +198,7 @@ impl Sequencer {
             );
 
             let net = Network::create(
+                "decrypt",
                 cfg.decrypt_bind,
                 cfg.keypair.clone(), // same auth
                 cfg.decrypt_peers,

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -1,7 +1,6 @@
 mod decrypt;
 mod include;
 mod metrics;
-mod produce;
 mod queue;
 mod sort;
 
@@ -12,13 +11,12 @@ use cliquenet::{self as net, MAX_MESSAGE_SIZE};
 use cliquenet::{Network, NetworkError, NetworkMetrics, Overlay};
 use metrics::SequencerMetrics;
 use multisig::{Committee, Keypair, PublicKey};
-use produce::BlockProducer;
 use sailfish::Coordinator;
 use sailfish::consensus::{Consensus, ConsensusMetrics};
 use sailfish::rbc::{Rbc, RbcConfig, RbcError, RbcMetrics};
 use sailfish::types::{Action, RoundNumber};
 use timeboost_crypto::Keyset;
-use timeboost_types::{Address, BundleVariant, CertifiedBlock, DecryptionKey};
+use timeboost_types::{Address, BundleVariant, DecryptionKey, Transaction};
 use timeboost_types::{CandidateList, CandidateListBytes, DelayedInboxIndex, InclusionList};
 use tokio::select;
 use tokio::sync::mpsc::{self, Receiver, Sender};
@@ -27,7 +25,6 @@ use tracing::{error, info, warn};
 
 use decrypt::{DecryptError, Decrypter};
 use include::Includer;
-use produce::ProducerError;
 use queue::BundleQueue;
 use sort::Sorter;
 
@@ -38,23 +35,27 @@ type Candidates = VecDeque<(RoundNumber, Vec<CandidateList>)>;
 pub struct SequencerConfig {
     priority_addr: Address,
     keypair: Keypair,
-    peers: Vec<(PublicKey, net::Address)>,
-    bind: net::Address,
+    sailfish_peers: Vec<(PublicKey, net::Address)>,
+    sailfish_bind: net::Address,
+    decrypt_bind: net::Address,
+    decrypt_peers: Vec<(PublicKey, net::Address)>,
     index: DelayedInboxIndex,
     dec_sk: DecryptionKey,
     recover: bool,
 }
 
 impl SequencerConfig {
-    pub fn new<A>(keyp: Keypair, dec_sk: DecryptionKey, bind: A) -> Self
+    pub fn new<A>(keyp: Keypair, dec_sk: DecryptionKey, sf_bind: A, dec_bind: A) -> Self
     where
         A: Into<net::Address>,
     {
         Self {
             priority_addr: Address::default(),
             keypair: keyp,
-            peers: Vec::new(),
-            bind: bind.into(),
+            sailfish_peers: Vec::new(),
+            decrypt_peers: Vec::new(),
+            sailfish_bind: sf_bind.into(),
+            decrypt_bind: dec_bind.into(),
             index: DelayedInboxIndex::default(),
             dec_sk,
             recover: true,
@@ -66,12 +67,21 @@ impl SequencerConfig {
         self
     }
 
-    pub fn with_peers<I, A>(mut self, it: I) -> Self
+    pub fn with_sailfish_peers<I, A>(mut self, it: I) -> Self
     where
         I: IntoIterator<Item = (PublicKey, A)>,
         A: Into<net::Address>,
     {
-        self.peers = it.into_iter().map(|(k, a)| (k, a.into())).collect();
+        self.sailfish_peers = it.into_iter().map(|(k, a)| (k, a.into())).collect();
+        self
+    }
+
+    pub fn with_decrypt_peers<I, A>(mut self, it: I) -> Self
+    where
+        I: IntoIterator<Item = (PublicKey, A)>,
+        A: Into<net::Address>,
+    {
+        self.decrypt_peers = it.into_iter().map(|(k, a)| (k, a.into())).collect();
         self
     }
 
@@ -94,7 +104,7 @@ pub struct Sequencer {
     label: PublicKey,
     task: JoinHandle<Result<()>>,
     bundles: BundleQueue,
-    output: Receiver<CertifiedBlock>,
+    output: Receiver<Transaction>,
 }
 
 impl Drop for Sequencer {
@@ -110,8 +120,7 @@ struct Task {
     includer: Includer,
     decrypter: Decrypter,
     sorter: Sorter,
-    producer: BlockProducer,
-    output: Sender<CertifiedBlock>,
+    output: Sender<Transaction>,
     mode: Mode,
 }
 
@@ -137,11 +146,10 @@ impl Sequencer {
     {
         let cons_metrics = ConsensusMetrics::new(metrics);
         let rbc_metrics = RbcMetrics::new(metrics);
-        let net_metrics = NetworkMetrics::new(metrics, cfg.peers.iter().map(|(k, _)| *k));
         let seq_metrics = Arc::new(SequencerMetrics::new(metrics));
 
         let committee = Committee::new(
-            cfg.peers
+            cfg.sailfish_peers
                 .iter()
                 .map(|(k, _)| *k)
                 .enumerate()
@@ -151,15 +159,18 @@ impl Sequencer {
         let public_key = cfg.keypair.public_key();
 
         let queue = BundleQueue::new(cfg.priority_addr, cfg.index, seq_metrics.clone());
+
         // Limit max. size of candidate list. Leave margin of 128 KiB for overhead.
         queue.set_max_data_len(cliquenet::MAX_MESSAGE_SIZE - 128 * 1024);
 
         let sailfish = {
+            let met = NetworkMetrics::new(metrics, cfg.sailfish_peers.iter().map(|(k, _)| *k));
+
             let net = Network::create(
-                cfg.bind.clone(),
+                cfg.sailfish_bind,
                 cfg.keypair.clone(),
-                cfg.peers.clone(),
-                net_metrics,
+                cfg.sailfish_peers,
+                met,
             )
             .await?;
 
@@ -175,49 +186,17 @@ impl Sequencer {
         let decrypter = {
             let keyset = Keyset::new(1, committee.size());
 
-            let peers: Vec<_> = cfg
-                .peers
-                .iter()
-                .map(|(k, a)| (*k, a.clone().with_port(a.port() + 250)))
-                .collect();
-
-            let addr = {
-                let p = cfg.bind.port() + 250;
-                cfg.bind.clone().with_port(p)
-            };
+            let met = NetworkMetrics::new(metrics, cfg.decrypt_peers.iter().map(|(k, _)| *k));
 
             let net = Network::create(
-                addr,
+                cfg.decrypt_bind,
                 cfg.keypair.clone(), // same auth
-                peers,
-                NetworkMetrics::default(),
+                cfg.decrypt_peers,
+                met,
             )
             .await?;
 
             Decrypter::new(public_key, Overlay::new(net), keyset, cfg.dec_sk)
-        };
-
-        let producer = {
-            let peers: Vec<_> = cfg
-                .peers
-                .iter()
-                .map(|(k, a)| (*k, a.clone().with_port(a.port() + 500)))
-                .collect();
-
-            let addr = {
-                let p = cfg.bind.port() + 500;
-                cfg.bind.with_port(p)
-            };
-
-            let net = Network::create(
-                addr,
-                cfg.keypair.clone(), // same auth
-                peers,
-                NetworkMetrics::default(),
-            )
-            .await?;
-
-            BlockProducer::new(cfg.keypair, Overlay::new(net), committee.clone())
         };
 
         let (tx, rx) = mpsc::channel(1024);
@@ -229,7 +208,6 @@ impl Sequencer {
             includer: Includer::new(committee, cfg.index),
             decrypter,
             sorter: Sorter::new(public_key),
-            producer,
             output: tx,
             mode: Mode::Passive,
         };
@@ -253,9 +231,9 @@ impl Sequencer {
         self.bundles.add_bundles(it)
     }
 
-    pub async fn next_block(&mut self) -> Result<CertifiedBlock> {
+    pub async fn next_transaction(&mut self) -> Result<Transaction> {
         select! {
-            cert = self.output.recv() => cert.ok_or(TimeboostError::ChannelClosed),
+            trx = self.output.recv() => trx.ok_or(TimeboostError::ChannelClosed),
             res = &mut self.task => match res {
                 Ok(Ok(())) => {
                     error!(node = %self.label, "unexpected task termination");
@@ -327,10 +305,7 @@ impl Task {
                 result = self.decrypter.next() => match result {
                     Ok(incl) => {
                         for t in self.sorter.sort(incl) {
-                            if let Err(err) = self.producer.enqueue(t).await {
-                                error!(node = %self.label, %err, "failed to enqueue transaction");
-                                return Err(TimeboostError::ChannelClosed);
-                            }
+                            self.output.send(t).await.map_err(|_| TimeboostError::ChannelClosed)?
                         }
                         if self.decrypter.has_capacity() {
                             let Some(ilist) = pending.take() else {
@@ -340,19 +315,6 @@ impl Task {
                                 error!(node = %self.label, %err, "decrypt enqueue error");
                             }
                         }
-                    }
-                    Err(err) => {
-                        error!(node = %self.label, %err);
-                    }
-                },
-                result = self.producer.next() => match result {
-                    Ok(cert_block) => {
-                        let num = cert_block.num();
-                        if let Err(err) = self.output.send(cert_block).await {
-                            error!(node = %self.label, %err, "failed to send block");
-                            return Err(TimeboostError::ChannelClosed);
-                        }
-                        self.producer.gc(num).await?
                     }
                     Err(err) => {
                         error!(node = %self.label, %err);
@@ -458,7 +420,4 @@ pub enum TimeboostError {
 
     #[error("decrypt error: {0}")]
     Decrypt(#[from] DecryptError),
-
-    #[error("producer error: {0}")]
-    Produce(#[from] ProducerError),
 }

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -164,7 +164,11 @@ impl Sequencer {
         queue.set_max_data_len(cliquenet::MAX_MESSAGE_SIZE - 128 * 1024);
 
         let sailfish = {
-            let met = NetworkMetrics::new(metrics, cfg.sailfish_peers.iter().map(|(k, _)| *k));
+            let met = NetworkMetrics::new(
+                "sailfish",
+                metrics,
+                cfg.sailfish_peers.iter().map(|(k, _)| *k),
+            );
 
             let net = Network::create(
                 cfg.sailfish_bind,
@@ -186,7 +190,11 @@ impl Sequencer {
         let decrypter = {
             let keyset = Keyset::new(1, committee.size());
 
-            let met = NetworkMetrics::new(metrics, cfg.decrypt_peers.iter().map(|(k, _)| *k));
+            let met = NetworkMetrics::new(
+                "decrypt",
+                metrics,
+                cfg.decrypt_peers.iter().map(|(k, _)| *k),
+            );
 
             let net = Network::create(
                 cfg.decrypt_bind,

--- a/timeboost-sequencer/src/sort.rs
+++ b/timeboost-sequencer/src/sort.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use multisig::PublicKey;
 use ssz::decode_list_of_variable_length_items as ssz_decode;
-use timeboost_types::{Bytes, InclusionList, Timestamp, Transaction};
+use timeboost_types::{Bytes, InclusionList, Transaction};
 use tracing::warn;
 
 const MAX_BUNDLE_TXS: usize = 1024;
@@ -18,7 +18,7 @@ impl Sorter {
         Self { key }
     }
 
-    pub fn sort(&mut self, list: InclusionList) -> impl Iterator<Item = (Timestamp, Transaction)> {
+    pub fn sort(&mut self, list: InclusionList) -> impl Iterator<Item = Transaction> {
         let timestamp = list.timestamp();
         let seed = list.digest();
 
@@ -42,7 +42,7 @@ impl Sorter {
                             );
                             continue;
                         }
-                        match Transaction::decode(&t) {
+                        match Transaction::decode(timestamp, &t) {
                             Ok(tx) => {
                                 if priority {
                                     ptx.push(tx)
@@ -63,7 +63,7 @@ impl Sorter {
         }
 
         rtx.sort_unstable_by(|x, y| compare(&seed, x, y));
-        ptx.into_iter().chain(rtx).map(move |t| (timestamp, t))
+        ptx.into_iter().chain(rtx)
     }
 }
 

--- a/timeboost-types/src/time.rs
+++ b/timeboost-types/src/time.rs
@@ -44,6 +44,7 @@ impl Committable for Epoch {
     Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize,
 )]
 #[serde(transparent)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Timestamp(u64);
 
 impl Timestamp {

--- a/timeboost/Cargo.toml
+++ b/timeboost/Cargo.toml
@@ -32,6 +32,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_bytes = { workspace = true }
 tide-disco = { workspace = true }
+timeboost-builder = { path = "../timeboost-builder" }
 timeboost-crypto = { path = "../timeboost-crypto" }
 timeboost-sequencer = { path = "../timeboost-sequencer" }
 timeboost-types = { path = "../timeboost-types" }

--- a/timeboost/src/binaries/builder.rs
+++ b/timeboost/src/binaries/builder.rs
@@ -1,10 +1,7 @@
 use anyhow::{Context, Result, ensure};
 use cliquenet::Address;
 use multisig::{Keypair, PublicKey};
-use std::{
-    net::{Ipv4Addr, SocketAddr},
-    path::PathBuf,
-};
+use std::{net::SocketAddr, path::PathBuf, str::FromStr};
 use timeboost::{
     keyset::{KeysetConfig, private_keys, wait_for_live_peer},
     {Timeboost, TimeboostConfig, rpc_api},
@@ -30,9 +27,17 @@ struct Cli {
     #[clap(long)]
     id: u16,
 
-    /// The port of the node to build.
+    /// The listen address of the sailfish node.
     #[clap(long)]
-    port: u16,
+    sailfish_addr: String,
+
+    /// The listen address of the decrypt node.
+    #[clap(long)]
+    decrypt_addr: String,
+
+    /// The listen address of the producer node.
+    #[clap(long)]
+    producer_addr: String,
 
     /// The port of the RPC API.
     #[clap(long)]
@@ -176,6 +181,7 @@ async fn main() -> Result<()> {
     };
 
     let keypair = Keypair::from(sig_key);
+
     let dec_sk = keyset
         .build_decryption_material(dec_sk)
         .expect("parse keyset");
@@ -191,10 +197,12 @@ async fn main() -> Result<()> {
         .keyset()
         .iter()
         .take(num)
-        .map(|ph| format!("http://{}", ph.url).parse().unwrap())
+        .map(|ph| format!("http://{}", ph.sailfish_url).parse().unwrap())
         .collect();
 
-    let mut peer_hosts_and_keys = Vec::new();
+    let mut sailfish_peer_hosts_and_keys = Vec::new();
+    let mut decrypt_peer_hosts_and_keys = Vec::new();
+    let mut producer_peer_hosts_and_keys = Vec::new();
 
     // Rust is *really* picky about mixing iterators, so we just erase the type.
     let peer_host_iter: Box<dyn Iterator<Item = &_>> = if cli.multi_region {
@@ -217,22 +225,29 @@ async fn main() -> Result<()> {
 
     // So we take chunks of 4 per region (this is ALWAYS 4), then, take `take_from_group` node keys from each chunk.
     for peer_host in peer_host_iter {
-        let mut spl = peer_host.url.splitn(3, ":");
-        let p0 = spl.next().expect("valid url");
-        let p1: u16 = spl
-            .next()
-            .expect("valid port")
-            .parse()
-            .expect("integer port");
-        let peer_address = Address::from((p0, p1));
-        wait_for_live_peer(peer_address.clone()).await?;
+        let sailfish_address = Address::from_str(&peer_host.sailfish_url)?;
+        let decrypt_address = Address::from_str(&peer_host.decrypt_url)?;
+        let producer_address = Address::from_str(&peer_host.producer_url)?;
 
-        let pubkey =
-            PublicKey::try_from(peer_host.pubkey.as_str()).expect("derive public signature key");
-        peer_hosts_and_keys.push((pubkey, peer_address));
+        wait_for_live_peer(sailfish_address.clone()).await?;
+
+        let pubkey = PublicKey::try_from(&*peer_host.pubkey)
+            .context("failed to derive public signature key")?;
+
+        sailfish_peer_hosts_and_keys.push((pubkey, sailfish_address));
+        decrypt_peer_hosts_and_keys.push((pubkey, decrypt_address));
+        producer_peer_hosts_and_keys.push((pubkey, producer_address));
     }
 
-    let bind_address = SocketAddr::from((Ipv4Addr::UNSPECIFIED, cli.port));
+    let sailfish_address =
+        SocketAddr::from_str(&cli.sailfish_addr).context("failed to parse sailfish address")?;
+
+    let decrypt_address =
+        SocketAddr::from_str(&cli.decrypt_addr).context("failed to parse decrypt address")?;
+
+    let producer_address =
+        SocketAddr::from_str(&cli.producer_addr).context("failed to parse producer address")?;
+
     #[cfg(feature = "until")]
     let handle = {
         ensure!(peer_urls.len() >= usize::from(cli.id), "Not enough peers");
@@ -252,10 +267,14 @@ async fn main() -> Result<()> {
     let init = TimeboostConfig {
         rpc_port: cli.rpc_port,
         metrics_port: cli.metrics_port,
-        peers: peer_hosts_and_keys,
+        sailfish_peers: sailfish_peer_hosts_and_keys,
+        decrypt_peers: decrypt_peer_hosts_and_keys,
+        producer_peers: producer_peer_hosts_and_keys,
         keypair,
         dec_sk,
-        bind_address,
+        sailfish_address,
+        decrypt_address,
+        producer_address,
         nitro_url: cli.nitro_node_url,
         sender: tb_app_tx,
         receiver: tb_app_rx,

--- a/timeboost/src/binaries/sailfish.rs
+++ b/timeboost/src/binaries/sailfish.rs
@@ -329,8 +329,11 @@ async fn main() -> Result<()> {
 
     let prom = Arc::new(PrometheusMetrics::default());
     let sf_metrics = ConsensusMetrics::new(prom.as_ref());
-    let net_metrics =
-        NetworkMetrics::new(prom.as_ref(), peer_hosts_and_keys.iter().map(|(k, _)| *k));
+    let net_metrics = NetworkMetrics::new(
+        "sailfish",
+        prom.as_ref(),
+        peer_hosts_and_keys.iter().map(|(k, _)| *k),
+    );
     let rbc_metrics = RbcMetrics::new(prom.as_ref());
     let network = Network::create(
         bind_address,

--- a/timeboost/src/binaries/sailfish.rs
+++ b/timeboost/src/binaries/sailfish.rs
@@ -2,6 +2,7 @@ use std::{
     iter::repeat_with,
     net::{Ipv4Addr, SocketAddr},
     path::PathBuf,
+    str::FromStr,
     sync::Arc,
 };
 
@@ -263,9 +264,9 @@ async fn main() -> Result<()> {
     let peer_urls: Vec<reqwest::Url> = {
         let mut urls = Vec::new();
         for ph in keyset.keyset().iter().take(num) {
-            let url = format!("http://{}", ph.url)
+            let url = format!("http://{}", ph.sailfish_url)
                 .parse()
-                .context(format!("Failed to parse URL: http://{}", ph.url))?;
+                .context(format!("Failed to parse URL: http://{}", ph.sailfish_url))?;
             urls.push(url);
         }
         urls
@@ -315,20 +316,7 @@ async fn main() -> Result<()> {
     // So we take chunks of 4 per region (this is ALWAYS 4), then, take `take_from_group` node keys
     // from each chunk.
     for peer_host in peer_host_iter {
-        let mut spl = peer_host.url.splitn(3, ":");
-        let p0 = spl
-            .next()
-            .context("Invalid URL format: missing host part")?;
-
-        let p1_str = spl
-            .next()
-            .context("Invalid URL format: missing port part")?;
-
-        let p1: u16 = p1_str
-            .parse()
-            .context(format!("Failed to parse port number: {}", p1_str))?;
-
-        let peer_address = Address::from((p0, p1));
+        let peer_address = Address::from_str(&peer_host.sailfish_url)?;
         wait_for_live_peer(peer_address.clone()).await?;
 
         let pubkey = PublicKey::try_from(peer_host.pubkey.as_str()).context(format!(

--- a/timeboost/src/binaries/sailfish.rs
+++ b/timeboost/src/binaries/sailfish.rs
@@ -336,6 +336,7 @@ async fn main() -> Result<()> {
     );
     let rbc_metrics = RbcMetrics::new(prom.as_ref());
     let network = Network::create(
+        "sailfish",
         bind_address,
         keypair.clone(),
         peer_hosts_and_keys.clone(),

--- a/timeboost/src/keyset.rs
+++ b/timeboost/src/keyset.rs
@@ -19,7 +19,9 @@ pub struct KeysetConfig {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct PublicNodeInfo {
-    pub url: String,
+    pub sailfish_url: String,
+    pub decrypt_url: String,
+    pub producer_url: String,
     pub pubkey: String,
 
     /// The optional signature private key for this node.

--- a/timeboost/src/lib.rs
+++ b/timeboost/src/lib.rs
@@ -8,6 +8,7 @@ use api::metrics::serve_metrics_api;
 use cliquenet::Address;
 use metrics::TimeboostMetrics;
 use reqwest::Url;
+use timeboost_builder::{BlockProducer, BlockProducerConfig, ProducerDown};
 use timeboost_crypto::DecryptionScheme;
 use timeboost_crypto::traits::threshold_enc::ThresholdEncScheme;
 use timeboost_sequencer::{Sequencer, SequencerConfig};
@@ -39,8 +40,14 @@ pub struct TimeboostConfig {
     /// The port to bind the metrics API server to.
     pub metrics_port: u16,
 
-    /// The peers that this node will connect to.
-    pub peers: Vec<(PublicKey, Address)>,
+    /// The sailfish peers that this node will connect to.
+    pub sailfish_peers: Vec<(PublicKey, Address)>,
+
+    /// The decrypt peers that this node will connect to.
+    pub decrypt_peers: Vec<(PublicKey, Address)>,
+
+    /// The block producer peers that this node will connect to.
+    pub producer_peers: Vec<(PublicKey, Address)>,
 
     /// The keypair for the node.
     pub keypair: Keypair,
@@ -48,8 +55,14 @@ pub struct TimeboostConfig {
     /// The decryption key material for the node.
     pub dec_sk: DecryptionKey,
 
-    /// The bind address for the node.
-    pub bind_address: SocketAddr,
+    /// The bind address for the sailfish node.
+    pub sailfish_address: SocketAddr,
+
+    /// The bind address for the decrypter node.
+    pub decrypt_address: SocketAddr,
+
+    /// The bind address for the block producer node.
+    pub producer_address: SocketAddr,
 
     /// The url for arbitrum nitro node for gas calculations
     pub nitro_url: Option<reqwest::Url>,
@@ -74,6 +87,7 @@ pub struct Timeboost {
     label: PublicKey,
     init: TimeboostConfig,
     sequencer: Sequencer,
+    producer: BlockProducer,
     prometheus: Arc<PrometheusMetrics>,
     _metrics: Arc<TimeboostMetrics>,
     children: Vec<JoinHandle<()>>,
@@ -87,17 +101,29 @@ impl Timeboost {
             tokio::fs::try_exists(&init.stamp).await?
         };
 
-        let scf =
-            SequencerConfig::new(init.keypair.clone(), init.dec_sk.clone(), init.bind_address)
-                .recover(recover)
-                .with_peers(init.peers.clone());
+        let scf = SequencerConfig::new(
+            init.keypair.clone(),
+            init.dec_sk.clone(),
+            init.sailfish_address,
+            init.decrypt_address,
+        )
+        .recover(recover)
+        .with_sailfish_peers(init.sailfish_peers.clone())
+        .with_decrypt_peers(init.decrypt_peers.clone());
+
+        let bcf = BlockProducerConfig::new(init.keypair.clone(), init.producer_address)
+            .with_peers(init.producer_peers.clone());
+
         let pro = Arc::new(PrometheusMetrics::default());
         let seq = Sequencer::new(scf, &*pro).await?;
+        let blk = BlockProducer::new(bcf, &*pro).await?;
         let met = Arc::new(TimeboostMetrics::new(&*pro));
+
         Ok(Self {
             label: init.keypair.public_key(),
             init,
             sequencer: seq,
+            producer: blk,
             prometheus: pro,
             _metrics: met,
             children: Vec::new(),
@@ -126,18 +152,31 @@ impl Timeboost {
             .await?;
 
         loop {
-            select! { biased;
-                block = self.sequencer.next_block() => match block {
-                    Ok(block) => {
-                        info!(node = %self.label, block = ?block.cert().data(), "block");
+            select! {
+                trx = self.init.receiver.recv() => {
+                    if let Some(t) = trx {
+                        self.sequencer.add_bundles(once(t))
+                    }
+                },
+                trx = self.sequencer.next_transaction() => match trx {
+                    Ok(trx) => {
+                        info!(node = %self.label, trx = %trx.hash(), "transaction");
+                        let res: Result<(), ProducerDown> = self.producer.enqueue(trx).await;
+                        res?
                     }
                     Err(err) => {
                         return Err(err.into())
                     }
                 },
-                trx = self.init.receiver.recv() => {
-                    if let Some(t) = trx {
-                        self.sequencer.add_bundles(once(t))
+                blk = self.producer.next_block() => match blk {
+                    Ok(b) => {
+                        info!(node = %self.label, block = %b.num(), "certified block");
+                        let res: Result<(), ProducerDown> = self.producer.gc(b.num()).await;
+                        res?
+                    }
+                    Err(e) => {
+                        let e: ProducerDown = e;
+                        return Err(e.into())
                     }
                 }
             }


### PR DESCRIPTION
Move the block production into its own crate (`timeboost-builder`). The `Sequencer` of `timeboost-sequencer` now again only produces an ordered sequence of transactions. The timeboost crate ties the two together, enqueuing the transactions in the builder.

Also make less implicit assumptions about ports, but have the various network addresses be part of the configuration.

The transaction_order test has been moved into the tests crate and is accompanied by a block_order test, with both sharing the same setup logic.

Finally, `NetworkMetrics` requires a label now, to disambiguate metrics per network.