### PR TITLE
Some fixes to multisig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ bs58 = "0.5.1"
 bytes = { version = "1.8.0", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
 committable = "0.2"
+constant_time_eq = "0.4"
 criterion = "0.5"
 crossbeam-queue = "0.3.11"
 data-encoding = "2.6.0"

--- a/multisig/Cargo.toml
+++ b/multisig/Cargo.toml
@@ -13,6 +13,7 @@ bimap = { workspace = true }
 bincode = { workspace = true }
 bs58 = { workspace = true }
 committable = { workspace = true }
+constant_time_eq = { workspace = true }
 data-encoding = { workspace = true }
 ed25519-compact = { workspace = true }
 either = { workspace = true }

--- a/multisig/src/envelope.rs
+++ b/multisig/src/envelope.rs
@@ -22,7 +22,8 @@ pub enum Validated {}
 ///```compile_fail
 /// use multisig::{Envelope, Signature, Validated};
 ///
-/// let _: Envelope<Signature, Validated> = bincode::deserialize(&[]).unwrap();
+/// let _: Envelope<Signature, Validated> =
+///     bincode::serde::decode_from_slice(&[], bincode::config::standard()).unwrap().0;
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(bound(deserialize = "D: Deserialize<'de>, S: Deserialize<'de>"))]

--- a/multisig/src/signed.rs
+++ b/multisig/src/signed.rs
@@ -1,4 +1,5 @@
 use committable::{Commitment, Committable, RawCommitmentBuilder};
+use constant_time_eq::constant_time_eq;
 use serde::{Deserialize, Serialize};
 
 use crate::{Committee, Keypair, PublicKey, Signature};
@@ -25,7 +26,7 @@ impl<D: Committable> Signed<D> {
 
     pub fn is_valid(&self, membership: &Committee) -> bool {
         membership.contains_key(&self.signing_key)
-            && self.data.commit() == self.commitment
+            && constant_time_eq(self.data.commit().as_ref(), self.commitment.as_ref())
             && self
                 .signing_key
                 .is_valid(self.commitment.as_ref(), &self.signature)

--- a/multisig/tests/bench.rs
+++ b/multisig/tests/bench.rs
@@ -96,7 +96,9 @@ fn certificate_sizes() {
         let cert = mk_cert(&mut keys, comm.clone());
         println!(
             "{n:3} -> {:5} bytes",
-            bincode::serialize(&cert).unwrap().len()
+            bincode::serde::encode_to_vec(&cert, bincode::config::standard())
+                .unwrap()
+                .len()
         );
     }
 }


### PR DESCRIPTION
- Fixes benchmark and doc comment test.
- Uses constant time equality check.
- Ensures certificate data matches commitment.