### PR TITLE
refactor: simplify decryption phase

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -62,6 +62,8 @@ jobs:
         wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz
         tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
         sudo cp just /usr/bin/just
+    - name: Install rustfmt for nightly
+      run: rustup component add --toolchain nightly rustfmt
     - name: Check packages individually
       run: just check-individually
     - name: Run lint

--- a/justfile
+++ b/justfile
@@ -34,10 +34,10 @@ check-individually:
   done
 
 fmt:
-  cargo fmt --all
+  cargo +nightly fmt --all
 
 fmt_check:
-  cargo fmt --check
+  cargo +nightly fmt --check
 
 lint: clippy fmt_check
 

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -4,11 +4,13 @@
 // You should have received a copy of the MIT License
 // along with the HotShot repository. If not, see <https://mit-license.org/>.
 
-//! The [`Metrics`] trait is used to collect information from multiple components in the entire system.
+//! The [`Metrics`] trait is used to collect information from multiple components in the entire
+//! system.
 //!
 //! This trait can be used to spawn the following traits:
 //! - [`Counter`]: an ever-increasing value (example usage: total bytes send/received)
-//! - [`Gauge`]: a value that store the latest value, and can go up and down (example usage: amount of users logged in)
+//! - [`Gauge`]: a value that store the latest value, and can go up and down (example usage: amount
+//!   of users logged in)
 //! - [`Histogram`]: stores multiple float values based for a graph (example usage: CPU %)
 //! - text: stores a constant string in the collected metrics
 
