### PR TITLE
Return transactions in batches from sequencer.

### DIFF
--- a/tests/src/tests/timeboost/block_order.rs
+++ b/tests/src/tests/timeboost/block_order.rs
@@ -52,7 +52,7 @@ async fn block_order() {
                         Err(RecvError::Lagged(_)) => continue,
                         Err(err) => panic!("{err}")
                     },
-                    t = s.next_transaction() => {
+                    t = s.next_transactions() => {
                         p.enqueue(t.expect("transaction")).await.unwrap()
                     }
                     b = p.next_block() => {

--- a/timeboost-builder/src/produce.rs
+++ b/timeboost-builder/src/produce.rs
@@ -91,8 +91,11 @@ impl BlockProducer {
             .map_err(|_| ProducerDown(()))
     }
 
-    pub async fn enqueue(&mut self, tx: Transaction) -> Result<(), ProducerDown> {
-        self.queue.push_back(tx);
+    pub async fn enqueue<I>(&mut self, txs: I) -> Result<(), ProducerDown>
+    where
+        I: IntoIterator<Item = Transaction>,
+    {
+        self.queue.extend(txs);
 
         // TODO: produce blocks deterministically according to spec.
         // Useful links:

--- a/timeboost-sequencer/src/sort.rs
+++ b/timeboost-sequencer/src/sort.rs
@@ -18,7 +18,7 @@ impl Sorter {
         Self { key }
     }
 
-    pub fn sort(&mut self, list: InclusionList) -> impl Iterator<Item = Transaction> {
+    pub fn sort(&mut self, list: InclusionList) -> Vec<Transaction> {
         let timestamp = list.timestamp();
         let seed = list.digest();
 
@@ -63,7 +63,8 @@ impl Sorter {
         }
 
         rtx.sort_unstable_by(|x, y| compare(&seed, x, y));
-        ptx.into_iter().chain(rtx)
+        ptx.extend(rtx);
+        ptx
     }
 }
 

--- a/timeboost/src/lib.rs
+++ b/timeboost/src/lib.rs
@@ -158,9 +158,9 @@ impl Timeboost {
                         self.sequencer.add_bundles(once(t))
                     }
                 },
-                trx = self.sequencer.next_transaction() => match trx {
+                trx = self.sequencer.next_transactions() => match trx {
                     Ok(trx) => {
-                        info!(node = %self.label, trx = %trx.hash(), "transaction");
+                        info!(node = %self.label, len = %trx.len(), "next batch of transactions");
                         let res: Result<(), ProducerDown> = self.producer.enqueue(trx).await;
                         res?
                     }


### PR DESCRIPTION
Instead of enqueuing the individual transactions between sequencer worker task and then consuming them one by one, put the whole available batch into the channel and also return that to the caller. Clients can still flatten the batches into one sequence of transactions but potentially they can also process the batches in a more performant way.