### PR TITLE
SG01 refactor 

### DIFF
--- a/multisig/src/committee.rs
+++ b/multisig/src/committee.rs
@@ -28,8 +28,8 @@ impl Committee {
         NonZeroUsize::new(self.parties.len()).expect("committee is not empty")
     }
 
-    /// Returns the threshold for consensus, which is `ceil(n/3)` where `n` is the committee size.
-    pub fn threshold(&self) -> NonZeroUsize {
+    /// Returns the at-least-one-honest threshold for consensus, which is `ceil(n/3)` where `n` is the committee size.
+    pub fn one_honest_threshold(&self) -> NonZeroUsize {
         let t = self.parties.len().div_ceil(3);
         NonZeroUsize::new(t).expect("ceil(n/3) with n > 0 never gives 0")
     }

--- a/sailfish-consensus/src/lib.rs
+++ b/sailfish-consensus/src/lib.rs
@@ -395,7 +395,7 @@ where
 
         // Have we received more than f timeouts?
         if votes != accum.votes(&commit)
-            && accum.votes(&commit) == self.committee.threshold().get() + 1
+            && accum.votes(&commit) == self.committee.one_honest_threshold().get()
         {
             let t = TimeoutMessage::new(evidence, &self.keypair, self.deterministic);
             let e = Envelope::signed(t, &self.keypair, self.deterministic);

--- a/timeboost-crypto/src/lib.rs
+++ b/timeboost-crypto/src/lib.rs
@@ -81,7 +81,8 @@ impl Keyset {
         self.size
     }
 
-    pub fn threshold(&self) -> NonZeroUsize {
+    /// threshold where at least one is honest (=f+1) where f is faulty (inclusive) upperbound
+    pub fn one_honest_threshold(&self) -> NonZeroUsize {
         let t = self.size().get().div_ceil(3);
         NonZeroUsize::new(t).expect("ceil(n/3) with n > 0 never gives 0")
     }

--- a/timeboost-crypto/src/traits/dleq_proof.rs
+++ b/timeboost-crypto/src/traits/dleq_proof.rs
@@ -1,6 +1,12 @@
 use spongefish::{DomainSeparatorMismatch, ProofError};
 use thiserror::Error;
 
+/// Proof of Discrete-log Equality Relation:
+/// Given a tuple (g, g_hat, h, h_hat) prove that DLOG_{g}(g_hat) == DLOG_{h}(h_hat).
+///
+/// In the literature, it's also referred as "DH-triple" relation where g is implicitly
+/// the group generator, and h=g^y for some y, and the proof is attesting to the Diffie-Hellman
+/// triple (g_hat, h, h_hat) = (g^x, g^y, g^{x*y}) for some x.
 pub trait DleqProofScheme {
     type DleqTuple;
     type Scalar;

--- a/timeboost-crypto/src/traits/threshold_enc.rs
+++ b/timeboost-crypto/src/traits/threshold_enc.rs
@@ -1,6 +1,7 @@
 use ark_std::rand::Rng;
 use thiserror::Error;
 
+use crate::traits::dleq_proof::DleqProofError;
 use crate::{Keyset, KeysetId};
 
 /// A Threshold Encryption Scheme.
@@ -55,6 +56,8 @@ pub enum ThresholdEncError {
     Argument(String),
     #[error("Not enough decryption shares")]
     NotEnoughShares,
+    #[error(transparent)]
+    DleqError(DleqProofError),
     #[error("Internal Error: {0}")]
     Internal(anyhow::Error),
     #[error(transparent)]

--- a/timeboost-crypto/src/traits/threshold_enc.rs
+++ b/timeboost-crypto/src/traits/threshold_enc.rs
@@ -64,4 +64,6 @@ pub enum ThresholdEncError {
     IOError(#[from] std::io::Error),
     #[error(transparent)]
     SerializationError(#[from] ark_serialize::SerializationError),
+    #[error("Faulty node indices: {0:?}")]
+    FaultySubset(Vec<u32>),
 }

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -497,7 +497,7 @@ impl Worker {
                 .shares
                 .iter()
                 .filter(|(k, _)| k.round() == round)
-                .all(|(_, v)| self.committee.threshold().get() < v.len());
+                .all(|(_, v)| self.committee.one_honest_threshold().get() < v.len());
 
         if !hatched {
             // ciphertexts are not ready to be decrypted.

--- a/timeboost-sequencer/src/include.rs
+++ b/timeboost-sequencer/src/include.rs
@@ -125,7 +125,7 @@ impl Includer {
         let mut include = Vec::new();
 
         for (rb, n) in regular {
-            if n > self.committee.threshold().get() {
+            if n > self.committee.one_honest_threshold().get() {
                 if self.is_unknown(&rb) {
                     self.cache
                         .entry(self.round)


### PR DESCRIPTION
This is Part 1 of the Decryption phase refactor effort: https://app.asana.com/1/1208976916964769/project/1209394409339229/task/1209978846980044

### This PR:

- rename fuzzy `keyset.threshold()` to explicit `.one_honest_threshold()`
- add a missing ciphertext validity check during `combine()` (Step1.1 in BonehShoup Sec 22.3.3.2)
- extend error type to support `ThresholdEncError::FaultySubset` which outputs a blameable faulty subset for downstream users/callers to deal with those faulty decryption shares. 
  - unit tests updated to test this functionality