@@ -20,15 +22,18 @@ use dyn_clone::DynClone;
 pub trait Metrics: Send + Sync + DynClone + Debug {
     /// Create a [`Counter`] with an optional `unit_label`.
     ///
-    /// The `unit_label` can be used to indicate what the unit of the value is, e.g. "kb" or "seconds"
+    /// The `unit_label` can be used to indicate what the unit of the value is, e.g. "kb" or
+    /// "seconds"
     fn create_counter(&self, name: &str, unit_label: Option<&str>) -> Box<dyn Counter>;
     /// Create a [`Gauge`] with an optional `unit_label`.
     ///
-    /// The `unit_label` can be used to indicate what the unit of the value is, e.g. "kb" or "seconds"
+    /// The `unit_label` can be used to indicate what the unit of the value is, e.g. "kb" or
+    /// "seconds"
     fn create_gauge(&self, name: &str, unit_label: Option<&str>) -> Box<dyn Gauge>;
     /// Create a [`Histogram`] with an optional `unit_label`.
     ///
-    /// The `unit_label` can be used to indicate what the unit of the value is, e.g. "kb" or "seconds"
+    /// The `unit_label` can be used to indicate what the unit of the value is, e.g. "kb" or
+    /// "seconds"
     fn create_histogram(
         &self,
         name: &str,

--- a/multisig/src/committee.rs
+++ b/multisig/src/committee.rs
@@ -28,7 +28,8 @@ impl Committee {
         NonZeroUsize::new(self.parties.len()).expect("committee is not empty")
     }
 
-    /// Returns the at-least-one-honest threshold for consensus, which is `ceil(n/3)` where `n` is the committee size.
+    /// Returns the at-least-one-honest threshold for consensus, which is `ceil(n/3)` where `n` is
+    /// the committee size.
     pub fn one_honest_threshold(&self) -> NonZeroUsize {
         let t = self.parties.len().div_ceil(3);
         NonZeroUsize::new(t).expect("ceil(n/3) with n > 0 never gives 0")

--- a/multisig/src/envelope.rs
+++ b/multisig/src/envelope.rs
@@ -19,7 +19,7 @@ pub enum Validated {}
 /// signature has been checked at least once. By construction it is impossible to
 /// create a validated envelope without either creating or verifying the signature.
 ///
-///```compile_fail
+/// ```compile_fail
 /// use multisig::{Envelope, Signature, Validated};
 ///
 /// let _: Envelope<Signature, Validated> =

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+edition = "2024"
+wrap_comments = true
+normalize_comments = true
+comment_width = 100
+reorder_imports = true

--- a/sailfish-consensus/src/dag.rs
+++ b/sailfish-consensus/src/dag.rs
@@ -105,7 +105,8 @@ impl<T: PartialEq> Dag<T> {
 
     /// Returns an iterator over all vertices within the specified round range.
     ///
-    /// This method allows iteration over vertices across multiple rounds using any valid range syntax:
+    /// This method allows iteration over vertices across multiple rounds using any valid range
+    /// syntax:
     /// - `vertex_range(1..4)` - vertices from rounds 1,2,3
     /// - `vertex_range(1..=4)` - vertices from rounds 1,2,3,4
     /// - `vertex_range(1..)` - vertices from round 1 onwards

--- a/sailfish-consensus/src/lib.rs
+++ b/sailfish-consensus/src/lib.rs
@@ -272,10 +272,10 @@ where
     /// Upon receiving a no vote message we:
     /// - Verify that we are the leader for round `r + 1` from timeout round `r`.
     /// - Check if we have a timeout certificate for the round, or else set it.
-    /// - Add the `no_vote` to our `VoteAccumulator`. Upon receiving `2f + 1`
-    ///   `no_votes` a certificate will be created.
-    /// - If a no-vote certificate has been created, advance to the next round with
-    ///   the `no_vote` and `timeout_certificate`.
+    /// - Add the `no_vote` to our `VoteAccumulator`. Upon receiving `2f + 1` `no_votes` a
+    ///   certificate will be created.
+    /// - If a no-vote certificate has been created, advance to the next round with the `no_vote`
+    ///   and `timeout_certificate`.
     pub fn handle_no_vote(&mut self, e: Envelope<NoVoteMessage, Validated>) -> Vec<Action<T>> {
         trace!(
             node    = %self.public_key(),

--- a/sailfish-rbc/src/abraham.rs
+++ b/sailfish-rbc/src/abraham.rs
@@ -115,11 +115,10 @@ impl RbcConfig {
 /// deliver vertex proposals. The algorithm is based on Abraham et al. \[1\]:
 ///
 /// 1. Propose: When broadcasting a message we send a proposal to all parties.
-/// 2. Vote: When receiving a first proposal from a broadcaster, we send
-///    a vote for the proposal to all parties.
-/// 3. Commit: When receiving 𝑛 − 𝑓 votes for a proposal, we send the
-///    resulting certificate to all parties and deliver the message to the
-///    application.
+/// 2. Vote: When receiving a first proposal from a broadcaster, we send a vote for the proposal to
+///    all parties.
+/// 3. Commit: When receiving 𝑛 − 𝑓 votes for a proposal, we send the resulting certificate to all
+///    parties and deliver the message to the application.
 ///
 /// Voting uses the commit digest of the proposal, not the proposal message itself,
 /// in order to minimise the amount of data to send.

--- a/tests/src/tests/network.rs
+++ b/tests/src/tests/network.rs
@@ -147,7 +147,8 @@ pub trait TestableNetwork {
                         }
                     }
                     if all_evaluated {
-                        // We are done with this nodes test, we can break our loop and pop off `JoinSet` handles
+                        // We are done with this nodes test, we can break our loop and pop off
+                        // `JoinSet` handles
                         sleep(Duration::from_secs(1)).await;
                         return TaskHandleResult::new(coordinator.public_key(), outcome);
                     }

--- a/tests/src/tests/network/network_tests.rs
+++ b/tests/src/tests/network/network_tests.rs
@@ -156,7 +156,8 @@ where
                 let node_public_key = kpr.public_key();
                 TestCondition::new(format!("Vertex from {}", k.public_key()), move |msg, _a| {
                     if let Some(Message::Vertex(v)) = msg {
-                        // Go 20 rounds passed timeout, make sure all nodes receive all vertices from round
+                        // Go 20 rounds passed timeout, make sure all nodes receive all vertices
+                        // from round
                         if **v.data().round().data() == timeout_round + 20
                             && node_public_key == *v.data().source()
                         {
@@ -236,7 +237,8 @@ where
                 let node_public_key = kpr.public_key();
                 TestCondition::new(format!("Vertex from {}", k.public_key()), move |msg, _a| {
                     if let Some(Message::Vertex(v)) = msg {
-                        // Go 20 rounds passed timeout, make sure all nodes receive all vertices from round
+                        // Go 20 rounds passed timeout, make sure all nodes receive all vertices
+                        // from round
                         if **v.data().round().data() == timeout_round + 20
                             && node_public_key == *v.data().source()
                         {

--- a/timeboost-crypto/src/lib.rs
+++ b/timeboost-crypto/src/lib.rs
@@ -64,7 +64,7 @@ impl Committable for KeysetId {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct Keyset {
     id: KeysetId,
     size: NonZeroUsize,

--- a/timeboost-crypto/src/lib.rs
+++ b/timeboost-crypto/src/lib.rs
@@ -93,6 +93,12 @@ impl Keyset {
         let t = self.size().get().div_ceil(3);
         NonZeroUsize::new(t).expect("ceil(n/3) with n > 0 never gives 0")
     }
+
+    /// threshold where the majority of honest nodes will agree (>=2f+1)
+    pub fn honest_majority_threshold(&self) -> NonZeroUsize {
+        let t = self.size().get() * 2 / 3 + 1;
+        NonZeroUsize::new(t).expect("ceil(2n/3) with n > 0 never gives 0")
+    }
 }
 
 #[serde_as]

--- a/timeboost-crypto/src/lib.rs
+++ b/timeboost-crypto/src/lib.rs
@@ -13,6 +13,7 @@ use serde_with::serde_as;
 use sg_encryption::ShoupGennaro;
 use sha2::Sha256;
 use spongefish::DigestBridge;
+use std::fmt;
 use std::{convert::TryFrom, num::NonZeroUsize};
 use traits::threshold_enc::ThresholdEncScheme;
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -20,10 +21,19 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Nonce(u128);
 
+/// Idnetifier to a ciphertext
+pub type CiphertextId = Nonce;
+
 #[derive(
     Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
 )]
 pub struct KeysetId(u64);
+
+impl fmt::Display for KeysetId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "KeysetId({})", self.0)
+    }
+}
 
 impl TryFrom<&[u8]> for KeysetId {
     type Error = InvalidKeysetId;
@@ -126,7 +136,7 @@ pub struct Ciphertext<C: CurveGroup> {
 }
 
 #[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct DecShare<C: CurveGroup> {
     #[serde_as(as = "crate::SerdeAs")]
     w: C,
@@ -236,7 +246,8 @@ impl From<Plaintext> for Vec<u8> {
 }
 
 impl<C: CurveGroup> Ciphertext<C> {
-    pub fn nonce(&self) -> Nonce {
+    /// Currently using its (expectedly) unique nonce as its identifier
+    pub fn id(&self) -> CiphertextId {
         self.nonce
     }
 }

--- a/timeboost-crypto/src/lib.rs
+++ b/timeboost-crypto/src/lib.rs
@@ -21,9 +21,6 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Nonce(u128);
 
-/// Idnetifier to a ciphertext
-pub type CiphertextId = Nonce;
-
 #[derive(
     Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
 )]
@@ -242,13 +239,6 @@ impl Plaintext {
 impl From<Plaintext> for Vec<u8> {
     fn from(plaintext: Plaintext) -> Self {
         plaintext.0
-    }
-}
-
-impl<C: CurveGroup> Ciphertext<C> {
-    /// Currently using its (expectedly) unique nonce as its identifier
-    pub fn id(&self) -> CiphertextId {
-        self.nonce
     }
 }
 

--- a/timeboost-crypto/src/sg_encryption.rs
+++ b/timeboost-crypto/src/sg_encryption.rs
@@ -32,8 +32,8 @@ use crate::{
 /// instantiated as a key encapsulation mechanism (hybrid cryptosystem) for a symmetric key.
 ///
 /// NOTE:
-/// 1. k-out-of-n threshold scheme means >= k correct decryption shares lead to successful `combine()`
-///    in the case of timeboost, k=f+1 where f is the (inclusive) faulty nodes
+/// 1. k-out-of-n threshold scheme means >= k correct decryption shares lead to successful
+///    `combine()` in the case of timeboost, k=f+1 where f is the (inclusive) faulty nodes
 pub struct ShoupGennaro<C, H, D>
 where
     C: CurveGroup,
@@ -304,8 +304,9 @@ where
         let (v, e, w_hat, pi) = (ct.v, ct.e.clone(), ct.w_hat, ct.pi.clone());
 
         // dev note: currently our scheme binds the keyset_id associated data not through `aad`
-        // but through symmetric key derivation used to compute `e`, thus `e` indirectly binds `keyset_id`,
-        // which is why `aad` is left unused. Technically, keyset_id is part of aad, we should use aad to derive u_hat
+        // but through symmetric key derivation used to compute `e`, thus `e` indirectly binds
+        // `keyset_id`, which is why `aad` is left unused. Technically, keyset_id is part of
+        // aad, we should use aad to derive u_hat
         let u_hat = hash_to_curve::<C, H>(v, e)
             .map_err(|e| ThresholdEncError::Internal(anyhow!("Hash to curve failed: {:?}", e)))?;
         let tuple = DleqTuple::new(g, v, u_hat, w_hat);
@@ -457,10 +458,11 @@ mod test {
     }
 
     #[test]
-    // NOTE: we are using (t, N) threshold scheme, where exactly =t valid shares can successfully decrypt,
-    // in the context of timeboost, t=f+1 where f is the upper bound of faulty nodes. In the original spec,
-    // authors used `t+1` shares to decrypt, but here, we are testing SG01 scheme purely from the perspective
-    // of the standalone cryptographic scheme, so be aware of the slight mismatch of notation.
+    // NOTE: we are using (t, N) threshold scheme, where exactly =t valid shares can successfully
+    // decrypt, in the context of timeboost, t=f+1 where f is the upper bound of faulty nodes.
+    // In the original spec, authors used `t+1` shares to decrypt, but here, we are testing SG01
+    // scheme purely from the perspective of the standalone cryptographic scheme, so be aware of
+    // the slight mismatch of notation.
     fn test_combine_invalid_shares() {
         let rng = &mut test_rng();
         let committee = Keyset::new(0, NonZeroUsize::new(10).unwrap());

--- a/timeboost-crypto/src/traits/threshold_enc.rs
+++ b/timeboost-crypto/src/traits/threshold_enc.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use ark_std::rand::Rng;
 use thiserror::Error;
 
@@ -65,5 +67,5 @@ pub enum ThresholdEncError {
     #[error(transparent)]
     SerializationError(#[from] ark_serialize::SerializationError),
     #[error("Faulty node indices: {0:?}")]
-    FaultySubset(Vec<u32>),
+    FaultySubset(BTreeSet<u32>),
 }

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -1,257 +1,174 @@
-use bimap::BiMap;
 use bytes::{BufMut, BytesMut};
 use cliquenet::MAX_MESSAGE_SIZE;
 use cliquenet::overlay::{Data, DataError, NetworkDown, Overlay};
 use multisig::PublicKey;
 
 use sailfish::types::RoundNumber;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use tokio::time::sleep;
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::BTreeMap;
+use std::time::Duration;
 use timeboost_crypto::traits::threshold_enc::{ThresholdEncError, ThresholdEncScheme};
-use timeboost_crypto::{DecryptionScheme, Keyset, KeysetId, Nonce};
-use timeboost_types::{Bytes, DecShareKey, DecryptionKey, InclusionList, ShareInfo};
+use timeboost_crypto::{DecryptionScheme, Keyset, KeysetId, Nonce, Plaintext};
+use timeboost_types::{Bytes, DecryptionKey, InclusionList};
 use tokio::spawn;
 use tokio::sync::mpsc::{Receiver, Sender, channel};
 use tokio::task::JoinHandle;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 type Result<T> = std::result::Result<T, DecryptError>;
-type StateDiff = BTreeMap<RoundNumber, (Vec<usize>, Vec<usize>)>;
 type DecShare = <DecryptionScheme as ThresholdEncScheme>::DecShare;
 type Ciphertext = <DecryptionScheme as ThresholdEncScheme>::Ciphertext;
 
 const MAX_ROUNDS: usize = 100;
 
-/// Status of the inclusion list
-enum Status {
-    Encrypted(InclusionList),
-    Decrypted(InclusionList),
-}
-
-impl From<Status> for InclusionList {
-    fn from(status: Status) -> Self {
-        match status {
-            Status::Encrypted(incl) | Status::Decrypted(incl) => incl,
-        }
-    }
-}
-
-/// Encrypted item (Decrypter -> Worker)
-struct EncryptedItem(KeysetId, Bytes);
-
-/// Decrypted item (Worker -> Decrypter)
-struct DecryptedItem(Bytes);
-
-enum WorkerCommand {
-    Decrypt(RoundNumber, Vec<EncryptedItem>),
+/// Command sent to Decrypter's background worker
+enum WorkerRequest {
+    // request to decrypt all encrypted transactions inside the inclusion list
+    Decrypt(InclusionList),
+    // request to garbage collect all states related to a round (and previous rounds)
     Gc(RoundNumber),
 }
 
-struct WorkerResponse(RoundNumber, Vec<DecryptedItem>);
+/// response from `WorkerRequest`
+enum WorkerResponse {
+    // response to decrypt request, return the decrypted inclusion list
+    Decrypt(InclusionList),
+}
 
+/// A decrypter, indentified by its signing/consensus public key, connects to other decrypters to collectively
+/// threshold-decrypt encrypted transactions in the inclusion list during the 2nd phase ("Decryption phase") of timeboost.
+///
+/// In timeboost protocol, a decrypter does both the share "decryption" (using its decryption key share),
+/// and combiner's "hatching" (using the combiner key).
+///
+/// Functionality wise, the core logic of decrypt and combine, and the caching of yet-hatched decryption shares are all
+/// managed by a dedicated `Worker` thread. Upon request, the worker receive an inclusion list (potentially w/ some encrypted tx),
+/// decypt and broadcast decryption shares to other decrypter's workers, until hatching them to plaintext tx, and finally
+/// returns to the Decrypter the decrypted inclusion list, with order perserved.
+/// The actual `Decrypter` only acts as a proxy to `enqueue` or be pulled by other timeboost components.
 pub struct Decrypter {
-    /// Public key of the node.
+    /// Public key of the node. "Label" is termed to refer to node identity in SG01 decryption scheme
     label: PublicKey,
-    /// Incoming (encrypted) incl lists.
-    incls: BTreeMap<RoundNumber, Status>,
-    /// Store encrypted state info.
-    modified: StateDiff,
-    /// Send worker commands.
-    enc_tx: Sender<WorkerCommand>,
-    /// Send decrypted data.
-    dec_tx: Sender<WorkerResponse>,
-    /// Receive decrypted data.
-    dec_rx: Receiver<WorkerResponse>,
+    /// Decryption committee this decrypter belongs to
+    committee: Keyset,
+    /// Locally stored incl lists: those still unencrypted and those yet fetched by the next phase of timeboost
+    incls: BTreeMap<RoundNumber, InclusionList>,
+    /// Sender end of the worker requests
+    req_tx: Sender<WorkerRequest>,
+    /// Receiver end of the worker response
+    res_rx: Receiver<WorkerResponse>,
     /// Worker task handle.
     jh: JoinHandle<()>,
 }
 
 impl Decrypter {
     pub fn new(label: PublicKey, net: Overlay, committee: Keyset, dec_sk: DecryptionKey) -> Self {
-        let (enc_tx, enc_rx) = channel(MAX_ROUNDS);
-        let (dec_tx, dec_rx) = channel(MAX_ROUNDS);
-        let decrypter = Worker::new(label, net, committee, dec_sk);
+        let (req_tx, req_rx) = channel(MAX_ROUNDS);
+        let (res_tx, res_rx) = channel(MAX_ROUNDS);
+        let worker = Worker::new(label, net, committee.clone(), dec_sk);
 
         Self {
             label,
-            enc_tx,
-            dec_tx: dec_tx.clone(),
-            dec_rx,
+            committee,
             incls: BTreeMap::new(),
-            modified: BTreeMap::new(),
-            jh: spawn(decrypter.go(enc_rx, dec_tx)),
+            req_tx,
+            res_rx,
+            jh: spawn(worker.go(req_rx, res_tx)),
         }
     }
 
+    /// Check if the channels between decrypter and its core worker still have capacity left
     pub fn has_capacity(&mut self) -> bool {
-        self.dec_tx.capacity() > 0 && self.enc_tx.capacity() > 0
+        self.req_tx.capacity() > 0 && self.res_rx.capacity() > 0
     }
 
+    /// Garbage collect cached state of `r` (and prior) rounds
     pub async fn gc(&mut self, r: RoundNumber) -> Result<()> {
-        self.enc_tx
-            .send(WorkerCommand::Gc(r))
+        self.req_tx
+            .send(WorkerRequest::Gc(r))
             .await
             .map_err(|_| DecryptError::Shutdown)
     }
 
-    /// Identifies encrypted bundles in inclusion lists,
-    /// computes the expected state diff, then sends the
-    /// encrypted data to the worker for hatching.
+    /// Send the inclusion list to worker to decrypt if it contains encrypted bundles,
+    /// Else append to local cache waiting to be pulled.
+    ///
+    /// decrypter will process any unencrypted inclusion list, or those encrypted under the keyset this decrypter belongs to,
+    /// but will reject bundles encrypted for totally a different keyset.
     pub async fn enqueue(&mut self, incl: InclusionList) -> Result<()> {
         let round = incl.round();
-        let total_items = incl.len();
-        let (encrypted_pb_idx, encrypted_pb_data): (Vec<_>, Vec<_>) = incl
-            .priority_bundles()
-            .iter()
-            .enumerate()
-            .filter_map(|(i, priority)| {
-                priority
-                    .bundle()
-                    .kid()
-                    .map(|kid| (i, EncryptedItem(kid, priority.bundle().data().clone())))
-            })
-            .unzip();
+        let incl_digest = incl.digest();
 
-        let (encrypted_rb_idx, encrypted_rb_data): (Vec<_>, Vec<_>) = incl
-            .regular_bundles()
-            .iter()
-            .enumerate()
-            .filter_map(|(i, bundle)| {
-                bundle
-                    .kid()
-                    .map(|kid| (i, EncryptedItem(kid, bundle.data().clone())))
-            })
-            .unzip();
+        if incl.is_encrypted() {
+            let required_keysets = incl.kids();
+            if required_keysets.is_empty() {
+                debug!(%round, digeset = ?incl_digest, "Internal err: encrypted inclusion list return empty keyset ids");
+            }
 
-        let encrypted_data: Vec<EncryptedItem> = encrypted_pb_data
-            .into_iter()
-            .chain(encrypted_rb_data)
-            .collect();
+            // ensure encrypted inclusion list is sent to the correct decrypter
+            if !required_keysets.contains(&self.committee.id()) {
+                return Err(DecryptError::WrongDecrypter(
+                    required_keysets[0],
+                    self.committee.id(),
+                ));
+            }
 
-        let enc_items = encrypted_data.len();
-        if encrypted_data.is_empty() {
-            // short-circuit if no encrypted txns
-            self.incls.insert(round, Status::Decrypted(incl));
-            self.dec_tx
-                .send(WorkerResponse(round, vec![]))
+            self.req_tx
+                .send(WorkerRequest::Decrypt(incl.clone()))
                 .await
-                .map_err(|_| DecryptError::Shutdown)?;
-        } else {
-            self.enc_tx
-                .send(WorkerCommand::Decrypt(round, encrypted_data))
-                .await
-                .map_err(|_| DecryptError::Shutdown)?;
-            // bookkeeping for reassembling inclusion list.
-            self.incls.insert(round, Status::Encrypted(incl));
-            self.modified
-                .insert(round, (encrypted_pb_idx, encrypted_rb_idx));
+                .map_err(|_| DecryptError::Shutdown)?
         }
+        self.incls.insert(round, incl);
+
         trace!(
             node        = %self.label,
             round       = %round,
-            enc_items   = %enc_items,
-            total_items = %total_items,
-            "enqueued"
+            digest      = ?incl_digest,
+            "enqueued InclusionList"
         );
         Ok(())
     }
 
-    /// Produces decrypted inclusion lists in round-order by:
-    ///
-    ///  1. receive decrypted (hatched) data for round r.
-    ///  2. reassemble incl list and mark round as "decrypted".
-    ///  3. if r is next round, then return list, otherwise, goto (1).
-    ///
-    pub async fn next(&mut self) -> Result<InclusionList> {
-        while let Some(WorkerResponse(r, dec)) = self.dec_rx.recv().await {
-            if let Some(status) = self.incls.get_mut(&r) {
-                if let Status::Encrypted(incl) = status {
-                    // reassemble inclusion list for round r
-                    let dec_incl = assemble_incl(r, incl.to_owned(), dec, &mut self.modified)?;
-                    *status = Status::Decrypted(dec_incl);
-                }
-            };
+    /// Try to pop the first inclusion list (w/ the smallest round number) if decrypted, else return None
+    fn first_decrypted(&mut self) -> Option<InclusionList> {
+        self.incls.first_entry().and_then(|entry| {
+            if entry.get().is_encrypted() {
+                None
+            } else {
+                Some(entry.remove())
+            }
+        })
+    }
 
-            // Process inclusion lists in order and return the next round if decrypted.
-            if let Some((round, status)) = self.incls.pop_first() {
-                if let Status::Decrypted(incl) = status {
-                    return Ok(incl);
-                } else {
-                    debug!(
-                        node  = %self.label,
-                        round = %r,
-                        next  = %round,
-                        "received decrypted txns of future round",
-                    );
-                    self.incls.insert(round, status);
-                }
+    /// Produces decrypted inclusion lists ordered by round number
+    pub async fn next(&mut self) -> Result<InclusionList> {
+        // first try to return the first inclusion list if it's already decrypted
+        if let Some(incl) = self.first_decrypted() {
+            return Ok(incl);
+        }
+
+        // normal loop: try to receive the next decrypted inclusion list
+        while let Some(WorkerResponse::Decrypt(dec_incl)) = self.res_rx.recv().await {
+            let round = dec_incl.round();
+            // update decrypter cache of inclusion list
+            info!(node = %self.label, %round, epoch = %dec_incl.epoch(), "InclusionList decrypted!");
+            // sanity check
+            if dec_incl.is_encrypted() {
+                warn!(%round, "Internal error, decrypter worker returns non-decrypted InclusionList");
+            }
+            self.incls.insert(round, dec_incl);
+
+            // since the newly finished/responded inclusion list might belong to a later round
+            // the first entry might still be unencrypted, in which case continue the loop and
+            // wait until the worker finishes decrypting it.
+            if let Some(incl) = self.first_decrypted() {
+                return Ok(incl);
             }
         }
         Err(DecryptError::Shutdown)
     }
-}
-
-/// Re-assemble inclusion list using the decrypted items.
-///
-/// The state diff (`modified`) points to the entries
-/// where encrypted data should be replaced.
-///
-/// Decrypted items (`dec`) is output from the Decrypter.
-/// The Decrypter preserves bundle ordering and returns a single
-/// batch containing priority bundles followed by non-priority.
-fn assemble_incl(
-    r: RoundNumber,
-    incl: InclusionList,
-    dec: Vec<DecryptedItem>,
-    modified: &mut StateDiff,
-) -> Result<InclusionList> {
-    let (modified_priority_bundles, modified_regular_bundles) = modified
-        .remove(&r)
-        .expect("encrypted incl => modified entry");
-    let mut new_incl =
-        InclusionList::new(incl.round(), incl.timestamp(), incl.delayed_inbox_index());
-    let (mut priority_bundles, regular_bundles) = incl.into_bundles();
-    let (mp_len, rp_len) = (
-        modified_priority_bundles.len(),
-        modified_regular_bundles.len(),
-    );
-    if mp_len + rp_len != dec.len() {
-        return Err(DecryptError::State);
-    }
-
-    for (i, m) in modified_priority_bundles.into_iter().enumerate() {
-        let bundle = priority_bundles
-            .get_mut(m)
-            .ok_or(DecryptError::InvalidMessage)?;
-        bundle.set_data(dec.get(i).ok_or(DecryptError::State)?.0.clone());
-    }
-
-    let mut encrypted_bundles = vec![];
-    for m in modified_regular_bundles.iter() {
-        let encrypted_tx = regular_bundles
-            .get(*m)
-            .ok_or(DecryptError::InvalidMessage)?;
-        encrypted_bundles.push(encrypted_tx.clone());
-    }
-
-    let mut new_bundles = BTreeSet::from_iter(regular_bundles);
-    for (i, tx) in encrypted_bundles.into_iter().enumerate() {
-        let mut decrypted_bundles = new_bundles.take(&tx).ok_or(DecryptError::InvalidMessage)?;
-        let data = dec
-            .get(i + mp_len)
-            .ok_or(DecryptError::InvalidMessage)?
-            .0
-            .clone();
-        decrypted_bundles.set_data(data);
-        new_bundles.insert(decrypted_bundles);
-    }
-
-    new_incl
-        .set_priority_bundles(priority_bundles)
-        .set_regular_bundles(new_bundles);
-
-    Ok(new_incl)
 }
 
 impl Drop for Decrypter {
@@ -260,20 +177,29 @@ impl Drop for Decrypter {
     }
 }
 
-type Incubator = BTreeMap<DecShareKey, BTreeMap<u32, DecShare>>;
-
 /// Worker is responsible for "hatching" ciphertexts.
 ///
 /// When ciphertexts in a round have received t+1 decryption shares
 /// the shares can be combined to decrypt the ciphertext (hatching).
 struct Worker {
+    /// labeling the node by its signing/consensus public key
     label: PublicKey,
+    /// overlay network to connect to other decrypters
     net: Overlay,
+    /// keyset metadata about the decryption committee
     committee: Keyset,
+    /// round number of the first decrypter request, used to ignore received decryption shares for eariler rounds
+    first_requested_round: Option<RoundNumber>,
+    /// decryption key used to decrypt and combine
     dec_sk: DecryptionKey,
-    cid2idx: HashMap<Nonce, usize>,
-    cid2ct: BiMap<(RoundNumber, Nonce), Ciphertext>,
-    shares: Incubator,
+
+    /// cache of decrtyped shares (keyed by round number), each entry value is a nested vector: an ordered list of per-ciphertext decryption shares.
+    /// the order is derived from the ciphertext payload from the inclusion list `self.incls` of the same round
+    dec_shares: BTreeMap<RoundNumber, Vec<Vec<DecShare>>>,
+    /// cache of encrypted inclusion list waiting to be hatched using `dec_shares`
+    incls: BTreeMap<RoundNumber, InclusionList>,
+    /// the latest rounds whose ciphertexts are hatched
+    last_hatched_round: RoundNumber,
 }
 
 impl Worker {
@@ -282,272 +208,318 @@ impl Worker {
             label,
             net,
             committee,
+            first_requested_round: None,
             dec_sk,
-            cid2idx: HashMap::default(),
-            cid2ct: BiMap::default(),
-            shares: Incubator::default(),
+            dec_shares: BTreeMap::default(),
+            incls: BTreeMap::default(),
+            last_hatched_round: RoundNumber::genesis(),
         }
     }
 
-    pub async fn go(mut self, mut enc_rx: Receiver<WorkerCommand>, dec_tx: Sender<WorkerResponse>) {
-        let mut catching_up = true;
-        let mut hatched_rounds = BTreeSet::new();
+    // entry point of `worker` thread, it runs in a loop until shutdown or out of channel capacity.
+    pub async fn go(mut self, mut req_rx: Receiver<WorkerRequest>, res_tx: Sender<WorkerResponse>) {
+        let node = self.label;
 
         loop {
-            let mut r = self
-                .shares
-                .keys()
-                .next()
-                .map(|k| k.round())
-                .unwrap_or(RoundNumber::genesis());
-
-            trace!(
-                node   = %self.label,
-                round  = %r,
-                shares = %self.shares.len(),
-                cids   = %self.cid2ct.len(),
-            );
+            // each event loop is triggered by receiving one of the following
+            // - a new request from Decrypter
+            // - batch of decrypted shares from other decrypters
             tokio::select! {
-                // received batch of decryption shares from remote node.
+                // receiving a request from the decrypter
+                val = req_rx.recv() => match val {
+                    Some(WorkerRequest::Decrypt(incl)) => {
+                        let round = incl.round();
+                        trace!(%node, %round, "decrypt request");
+
+                        match self.on_decrypt_request(round, incl).await {
+                            Err(DecryptError::Shutdown) => return,
+                            Err(err) => {
+                                error!(%node, %round, %err, "failed to process decrypt request");
+                                continue;
+                            },
+                            _ => trace!(%node, %round, "decrypt request... DONE"),
+                        }
+                    },
+                    Some(WorkerRequest::Gc(round))=> {
+                        trace!(%node, %round, "gc request");
+                        if let Err(err) = self.on_gc_request(round).await {
+                            error!(%node, %round, %err, "failed to gc");
+                        }
+                        trace!(%node, %round, "gc request... DONE");
+                        continue;
+                    },
+                    None => {
+                        debug!(%node, "decrypter has shutdown, shutting down its worker");
+                        return;
+                    }
+                },
+
+                // receiving a batch of decrypted shares from other decrypters
                 val = self.net.receive() => match val {
                     Ok((src, data)) => {
+                        // ignore msg sent to self during broadcast
                         if src == self.label {
                             continue;
                         }
-                        let s = match deserialize::<ShareInfo>(&data) {
-                            Ok(share) => share,
-                            Err(err) => {
-                                warn!(node = %self.label, %err, "deserialization error");
-                                continue;
-                            }
+                        let Ok(dec_shares) = deserialize::<DecShareBatch>(&data) else {
+                            error!(%node, from=%src, "failed to deserialize decrypted shares");
+                            continue;
                         };
-                        trace!(
-                            node   = %self.label,
-                            round  = %s.round(),
-                            data   = %s.cids().len(),
-                            from   = %src,
-                            "receive"
-                        );
-                        if hatched_rounds.contains(&s.round()) || s.round() < r {
+
+                        let round = dec_shares.round;
+                        trace!(%node, from=%src, %round, "receive decrypted shares");
+
+                        if round <= self.last_hatched_round || round < self.oldest_cached_round() {
                             // shares for which the ciphertexts have already hatched
                             // or shares that are older than the first ciphertext in
-                            // the incubator are not inserted.
+                            // the local cache are not inserted.
                             continue;
                         }
-
-                        r = s.round();
-                        if let Err(err) = self.insert_shares(s) {
-                            warn!(node = %self.label, %err, "failed to insert shares from remote");
+                        if let Err(err) = self.insert_shares(dec_shares) {
+                            error!(%node, from=%src, %round, %err, "failed to process decrypted shares");
+                            continue;
                         }
+                        trace!(%node, from=%src, %round, "receive decrypted shares... DONE");
                     },
                     Err(e) => {
-                        let _: NetworkDown = e;
-                        debug!(node = %self.label, "network down");
-                        return;
-                    }
-                },
-
-                // received batch of encrypted data from local inclusion list.
-                val = enc_rx.recv() => match val {
-                    Some(WorkerCommand::Decrypt(round, enc_data)) => {
-                        trace!(
-                            node  = %self.label,
-                            round = %round,
-                            data  = %enc_data.len(),
-                            "decrypt"
-                        );
-
-                        r = round;
-                        match self.decrypt(round, enc_data).await {
-                            Ok(s) => {
-                                let data = match serialize(&s) {
-                                    Ok(data) => data,
-                                    Err(err) => {
-                                        warn!(node = %self.label, %err, "serialization error");
-                                        continue;
-                                    }
-                                };
-                                if let Err(e) = self.net.broadcast(*round, data).await {
-                                    let _: NetworkDown = e;
-                                    debug!(node = %self.label, "network down");
-                                    return
-                                }
-                                if let Err(err) = self.insert_shares(s) {
-                                    warn!(node = %self.label, %err, "failed to insert local shares");
-                                    continue;
-                                }
-                                if catching_up {
-                                    // fast-forward
-                                    self.shares.retain(|k, _| {
-                                        let old = k.round() < round;
-                                        if old {
-                                            hatched_rounds.insert(k.round());
-                                        }
-                                        !old
-                                    });
-                                    catching_up = false;
-                                }
-                            }
-                            Err(err) => {
-                                warn!(node = %self.label, %err, "failed to decrypt data");
-                                continue;
-                            }
-                        }
-                    }
-                    Some(WorkerCommand::Gc(round)) => {
-                        let round = round.saturating_sub(MAX_ROUNDS as u64);
-                        // gc only if activity in the incubator.
-                        if round > 0 && !r.is_genesis() {
-                            trace!(node = %self.label, round, "gc");
-                            self.net.gc(round);
-                            hatched_rounds.retain(|r| round <= **r);
-                            continue;
-                        }
-                    }
-                    None => {
-                        debug!(node = %self.label, "decrypter shutdown");
+                        let _: NetworkDown = e; // ensure err type
+                        debug!(%node, "Overlay network has shutdown, shutting down worker");
                         return;
                     }
                 },
             }
 
-            // check for hatched ciphertexts
-            match self.hatch(r) {
-                Ok(Some((dec_round, dec_items))) => {
-                    if let Err(err) = dec_tx.send(WorkerResponse(dec_round, dec_items)).await {
-                        error!(node = %self.label, %err, "failed to send decrypted data");
-                        return;
+            // workers don't have to hatch for unrequested rounds.
+            if self.first_requested_round.is_none() {
+                continue;
+            }
+
+            // when processing the incoming event (all steps above), we already early-return and continue the loop if any intermediate steps error.
+            // If they succeed, then some local decryption shares must have been updated, thus we try to hatch them.
+            let round = self.oldest_cached_round();
+            match self.hatch(round) {
+                Ok(Some(incl)) => {
+                    while let Err(err) = res_tx.send(WorkerResponse::Decrypt(incl.clone())).await {
+                        error!(%node, %err, "failed to send hatched inclusion list, retrying");
+                        sleep(Duration::from_millis(50)).await;
                     }
-                    hatched_rounds.insert(r);
+                    self.last_hatched_round = round;
+                    self.gc(round);
+                    debug!(%node, %round, "hatch inclusion list... DONE");
                 }
-                Err(err) => match err {
-                    DecryptError::MissingCiphertext(cid) => {
-                        debug!(node = %self.label, round  = %r, ?cid, "missing ciphertext");
-                    }
-                    DecryptError::MissingIndex(cid) => {
-                        warn!(node = %self.label, round  = %r, ?cid, "missing index mapping");
-                    }
-                    _ => {
-                        warn!(node = %self.label, round  = %r, %err, "failed to decrypt shares");
-                    }
-                },
-                _ => {}
+                Err(err) => warn!(%round, %err, %node, "failed to hatch"),
+                Ok(None) => continue,
             }
         }
     }
 
-    async fn decrypt(
-        &mut self,
-        round: RoundNumber,
-        encrypted_items: Vec<EncryptedItem>,
-    ) -> Result<ShareInfo> {
-        let mut cids = vec![];
-        let mut kids = vec![];
+    /// returns the oldest round number in locally cached decryption shares (w/ smallest round number)
+    fn oldest_cached_round(&self) -> RoundNumber {
+        self.dec_shares
+            .keys()
+            .next()
+            .copied()
+            .unwrap_or(RoundNumber::genesis())
+    }
+
+    /// logic to process a `WorkerRequest::Decrypt` request from the decrypter
+    async fn on_decrypt_request(&mut self, round: RoundNumber, incl: InclusionList) -> Result<()> {
+        let dec_shares = self.decrypt(round, incl.clone()).await?;
+        self.net
+            .broadcast(round.u64(), serialize(&dec_shares)?)
+            .await?;
+        self.insert_shares(dec_shares)?;
+        self.incls.insert(round, incl);
+
+        // edge case: when processing the first decrypt request, workers may have received decryption shares
+        // of eariler rounds from other decrypters, but this worker doesn't need those shares, thus pruning them.
+        if self.first_requested_round.is_none() {
+            debug!(node=%self.label, %round, "set first requested round");
+            self.dec_shares.retain(|k, _| k >= &round);
+            self.first_requested_round = Some(round);
+        }
+
+        Ok(())
+    }
+
+    /// garbage collect internally cached state. Different from `self.on_gc_request()` which deals with incoming gc request,
+    /// indicating more than just local gc, but also overlay network-wise gc.
+    fn gc(&mut self, round: RoundNumber) {
+        self.dec_shares.retain(|r, _| *r > round);
+        self.incls.retain(|r, _| *r > round);
+    }
+
+    /// logic to garbage collect a round (and all prior rounds)
+    async fn on_gc_request(&mut self, round: RoundNumber) -> Result<()> {
+        if round.u64() > 0 && !self.dec_shares.is_empty() {
+            self.net.gc(round.u64());
+            self.gc(round);
+        }
+        Ok(())
+    }
+
+    /// scan through the inclusion list and extract the relevant ciphertext from encrypted bundle/tx, preserving the order,
+    /// "relevant" means encrypted under the keyset this worker belongs to.
+    fn extract_ciphertexts(&self, incl: &InclusionList) -> Result<Vec<Ciphertext>> {
+        let kid = self.committee.id();
+        let cts = incl
+            .priority_bundles()
+            .iter()
+            .filter(|pb| pb.bundle().kid() == Some(kid))
+            .map(|pb| pb.bundle().data())
+            .chain(
+                incl.regular_bundles()
+                    .iter()
+                    .filter(|b| b.kid() == Some(kid))
+                    .map(|b| b.data()),
+            )
+            .map(|bytes| deserialize::<Ciphertext>(bytes))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(cts)
+    }
+
+    /// Produce decryption shares for each *relevant* encrypted bundles inside the inclusion list,
+    /// where "relevant" means targetted to the same `KeysetId` as the current decrypter/worker.
+    /// Also see [`DecShareBatch`] doc.
+    async fn decrypt(&mut self, round: RoundNumber, incl: InclusionList) -> Result<DecShareBatch> {
+        let ciphertexts = self.extract_ciphertexts(&incl)?;
+
         let mut dec_shares = vec![];
-
-        for (idx, EncryptedItem(kid, data)) in encrypted_items.iter().enumerate() {
-            let ciphertext = deserialize::<Ciphertext>(data)?;
-
-            // establish mappings
-            let cid = ciphertext.nonce();
-            self.cid2ct.insert((round, cid), ciphertext.clone());
-            self.cid2idx.insert(cid, idx);
-
+        for ct in ciphertexts {
             let dec_share = <DecryptionScheme as ThresholdEncScheme>::decrypt(
                 self.dec_sk.privkey(),
-                &ciphertext,
+                &ct,
                 &vec![],
             )
             .map_err(DecryptError::Decryption)?;
 
-            cids.push(cid);
-            kids.push(*kid);
             dec_shares.push(dec_share);
         }
-
-        Ok(ShareInfo::new(round, kids, cids, dec_shares))
-    }
-
-    fn insert_shares(&mut self, share_info: ShareInfo) -> Result<()> {
-        let kids = share_info.kids();
-        let cids = share_info.cids();
-        let shares = share_info.dec_shares();
-        // add shares to the incubator using round, keyset id and nonce as key.
-        (0..cids.len()).try_for_each(|i| {
-            let kid = *kids.get(i).ok_or(DecryptError::InvalidMessage)?;
-            let cid = cids.get(i).ok_or(DecryptError::InvalidMessage)?;
-            let share = shares
-                .get(i)
-                .ok_or(DecryptError::InvalidMessage)?
-                .to_owned();
-            let key = DecShareKey::new(share_info.round(), *cid, kid);
-            self.shares
-                .entry(key)
-                .and_modify(|shares| {
-                    shares.insert(share.index(), share.clone());
-                })
-                .or_insert_with(|| [(share.index(), share)].into_iter().collect());
-            Ok(())
+        Ok(DecShareBatch {
+            round,
+            kid: self.committee.id(),
+            dec_shares,
         })
     }
 
-    fn hatch(&mut self, round: RoundNumber) -> Result<Option<(RoundNumber, Vec<DecryptedItem>)>> {
-        let hatched = !self.shares.is_empty()
-            && self
-                .shares
-                .iter()
-                .filter(|(k, _)| k.round() == round)
-                .all(|(_, v)| self.committee.one_honest_threshold().get() < v.len());
+    /// update local cache of decrypted shares
+    fn insert_shares(&mut self, batch: DecShareBatch) -> Result<()> {
+        // This operation is doing the following: assumme local cache for this round is:
+        // [[s1a, s1b], [s2a, s2b], [s3a, s3b]]
+        // there are 3 ciphertexts, and node a and b has contributed their decrypted shares batch so far.
+        // with node c's batch [s1c, s2c, s3c], the new local cache is:
+        // [[s1a, s1b, s1c], [s2a, s2b, s2c], [s3a, s3b, s3c]]
+        self.dec_shares
+            .entry(batch.round)
+            .or_insert(vec![vec![]; batch.len()])
+            .iter_mut()
+            .zip(batch.dec_shares)
+            .for_each(|(shares, new)| shares.push(new));
 
-        if !hatched {
-            // ciphertexts are not ready to be decrypted.
+        Ok(())
+    }
+
+    /// decide if a round is ready to be hatched
+    fn is_hatchable(&self, round: &RoundNumber) -> bool {
+        self.dec_shares.contains_key(round)
+            && self
+                .dec_shares
+                .get(round)
+                .unwrap() // safe unwrap
+                .iter()
+                .all(|shares| shares.len() >= self.committee.one_honest_threshold().get())
+    }
+
+    /// Attempt to hatch for round, returns Ok(Some(_)) if hatched successfully, Ok(None) if insufficient shares
+    /// dev note: this function doesn't update local states or garbage collect for hatched rounds
+    fn hatch(&self, round: RoundNumber) -> Result<Option<InclusionList>> {
+        if !self.is_hatchable(&round) {
             return Ok(None);
         }
-        let mut to_remove = vec![];
-        // combine decryption shares for each ciphertext
-        let decrypted: BTreeMap<_, _> = self
-            .shares
+
+        let per_ct_dec_shares = self
+            .dec_shares
+            .get(&round)
+            .unwrap() // safe unwrap due to is_hatchable check above
             .iter()
-            .filter(|(k, _)| k.round() == round)
-            .map(|(k, shares)| {
-                let ciphertext = self
-                    .cid2ct
-                    .get_by_left(&(round, *k.cid()))
-                    .ok_or(DecryptError::MissingCiphertext(*k.cid()))?;
+            .map(|s| s.iter().collect::<Vec<_>>())
+            .collect::<Vec<_>>();
+        // retreive ciphertext again from the original encrypted inclusion list, and some sanity check
+        let mut incl = self
+            .incls
+            .get(&round)
+            .ok_or(DecryptError::Internal(format!(
+                "missing inclusion list for round={round} in local cache"
+            )))?
+            .clone();
+        let ciphertexts = self.extract_ciphertexts(&incl)?;
+        if ciphertexts.len() != per_ct_dec_shares.len() {
+            return Err(DecryptError::Internal(
+                "unexpected mismatched length".to_string(),
+            ));
+        }
 
-                let idx = *self
-                    .cid2idx
-                    .get(k.cid())
-                    .ok_or(DecryptError::MissingIndex(*k.cid()))?;
-
-                let decrypted_data = DecryptionScheme::combine(
+        // hatching ciphertext
+        let decrypted: Vec<Plaintext> = ciphertexts
+            .iter()
+            .zip(per_ct_dec_shares)
+            .map(|(ct, dec_shares)| {
+                let aad = vec![];
+                DecryptionScheme::combine(
                     &self.committee,
                     self.dec_sk.combkey(),
-                    shares.values().collect::<Vec<_>>(),
-                    ciphertext,
-                    &vec![],
+                    dec_shares,
+                    ct,
+                    &aad,
                 )
-                .map_err(DecryptError::Decryption)?;
-                to_remove.push(*k.cid());
-                Ok((
-                    idx,
-                    DecryptedItem(Bytes::from(<Vec<u8>>::from(decrypted_data))),
-                ))
+                .map_err(DecryptError::Decryption)
             })
             .collect::<Result<_>>()?;
 
-        // clean up
-        self.shares.retain(|k, _| k.round() != round);
-        for cid in to_remove {
-            self.cid2idx
-                .remove(&cid)
-                .ok_or(DecryptError::MissingIndex(cid))?;
-            self.cid2ct
-                .remove_by_left(&(round, cid))
-                .ok_or(DecryptError::MissingCiphertext(cid))?;
+        // construct/modify the inclusion list to replace with decrypted payload
+        let kid = self.committee.id();
+        let mut num_encrypted_priority_bundles = 0;
+        incl.priority_bundles_mut()
+            .iter_mut()
+            .filter(|pb| pb.bundle().kid() == Some(kid))
+            .map(|pb| pb.bundle_mut())
+            .zip(decrypted.clone())
+            .for_each(|(bundle, plaintext)| {
+                num_encrypted_priority_bundles += 1;
+                bundle.set_data(Bytes::from(<Vec<u8>>::from(plaintext)))
+            });
+        incl.regular_bundles_mut()
+            .iter_mut()
+            .filter(|b| b.kid() == Some(kid))
+            .zip(decrypted[num_encrypted_priority_bundles..].to_vec())
+            .for_each(|(bundle, plaintext)| {
+                bundle.set_data(Bytes::from(<Vec<u8>>::from(plaintext)))
+            });
+        if incl.is_encrypted() {
+            return Err(DecryptError::Internal(
+                "didn't fully decrypt inclusion list".to_string(),
+            ));
         }
 
-        Ok(Some((round, decrypted.into_values().collect())))
+        Ok(Some(incl))
+    }
+}
+
+/// A batch of decryption shares. Each batch is uniquely identified via (round_number, keyset_id).
+/// Each inclusion list, w/ a unique round number, may contain encrypted bundles with different keysets,
+/// those bundles are split into batches, one for each keyset.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+struct DecShareBatch {
+    round: RoundNumber,
+    kid: KeysetId,
+    // note: each decrpytion share is for a different ciphertext
+    dec_shares: Vec<DecShare>,
+}
+
+impl DecShareBatch {
+    /// Returns the number of decryption share in this batch. Equivalently, it's the number of ciphertexts.
+    pub fn len(&self) -> usize {
+        self.dec_shares.len()
     }
 }
 
@@ -569,6 +541,9 @@ fn deserialize<T: for<'de> serde::Deserialize<'de>>(d: &bytes::Bytes) -> Result<
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum DecryptError {
+    #[error("Decryption request for: {0}, but send to decrypter in: {1}")]
+    WrongDecrypter(KeysetId, KeysetId),
+
     #[error("decryption error: {0}")]
     Decryption(#[from] ThresholdEncError),
 
@@ -595,6 +570,15 @@ pub enum DecryptError {
 
     #[error("inconsistent state")]
     State,
+
+    #[error("unexpected internal err: {0}")]
+    Internal(String),
+}
+
+impl From<NetworkDown> for DecryptError {
+    fn from(_: NetworkDown) -> Self {
+        Self::Shutdown
+    }
 }
 
 #[cfg(test)]

--- a/timeboost-sequencer/src/include.rs
+++ b/timeboost-sequencer/src/include.rs
@@ -79,8 +79,9 @@ impl Includer {
             self.seqno = SeqNo::zero();
         }
 
-        // NOTE: in timeboost spec, regular bundles are unordered set, thus technically a HashMap is sufficient.
-        // However, ordering them simplifies the decryption phase logic at no cost, thus we choose BTreeMap instead.
+        // NOTE: in timeboost spec, regular bundles are an unordered set, thus technically a HashMap
+        // is sufficient. However, ordering them simplifies the decryption phase logic at no cost,
+        // thus we choose BTreeMap instead.
         let mut regular: BTreeMap<Bundle, usize> = BTreeMap::new();
         let mut priority: BTreeMap<SeqNo, SignedPriorityBundle> = BTreeMap::new();
         let mut retry = RetryList::new();

--- a/timeboost-sequencer/src/include.rs
+++ b/timeboost-sequencer/src/include.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
 use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 
 use multisig::Committee;
 use sailfish::types::RoundNumber;
@@ -79,7 +79,9 @@ impl Includer {
             self.seqno = SeqNo::zero();
         }
 
-        let mut regular: HashMap<Bundle, usize> = HashMap::new();
+        // NOTE: in timeboost spec, regular bundles are unordered set, thus technically a HashMap is sufficient.
+        // However, ordering them simplifies the decryption phase logic at no cost, thus we choose BTreeMap instead.
+        let mut regular: BTreeMap<Bundle, usize> = BTreeMap::new();
         let mut priority: BTreeMap<SeqNo, SignedPriorityBundle> = BTreeMap::new();
         let mut retry = RetryList::new();
 

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -264,19 +264,17 @@ impl Sequencer {
 
 impl Task {
     /// Run sequencing logic.
-    //
     // Processing takes place as follows:
     //
-    // 1. Sailfish actions are executed and outputs collected in
-    //    round-indexed sequences of candidate lists.
-    // 2. Candidates are handed to the inclusion phase and produce the
-    //    next inclusion list.
-    // 3. If the decrypter has capacity the inclusion list is passed on
-    //    and processing continues with the next candidates.
+    // 1. Sailfish actions are executed and outputs collected in round-indexed sequences of
+    //    candidate lists.
+    // 2. Candidates are handed to the inclusion phase and produce the next inclusion list.
+    // 3. If the decrypter has capacity the inclusion list is passed on and processing continues
+    //    with the next candidates.
     // 4. Otherwise we buffer the inclusion list and pause Sailfish execution.
-    // 5. When the decrypter produces outputs we hand it to the ordering
-    //    phase and if it then has capacity we resume with the buffered
-    //    inclusion list from (4) and process the remaining candidates.
+    // 5. When the decrypter produces outputs we hand it to the ordering phase and if it then has
+    //    capacity we resume with the buffered inclusion list from (4) and process the remaining
+    //    candidates.
     // 6. The logic continues at step (1).
     //
     // NB that if Sailfish does not produce outputs (i.e. candidate lists)

--- a/timeboost-types/Cargo.toml
+++ b/timeboost-types/Cargo.toml
@@ -25,6 +25,7 @@ sailfish-types = { path = "../sailfish-types" }
 serde = { workspace = true }
 thiserror = { workspace = true }
 timeboost-crypto = { path = "../timeboost-crypto" }
+tracing = { workspace = true }
 
 [dev-dependencies]
 quickcheck = "1"

--- a/timeboost-types/src/bundle.rs
+++ b/timeboost-types/src/bundle.rs
@@ -163,10 +163,6 @@ impl PriorityBundle {
         &self.bundle
     }
 
-    pub fn bundle_mut(&mut self) -> &mut Bundle {
-        &mut self.bundle
-    }
-
     pub fn auction(&self) -> Address {
         self.auction
     }
@@ -259,8 +255,10 @@ impl SignedPriorityBundle {
         ))
     }
 
+    /// Set the data payload to un-encrypted, plaintext data.
     pub fn set_data(&mut self, d: Bytes) {
         self.bundle.data = d;
+        self.bundle.kid = None;
         self.update_hash()
     }
 

--- a/timeboost-types/src/decryption.rs
+++ b/timeboost-types/src/decryption.rs
@@ -1,13 +1,8 @@
-use sailfish_types::RoundNumber;
-use serde::{Deserialize, Serialize};
-use timeboost_crypto::{
-    DecryptionScheme, KeysetId, Nonce, traits::threshold_enc::ThresholdEncScheme,
-};
+use timeboost_crypto::{DecryptionScheme, traits::threshold_enc::ThresholdEncScheme};
 
 type KeyShare = <DecryptionScheme as ThresholdEncScheme>::KeyShare;
 type PublicKey = <DecryptionScheme as ThresholdEncScheme>::PublicKey;
 type CombKey = <DecryptionScheme as ThresholdEncScheme>::CombKey;
-type DecShare = <DecryptionScheme as ThresholdEncScheme>::DecShare;
 
 /// Key materials related to the decryption phase, including the public key for encryption,
 /// the per-node key share for decryption, and combiner key for hatching decryption shares into
@@ -38,74 +33,5 @@ impl DecryptionKey {
 
     pub fn privkey(&self) -> &KeyShare {
         &self.privkey
-    }
-}
-
-/// TODO: (alex) remove this? this is decryption phase specific temp struct. not exposing externally
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ShareInfo {
-    round: RoundNumber,
-    kids: Vec<KeysetId>,
-    cids: Vec<Nonce>,
-    dec_shares: Vec<DecShare>,
-}
-
-impl ShareInfo {
-    pub fn new(
-        round: RoundNumber,
-        kids: Vec<KeysetId>,
-        cids: Vec<Nonce>,
-        dec_shares: Vec<DecShare>,
-    ) -> Self {
-        ShareInfo {
-            round,
-            kids,
-            cids,
-            dec_shares,
-        }
-    }
-
-    pub fn round(&self) -> RoundNumber {
-        self.round
-    }
-
-    pub fn kids(&self) -> &[KeysetId] {
-        &self.kids
-    }
-
-    pub fn cids(&self) -> &[Nonce] {
-        &self.cids
-    }
-
-    pub fn dec_shares(&self) -> &[DecShare] {
-        &self.dec_shares
-    }
-}
-
-/// Metadata of a decryption share, including the round number it belongs to, a ciphertext identifier
-/// (currently using the nonce inside the ciphertext since it's never reused), and the keyset id.
-// TODO: (alex) see if we can simplify this to a mere cid?
-#[derive(Clone, Debug, Hash, Serialize, Deserialize, Ord, PartialEq, Eq, PartialOrd)]
-pub struct DecShareMetadata {
-    round: RoundNumber,
-    cid: Nonce,
-    kid: KeysetId,
-}
-
-impl DecShareMetadata {
-    pub fn new(round: RoundNumber, cid: Nonce, kid: KeysetId) -> Self {
-        DecShareMetadata { round, cid, kid }
-    }
-
-    pub fn round(&self) -> RoundNumber {
-        self.round
-    }
-
-    pub fn cid(&self) -> &Nonce {
-        &self.cid
-    }
-
-    pub fn kid(&self) -> &KeysetId {
-        &self.kid
     }
 }

--- a/timeboost-types/src/decryption.rs
+++ b/timeboost-types/src/decryption.rs
@@ -9,6 +9,9 @@ type PublicKey = <DecryptionScheme as ThresholdEncScheme>::PublicKey;
 type CombKey = <DecryptionScheme as ThresholdEncScheme>::CombKey;
 type DecShare = <DecryptionScheme as ThresholdEncScheme>::DecShare;
 
+/// Key materials related to the decryption phase, including the public key for encryption,
+/// the per-node key share for decryption, and combiner key for hatching decryption shares into
+/// plaintext
 #[derive(Debug, Clone)]
 pub struct DecryptionKey {
     pubkey: PublicKey,
@@ -38,6 +41,7 @@ impl DecryptionKey {
     }
 }
 
+/// TODO: (alex) remove this? this is decryption phase specific temp struct. not exposing externally
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ShareInfo {
     round: RoundNumber,
@@ -78,16 +82,19 @@ impl ShareInfo {
     }
 }
 
+/// Metadata of a decryption share, including the round number it belongs to, a ciphertext identifier
+/// (currently using the nonce inside the ciphertext since it's never reused), and the keyset id.
+// TODO: (alex) see if we can simplify this to a mere cid?
 #[derive(Clone, Debug, Hash, Serialize, Deserialize, Ord, PartialEq, Eq, PartialOrd)]
-pub struct DecShareKey {
+pub struct DecShareMetadata {
     round: RoundNumber,
     cid: Nonce,
     kid: KeysetId,
 }
 
-impl DecShareKey {
+impl DecShareMetadata {
     pub fn new(round: RoundNumber, cid: Nonce, kid: KeysetId) -> Self {
-        DecShareKey { round, cid, kid }
+        DecShareMetadata { round, cid, kid }
     }
 
     pub fn round(&self) -> RoundNumber {

--- a/timeboost-types/src/inclusion_list.rs
+++ b/timeboost-types/src/inclusion_list.rs
@@ -7,8 +7,8 @@ use timeboost_crypto::KeysetId;
 /// List of bundles to be included, selected from `CandidateList`.
 #[derive(Debug, Clone)]
 pub struct InclusionList {
-    // NOTE: different from sailfish's round number, monotonically increasing at timeboost sequencer
-    // side, derived from the max sailfish round among all the `Candidates` included.
+    // NOTE: different from sailfish's round number, monotonically increasing at timeboost
+    // sequencer side, derived from the max sailfish round among all the `Candidates` included.
     round: RoundNumber,
     time: Timestamp,
     index: DelayedInboxIndex,
@@ -53,7 +53,8 @@ impl InclusionList {
             || self.regular_bundles().iter().any(|b| b.is_encrypted())
     }
 
-    /// Returns the keysets (their IDs) required to decrypt the encryted bundles in this list, or empty vec if not encrypted.
+    /// Returns the keysets (their IDs) required to decrypt the encryted bundles in this list, or
+    /// empty vec if not encrypted.
     pub fn kids(&self) -> Vec<KeysetId> {
         let mut kids = BTreeSet::new();
         for pb in self.priority_bundles() {

--- a/timeboost-types/src/inclusion_list.rs
+++ b/timeboost-types/src/inclusion_list.rs
@@ -1,8 +1,15 @@
+use std::collections::BTreeSet;
+
 use crate::{Bundle, DelayedInboxIndex, Epoch, Timestamp, bundle::SignedPriorityBundle};
 use sailfish_types::RoundNumber;
+use serde::Serialize;
+use timeboost_crypto::KeysetId;
 
-#[derive(Debug, Clone)]
+/// List of bundles to be included, selected from `CandidateList`.
+#[derive(Debug, Clone, Serialize)]
 pub struct InclusionList {
+    // NOTE: different from sailfish's round number, monotonically increasing at timeboost sequencer side,
+    // derived from the max sailfish round among all the `Candidates` included.
     round: RoundNumber,
     time: Timestamp,
     index: DelayedInboxIndex,
@@ -39,6 +46,36 @@ impl InclusionList {
         self.regular.is_empty() && self.priority.is_empty()
     }
 
+    /// Returns true if any one of the bundle (either priority or regular) is encrypted
+    pub fn is_encrypted(&self) -> bool {
+        let is_decrypted = self
+            .priority_bundles()
+            .iter()
+            .all(|pb| !pb.bundle().is_encrypted())
+            && self.regular_bundles().iter().all(|b| !b.is_encrypted());
+        !is_decrypted
+    }
+
+    /// Returns the keysets (their IDs) required to decrypt the encryted bundles in this list, or empty vec if not encrypted.
+    pub fn kids(&self) -> Vec<KeysetId> {
+        let mut kids = BTreeSet::new();
+        for pb in self.priority_bundles() {
+            if let Some(kid) = pb.bundle().kid() {
+                kids.insert(kid);
+            }
+        }
+        for b in self.regular_bundles() {
+            if let Some(kid) = b.kid() {
+                kids.insert(kid);
+            }
+        }
+
+        if kids.len() > 1 {
+            tracing::error!(round = %self.round, num_keysets = %kids.len(),"Expect 1 keyset per inclusion list for now.");
+        }
+        kids.into_iter().collect()
+    }
+
     pub fn has_priority_bundles(&self) -> bool {
         !self.priority.is_empty()
     }
@@ -66,9 +103,15 @@ impl InclusionList {
     pub fn regular_bundles(&self) -> &[Bundle] {
         &self.regular
     }
+    pub fn regular_bundles_mut(&mut self) -> &mut [Bundle] {
+        &mut self.regular
+    }
 
     pub fn priority_bundles(&self) -> &[SignedPriorityBundle] {
         &self.priority
+    }
+    pub fn priority_bundles_mut(&mut self) -> &mut [SignedPriorityBundle] {
+        &mut self.priority
     }
 
     pub fn delayed_inbox_index(&self) -> DelayedInboxIndex {

--- a/timeboost-types/src/lib.rs
+++ b/timeboost-types/src/lib.rs
@@ -18,7 +18,7 @@ pub use bundle::{
 };
 pub use bytes::Bytes;
 pub use candidate_list::{CandidateList, CandidateListBytes};
-pub use decryption::{DecShareKey, DecryptionKey, ShareInfo};
+pub use decryption::{DecShareMetadata, DecryptionKey, ShareInfo};
 pub use delayed_inbox::DelayedInboxIndex;
 pub use inclusion_list::InclusionList;
 pub use retry_list::RetryList;

--- a/timeboost-types/src/lib.rs
+++ b/timeboost-types/src/lib.rs
@@ -18,7 +18,7 @@ pub use bundle::{
 };
 pub use bytes::Bytes;
 pub use candidate_list::{CandidateList, CandidateListBytes};
-pub use decryption::{DecShareMetadata, DecryptionKey, ShareInfo};
+pub use decryption::DecryptionKey;
 pub use delayed_inbox::DelayedInboxIndex;
 pub use inclusion_list::InclusionList;
 pub use retry_list::RetryList;

--- a/timeboost-utils/src/keyset.rs
+++ b/timeboost-utils/src/keyset.rs
@@ -126,15 +126,16 @@ pub async fn wait_for_live_peer(mut host: Address) -> Result<()> {
         .timeout(Duration::from_secs(1))
         .build()?;
 
-    // The port is always 8800 + node index. We need to increment the port by one because we are using
-    // the cli port for sailfish in our default config.
+    // The port is always 8800 + node index. We need to increment the port by one because we are
+    // using the cli port for sailfish in our default config.
     host.set_port(800 + host.port());
 
     loop {
         let url = format!("http://{host}/v0/healthz");
         tracing::info!(%host, %url, "establishing connection to load balancer");
 
-        // Check if the healthz endpoint returns a 200 on the new host, looping forever until it does
+        // Check if the healthz endpoint returns a 200 on the new host, looping forever until it
+        // does
         match client.get(&url).send().await {
             Ok(resp) => {
                 tracing::info!("got response {resp:?}, status {}", resp.status());

--- a/timeboost-utils/src/load_generation.rs
+++ b/timeboost-utils/src/load_generation.rs
@@ -26,8 +26,7 @@ pub fn make_bundle(pubkey: &EncKey) -> anyhow::Result<BundleVariant> {
         let plaintext = Plaintext::new(data.to_vec());
         let ciphertext = DecryptionScheme::encrypt(&mut rng, &kid, pubkey, &plaintext, &vec![])?;
         let encoded = serialize(&ciphertext)?;
-        bundle.set_data(encoded.into());
-        bundle.set_kid(kid);
+        bundle.set_encrypted_data(encoded.into(), kid);
     }
     if rng.gen_bool(0.5) {
         // priority

--- a/timeboost/src/binaries/builder.rs
+++ b/timeboost/src/binaries/builder.rs
@@ -141,8 +141,9 @@ async fn main() -> Result<()> {
         .get(cli.id as usize)
         .expect("keyset for this node to exist");
 
-    // Now, fetch the signature private key and decryption private key, preference toward the JSON config.
-    // Note that the clone of the two fields explicitly avoids cloning the entire `PublicNodeInfo`.
+    // Now, fetch the signature private key and decryption private key, preference toward the JSON
+    // config. Note that the clone of the two fields explicitly avoids cloning the entire
+    // `PublicNodeInfo`.
     let (sig_key, dec_sk) = match (my_keyset.sig_pk.clone(), my_keyset.dec_pk.clone()) {
         // We found both in the JSON, we're good to go.
         (Some(sig_pk), Some(dec_pk)) => {


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209394409339229/task/1209978846980044

This is 2nd/last part of the decryption phase refactoring, following #342 


### This PR:

- WorkerCommand -> WorkerRequest & WorkerResponse
- Bundle and InclusionList now have a `is_encrypted()` method, inferred via Some/None of `.kid`; and can be updated via `set_data(data)` after decryption or via `set_encrypted_data(ct, keyset_id)` to some ciphertext
- Decrypter will reject/ignore enqueue request if it's targetting a different keyset
  - add `InclusionList.kids()` to return a list of keysets involved
- reorganize hatched_rounds and first_requested_round from local variables of `go()` to fields of `Worker` struct/states, this helps with splitting the `go()` logic into more modular functions
- replace ShareInfo with DecShareBatch with the simplifying (but correct) assumption that every inclusion list could contains multiple batch, each batch is uniquely identified via (round, kid)
  - DecShareBatch is local to the decryption phase instead of a workspace-wide types
- completely rewrite decrypt(), hatch(), insert_shares() due to refactoring of the worker state
- Use `BTreeMap` for regular bundles to ensure the same inclusion list arriving at decryption phase for simpler tracking logic
- completely removed DecShareKey and ShareInfo


### Key places to review:

Probably reread `Decrypter.enqueue()`, `Decrypter.next()` and `Worker.go()` at a minimum.
