### PR TITLE
Dynamic committee

### DIFF
--- a/multisig/src/committee.rs
+++ b/multisig/src/committee.rs
@@ -112,7 +112,9 @@ impl<T: PartialOrd> Interval<T> {
             Self::From(start) => start <= p,
         }
     }
+}
 
+impl<T> Interval<T> {
     pub fn start(&self) -> &T {
         match self {
             Self::Range(start, _) => start,
@@ -144,6 +146,11 @@ impl<I> CommitteeSeq<I> {
     /// Get the current committee.
     pub fn current(&self) -> &Committee {
         &self.curr.1
+    }
+
+    /// Get the current committee start index.
+    pub fn current_start(&self) -> &I {
+        self.curr.0.start()
     }
 
     /// Find the most-recent committee that matches the given predicate.

--- a/multisig/src/committee.rs
+++ b/multisig/src/committee.rs
@@ -153,14 +153,9 @@ impl<I> CommitteeSeq<I> {
         self.curr.0.start()
     }
 
-    /// Find the most-recent committee that matches the given predicate.
-    pub fn find<F>(&self, pred: F) -> Option<&(Interval<I>, Committee)>
-    where
-        F: Fn(&Interval<I>, &Committee) -> bool,
-    {
-        once(&self.curr)
-            .chain(self.prev.iter().rev())
-            .find(|(r, v)| pred(r, v))
+    /// Iterate over committees and their intervals starting at the most recent.
+    pub fn iter(&self) -> impl Iterator<Item = &(Interval<I>, Committee)> {
+        once(&self.curr).chain(self.prev.iter().rev())
     }
 
     /// Drop committees as long as the given predicate holds true.
@@ -182,7 +177,7 @@ impl<I> CommitteeSeq<I> {
 impl<I: PartialOrd> CommitteeSeq<I> {
     /// Get the committee that covers the given index.
     pub fn get(&self, i: I) -> Option<&Committee> {
-        self.find(|iv, _| iv.contains(&i)).map(|(_, v)| v)
+        self.iter().find(|(iv, _)| iv.contains(&i)).map(|(_, v)| v)
     }
 }
 

--- a/multisig/src/committee.rs
+++ b/multisig/src/committee.rs
@@ -180,3 +180,9 @@ impl<I: PartialOrd + Clone> CommitteeSeq<I> {
         Ok(())
     }
 }
+
+impl<I> From<(RangeFrom<I>, Committee)> for CommitteeSeq<I> {
+    fn from((i, c): (RangeFrom<I>, Committee)) -> Self {
+        Self::new(i, c)
+    }
+}

--- a/multisig/src/lib.rs
+++ b/multisig/src/lib.rs
@@ -15,7 +15,7 @@ use ed25519_compact as ed25519;
 use serde::{Deserialize, Serialize};
 
 pub use cert::Certificate;
-pub use committee::{Committee, CommitteeSeq};
+pub use committee::{Committee, CommitteeSeq, IntervalOverlap};
 pub use envelope::{Envelope, Unchecked, Validated};
 pub use signed::Signed;
 pub use votes::VoteAccumulator;

--- a/multisig/src/lib.rs
+++ b/multisig/src/lib.rs
@@ -15,10 +15,19 @@ use ed25519_compact as ed25519;
 use serde::{Deserialize, Serialize};
 
 pub use cert::Certificate;
-pub use committee::Committee;
+pub use committee::{Committee, CommitteeSeq};
 pub use envelope::{Envelope, Unchecked, Validated};
 pub use signed::Signed;
 pub use votes::VoteAccumulator;
+
+/// Class of types that have an index.
+pub trait Indexed {
+    /// The index type.
+    type Index: PartialOrd + Clone;
+
+    /// The index value.
+    fn index(&self) -> Self::Index;
+}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct KeyId(u8);

--- a/sailfish-consensus/benches/consensus_single.rs
+++ b/sailfish-consensus/benches/consensus_single.rs
@@ -133,7 +133,6 @@ fn action_to_msg<T: Committable>(action: Action<T>) -> Option<Message<T>> {
         Action::ResetTimer(_) => None,
         Action::Deliver(..) => None,
         Action::Gc(_) => None,
-        Action::NextCommittee(..) => None,
     }
 }
 

--- a/sailfish-consensus/benches/consensus_single.rs
+++ b/sailfish-consensus/benches/consensus_single.rs
@@ -1,5 +1,5 @@
 use std::iter::repeat;
-use std::{collections::HashMap, fmt, num::NonZeroUsize};
+use std::{collections::HashMap, fmt};
 
 use committable::Committable;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
@@ -61,7 +61,7 @@ impl Net {
             })
             .collect::<HashMap<_, _>>();
 
-        let dag = Dag::new(NonZeroUsize::new(nodes.len()).unwrap());
+        let dag = Dag::new();
 
         let mut messages = Vec::new();
 

--- a/sailfish-consensus/benches/consensus_single.rs
+++ b/sailfish-consensus/benches/consensus_single.rs
@@ -133,6 +133,7 @@ fn action_to_msg<T: Committable>(action: Action<T>) -> Option<Message<T>> {
         Action::ResetTimer(_) => None,
         Action::Deliver(..) => None,
         Action::Gc(_) => None,
+        Action::NextCommittee(..) => None,
     }
 }
 

--- a/sailfish-consensus/benches/consensus_single.rs
+++ b/sailfish-consensus/benches/consensus_single.rs
@@ -5,7 +5,7 @@ use committable::Committable;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use multisig::{Committee, Keypair, PublicKey};
 use sailfish_consensus::{Consensus, Dag};
-use sailfish_types::{Action, Evidence, Message, Unit};
+use sailfish_types::{Action, Evidence, Message, RoundNumber, Unit};
 
 #[derive(Debug, Clone, Copy)]
 struct MultiRoundTestSpec {
@@ -42,10 +42,13 @@ impl Net {
         let MultiRoundTestSpec { nodes, rounds } = spec;
         let kps = (0..nodes).map(|_| Keypair::generate()).collect::<Vec<_>>();
 
-        let com = Committee::new(
-            kps.iter()
-                .enumerate()
-                .map(|(i, kp)| (i as u8, kp.public_key())),
+        let com = (
+            RoundNumber::genesis()..,
+            Committee::new(
+                kps.iter()
+                    .enumerate()
+                    .map(|(i, kp)| (i as u8, kp.public_key())),
+            ),
         );
 
         let mut nodes = kps
@@ -53,7 +56,7 @@ impl Net {
             .map(|kp| {
                 (
                     kp.public_key(),
-                    Consensus::new(kp, com.clone(), repeat(Unit)),
+                    Consensus::new(kp, com.clone().into(), repeat(Unit)),
                 )
             })
             .collect::<HashMap<_, _>>();

--- a/sailfish-consensus/src/dag.rs
+++ b/sailfish-consensus/src/dag.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, num::NonZeroUsize, ops::RangeBounds};
+use std::{collections::BTreeMap, fmt, ops::RangeBounds};
 
 use multisig::PublicKey;
 use sailfish_types::{RoundNumber, Vertex};
@@ -6,37 +6,30 @@ use sailfish_types::{RoundNumber, Vertex};
 #[derive(Debug, Clone)]
 pub struct Dag<T> {
     elements: BTreeMap<RoundNumber, BTreeMap<PublicKey, Vertex<T>>>,
-    max_keys: NonZeroUsize,
+}
+
+impl<T> Default for Dag<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Dag<T> {
+    /// Create a new empty DAG.
+    pub fn new() -> Self {
+        Self {
+            elements: BTreeMap::new(),
+        }
+    }
 }
 
 impl<T: PartialEq> Dag<T> {
-    /// Create a new empty DAG.
-    pub fn new(max_keys: NonZeroUsize) -> Self {
-        Self {
-            elements: BTreeMap::new(),
-            max_keys,
-        }
-    }
-
-    /// Create a new DAG from a sequence of `Vertex` values.
-    pub fn from_iter<I>(entries: I, max_keys: NonZeroUsize) -> Self
-    where
-        I: IntoIterator<Item = Vertex<T>>,
-    {
-        let mut dag = Self::new(max_keys);
-        for v in entries {
-            dag.add(v);
-        }
-        dag
-    }
-
     /// Adds a new vertex to the DAG in its corresponding round and source position
     pub fn add(&mut self, v: Vertex<T>) {
         debug_assert!(!self.contains(&v));
         let r = *v.round().data();
         let s = v.source();
         let m = self.elements.entry(r).or_default();
-        debug_assert!(m.len() < self.max_keys.get());
         m.insert(*s, v);
     }
 
@@ -53,6 +46,11 @@ impl<T: PartialEq> Dag<T> {
     /// Returns the total number of rounds present in the DAG
     pub fn depth(&self) -> usize {
         self.elements.len()
+    }
+
+    /// Get the number of vertices at a particular round.
+    pub fn size_at(&self, r: RoundNumber) -> usize {
+        self.elements.get(&r).map(|m| m.len()).unwrap_or(0)
     }
 
     /// Returns an iterator over all round numbers present in the DAG
@@ -160,7 +158,20 @@ impl<T: PartialEq> Dag<T> {
     }
 }
 
-impl<B: std::fmt::Display> Dag<B> {
+impl<T: PartialEq> FromIterator<Vertex<T>> for Dag<T> {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Vertex<T>>,
+    {
+        let mut dag = Self::new();
+        for v in iter {
+            dag.add(v);
+        }
+        dag
+    }
+}
+
+impl<T: fmt::Display> Dag<T> {
     /// Create a string representation of the DAG for debugging purposes.
     pub fn dbg(&self) -> String {
         let mut s = String::from("\n\n");
@@ -177,8 +188,6 @@ impl<B: std::fmt::Display> Dag<B> {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroUsize;
-
     use multisig::{Committee, Keypair, Signed, VoteAccumulator};
     use sailfish_types::{RoundNumber, Unit, Vertex};
 
@@ -186,7 +195,7 @@ mod tests {
 
     #[test]
     fn test_is_connected() {
-        let mut dag = Dag::<Unit>::new(NonZeroUsize::new(10).unwrap());
+        let mut dag = Dag::<Unit>::new();
 
         let kp1 = Keypair::generate();
         let kp2 = Keypair::generate();

--- a/sailfish-consensus/src/dag.rs
+++ b/sailfish-consensus/src/dag.rs
@@ -203,7 +203,7 @@ mod tests {
         ]);
 
         let gen_evidence = |r: u64| {
-            let mut va = VoteAccumulator::new(com.clone());
+            let mut va = VoteAccumulator::new(r.into(), com.clone());
             va.add(Signed::new(RoundNumber::from(r), &kp1, false))
                 .unwrap();
             va.add(Signed::new(RoundNumber::from(r), &kp2, false))

--- a/sailfish-consensus/src/lib.rs
+++ b/sailfish-consensus/src/lib.rs
@@ -632,6 +632,7 @@ where
     /// If all edges of the vertex point to other vertices in the DAG we add the
     /// vertex to the DAG. If we also have more than 2f vertices for the given
     /// round, we can try to commit the leader vertex of a round.
+    #[allow(clippy::result_large_err)]
     fn try_to_add_to_dag(
         &mut self,
         c: &Committee,

--- a/sailfish-rbc/src/digest.rs
+++ b/sailfish-rbc/src/digest.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use committable::{Commitment, Committable, RawCommitmentBuilder};
-use multisig::{Certificate, Envelope};
+use multisig::{Certificate, Envelope, Indexed};
 use sailfish_types::{Message, RoundNumber, Vertex};
 use serde::{Deserialize, Serialize};
 
@@ -23,6 +23,14 @@ impl Digest {
 
     pub fn round(&self) -> RoundNumber {
         self.0
+    }
+}
+
+impl Indexed for Digest {
+    type Index = RoundNumber;
+
+    fn index(&self) -> Self::Index {
+        self.round()
     }
 }
 

--- a/sailfish-rbc/src/error.rs
+++ b/sailfish-rbc/src/error.rs
@@ -1,4 +1,5 @@
 use cliquenet::overlay::{DataError, NetworkDown};
+use sailfish_types::RoundNumber;
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -17,6 +18,9 @@ pub enum RbcError {
 
     #[error("invalid sender")]
     InvalidSender,
+
+    #[error("no committee for round {0}")]
+    NoCommittee(RoundNumber),
 
     #[error("rbc has shut down")]
     Shutdown,

--- a/sailfish-types/src/info.rs
+++ b/sailfish-types/src/info.rs
@@ -1,0 +1,75 @@
+use std::fmt;
+
+use crate::RoundNumber;
+use committable::{Commitment, Committable, RawCommitmentBuilder};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CommitteeId(u64);
+
+impl CommitteeId {
+    pub const fn new(n: u64) -> Self {
+        Self(n)
+    }
+}
+
+impl From<u64> for CommitteeId {
+    fn from(n: u64) -> Self {
+        Self(n)
+    }
+}
+
+impl From<CommitteeId> for u64 {
+    fn from(id: CommitteeId) -> Self {
+        id.0
+    }
+}
+
+impl fmt::Display for CommitteeId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct CommitteeInfo {
+    id: CommitteeId,
+    round: RoundNumber,
+}
+
+impl CommitteeInfo {
+    pub fn new<C, N>(id: C, r: N) -> Self
+    where
+        C: Into<CommitteeId>,
+        N: Into<RoundNumber>,
+    {
+        Self {
+            id: id.into(),
+            round: r.into(),
+        }
+    }
+
+    pub fn id(&self) -> CommitteeId {
+        self.id
+    }
+
+    pub fn round(&self) -> RoundNumber {
+        self.round
+    }
+}
+
+impl fmt::Display for CommitteeInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{{ id := {}, round := {} }}", self.id, self.round)
+    }
+}
+
+impl Committable for CommitteeInfo {
+    fn commit(&self) -> Commitment<Self> {
+        RawCommitmentBuilder::new("CommitteeInfo")
+            .u64_field("id", self.id.into())
+            .u64_field("round", self.round.into())
+            .finalize()
+    }
+}

--- a/sailfish-types/src/lib.rs
+++ b/sailfish-types/src/lib.rs
@@ -12,6 +12,7 @@ pub use round::RoundNumber;
 pub use vertex::Vertex;
 
 use committable::{Commitment, Committable, RawCommitmentBuilder};
+use multisig::Indexed;
 use serde::{Deserialize, Serialize};
 
 /// The empty type has no values.
@@ -35,5 +36,13 @@ pub struct Unit;
 impl Committable for Unit {
     fn commit(&self) -> Commitment<Self> {
         RawCommitmentBuilder::new("Unit").finalize()
+    }
+}
+
+impl Indexed for Unit {
+    type Index = Self;
+
+    fn index(&self) -> Self::Index {
+        Unit
     }
 }

--- a/sailfish-types/src/lib.rs
+++ b/sailfish-types/src/lib.rs
@@ -5,11 +5,13 @@ mod round;
 mod vertex;
 
 pub use comm::{Comm, CommError};
-pub use message::{Action, Evidence, Payload};
+pub use message::{Action, Evidence, Payload, NextCommittee};
 pub use message::{Message, NoVote, NoVoteMessage, Timeout, TimeoutMessage};
 pub use payload::DataSource;
 pub use round::RoundNumber;
 pub use vertex::Vertex;
+
+use std::fmt;
 
 use committable::{Commitment, Committable, RawCommitmentBuilder};
 use multisig::Indexed;
@@ -44,5 +46,33 @@ impl Indexed for Unit {
 
     fn index(&self) -> Self::Index {
         Unit
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct UnixTime(u64);
+
+impl UnixTime {
+    pub fn seconds(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for UnixTime {
+    fn from(seconds: u64) -> Self {
+        Self(seconds)
+    }
+}
+
+impl From<UnixTime> for u64 {
+    fn from(seconds: UnixTime) -> Self {
+        seconds.0
+    }
+}
+
+impl fmt::Display for UnixTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
 }

--- a/sailfish-types/src/lib.rs
+++ b/sailfish-types/src/lib.rs
@@ -5,7 +5,7 @@ mod round;
 mod vertex;
 
 pub use comm::{Comm, CommError};
-pub use message::{Action, Evidence, Payload, NextCommittee};
+pub use message::{Action, Evidence, NextCommittee, Payload};
 pub use message::{Message, NoVote, NoVoteMessage, Timeout, TimeoutMessage};
 pub use payload::DataSource;
 pub use round::RoundNumber;

--- a/sailfish-types/src/lib.rs
+++ b/sailfish-types/src/lib.rs
@@ -1,11 +1,13 @@
 mod comm;
+mod info;
 mod message;
 mod payload;
 mod round;
 mod vertex;
 
 pub use comm::{Comm, CommError};
-pub use message::{Action, Evidence, NextCommittee, Payload};
+pub use info::{CommitteeId, CommitteeInfo};
+pub use message::{Action, Evidence, Payload};
 pub use message::{Message, NoVote, NoVoteMessage, Timeout, TimeoutMessage};
 pub use payload::DataSource;
 pub use round::RoundNumber;

--- a/sailfish-types/src/message.rs
+++ b/sailfish-types/src/message.rs
@@ -1,12 +1,12 @@
 use core::fmt;
 
 use committable::{Commitment, Committable, RawCommitmentBuilder};
-use multisig::{Certificate, Committee, CommitteeSeq};
+use multisig::{Certificate, CommitteeSeq};
 use multisig::{Envelope, Indexed, Keypair, PublicKey, Signed, Unchecked, Validated};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
-use crate::{CommitteeInfo, RoundNumber, Vertex};
+use crate::{RoundNumber, Vertex};
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub enum Message<T: Committable, Status = Validated> {
@@ -273,9 +273,6 @@ pub enum Action<T: Committable> {
 
     /// Signal that it is safe to garbage collect up to the given round number.
     Gc(RoundNumber),
-
-    /// Inform about the next committee to use.
-    NextCommittee(CommitteeInfo, Committee),
 }
 
 impl<T: Committable> Action<T> {
@@ -312,9 +309,6 @@ impl<T: Committable> fmt::Display for Action<T> {
             }
             Action::Gc(r) => {
                 write!(f, "Gc({r})")
-            }
-            Action::NextCommittee(info, _) => {
-                write!(f, "NextCommittee({info})")
             }
         }
     }

--- a/sailfish-types/src/message.rs
+++ b/sailfish-types/src/message.rs
@@ -489,7 +489,7 @@ impl Indexed for NoVoteMessage {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct NextCommittee {
     time: UnixTime,
-    round: RoundNumber
+    round: RoundNumber,
 }
 
 impl NextCommittee {

--- a/sailfish-types/src/round.rs
+++ b/sailfish-types/src/round.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::ops::{Add, AddAssign, Deref, Sub};
 
 use committable::{Commitment, Committable, RawCommitmentBuilder};
+use multisig::Indexed;
 use serde::{Deserialize, Serialize};
 
 /// The sailfish genesis round number.
@@ -26,6 +27,14 @@ impl RoundNumber {
 
     pub fn is_genesis(self) -> bool {
         self == GENESIS_ROUND
+    }
+}
+
+impl Indexed for RoundNumber {
+    type Index = Self;
+
+    fn index(&self) -> Self::Index {
+        *self
     }
 }
 

--- a/sailfish-types/src/vertex.rs
+++ b/sailfish-types/src/vertex.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeSet, fmt::Display, hash::Hash};
 
 use committable::{Commitment, Committable, RawCommitmentBuilder};
-use multisig::{Certificate, Keypair, PublicKey, Signed};
+use multisig::{Certificate, Indexed, Keypair, PublicKey, Signed};
 use serde::{Deserialize, Serialize};
 
 use super::message::NoVote;
@@ -110,6 +110,14 @@ impl<T> Vertex<T> {
 
     pub fn dbg(&self) -> String {
         format!("{} -> {:?}", self, self.edges().collect::<Vec<_>>())
+    }
+}
+
+impl<T> Indexed for Vertex<T> {
+    type Index = RoundNumber;
+
+    fn index(&self) -> Self::Index {
+        *self.round.data()
     }
 }
 

--- a/sailfish-types/src/vertex.rs
+++ b/sailfish-types/src/vertex.rs
@@ -37,7 +37,7 @@ impl<T> Vertex<T> {
             no_vote: None,
             committed: RoundNumber::genesis(),
             payload: d,
-            next_committee: None
+            next_committee: None,
         }
     }
 

--- a/sailfish-types/src/vertex.rs
+++ b/sailfish-types/src/vertex.rs
@@ -4,7 +4,7 @@ use committable::{Commitment, Committable, RawCommitmentBuilder};
 use multisig::{Certificate, Indexed, Keypair, PublicKey, Signed};
 use serde::{Deserialize, Serialize};
 
-use crate::{CommitteeInfo, Evidence, NoVote, RoundNumber};
+use crate::{Evidence, NoVote, RoundNumber};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Vertex<T> {
@@ -14,7 +14,6 @@ pub struct Vertex<T> {
     evidence: Evidence,
     no_vote: Option<Certificate<NoVote>>,
     committed: RoundNumber,
-    next_committee: Option<CommitteeInfo>,
     payload: T,
 }
 
@@ -37,7 +36,6 @@ impl<T> Vertex<T> {
             no_vote: None,
             committed: RoundNumber::genesis(),
             payload: data,
-            next_committee: None,
         }
     }
 
@@ -86,10 +84,6 @@ impl<T> Vertex<T> {
         &self.payload
     }
 
-    pub fn next_committee(&self) -> Option<&CommitteeInfo> {
-        self.next_committee.as_ref()
-    }
-
     pub fn set_committed_round<N: Into<RoundNumber>>(&mut self, n: N) -> &mut Self {
         self.committed = n.into();
         self
@@ -110,11 +104,6 @@ impl<T> Vertex<T> {
 
     pub fn set_no_vote(&mut self, n: Certificate<NoVote>) -> &mut Self {
         self.no_vote = Some(n);
-        self
-    }
-
-    pub fn set_next_committee(&mut self, i: CommitteeInfo) -> &mut Self {
-        self.next_committee = Some(i);
         self
     }
 
@@ -144,7 +133,6 @@ impl<T: Committable> Committable for Vertex<T> {
             .fixed_size_field("source", &self.source.as_bytes())
             .field("evidence", self.evidence.commit())
             .field("committed", self.committed.commit())
-            .optional("next_committee", &self.next_committee)
             .optional("no_vote", &self.no_vote)
             .field("payload", self.payload.commit())
             .u64_field("edges", self.edges.len() as u64);

--- a/sailfish/src/coordinator.rs
+++ b/sailfish/src/coordinator.rs
@@ -99,9 +99,6 @@ where
             Action::Deliver(_) => {
                 // nothing to do
             }
-            Action::NextCommittee(..) => {
-                // nothing to do
-            }
         }
         Ok(())
     }

--- a/sailfish/src/coordinator.rs
+++ b/sailfish/src/coordinator.rs
@@ -66,9 +66,7 @@ where
     pub fn init(&mut self) -> Vec<Action<T>> {
         assert!(!self.init, "Cannot call start twice");
         self.init = true;
-        let e = Evidence::Genesis;
-        let d = Dag::new(self.consensus.committee_size());
-        self.consensus.go(d, e)
+        self.consensus.go(Dag::new(), Evidence::Genesis)
     }
 
     /// Await the next sequence of consensus actions.

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr};
 
-use multisig::{Committee, Keypair, PublicKey};
+use multisig::{Committee, CommitteeSeq, Keypair, PublicKey};
+use sailfish_types::RoundNumber;
 use timeboost_utils::unsafe_zero_keypair;
 
 #[cfg(test)]
@@ -52,7 +53,7 @@ pub(crate) mod prelude {
 pub struct Group {
     pub size: usize,
     pub peers: HashMap<PublicKey, SocketAddr>,
-    pub committee: Committee,
+    pub committees: CommitteeSeq<RoundNumber>,
     pub keypairs: Vec<Keypair>,
 }
 
@@ -79,7 +80,7 @@ impl Group {
         Self {
             size,
             peers,
-            committee: Committee::new(pubks),
+            committees: (RoundNumber::genesis().., Committee::new(pubks)).into(),
             keypairs,
         }
     }

--- a/tests/src/tests/consensus/helpers/fake_network.rs
+++ b/tests/src/tests/consensus/helpers/fake_network.rs
@@ -1,9 +1,6 @@
 use multisig::PublicKey;
 use sailfish::types::{Evidence, RoundNumber};
-use std::{
-    collections::{HashMap, VecDeque},
-    num::NonZeroUsize,
-};
+use std::collections::{HashMap, VecDeque};
 
 use super::{interceptor::Interceptor, node_instrument::TestNodeInstrument};
 use crate::prelude::*;
@@ -27,10 +24,9 @@ impl FakeNetwork {
 
     pub(crate) fn start(&mut self) {
         let mut next = Vec::new();
-        let committee_size = NonZeroUsize::new(self.nodes.len()).unwrap();
         for node_instrument in self.nodes.values_mut() {
             let node = node_instrument.node_mut();
-            for a in node.go(Dag::new(committee_size), Evidence::Genesis) {
+            for a in node.go(Dag::new(), Evidence::Genesis) {
                 Self::handle_action(a, &mut next)
             }
         }

--- a/tests/src/tests/consensus/helpers/fake_network.rs
+++ b/tests/src/tests/consensus/helpers/fake_network.rs
@@ -128,6 +128,9 @@ impl FakeNetwork {
             Action::Gc(_) => {
                 return;
             }
+            Action::NextCommittee(..) => {
+                return;
+            }
             Action::SendNoVote(to, e) => (Some(to), Message::NoVote(e)),
             Action::SendProposal(e) => (None, Message::Vertex(e)),
             Action::SendTimeout(e) => (None, Message::Timeout(e)),

--- a/tests/src/tests/consensus/helpers/fake_network.rs
+++ b/tests/src/tests/consensus/helpers/fake_network.rs
@@ -78,12 +78,10 @@ impl FakeNetwork {
     /// Look in each node and grab their queue of messages
     /// Used for asserting in tests to make sure outputs are expected
     pub(crate) fn msgs_in_queue(&self) -> HashMap<PublicKey, &VecDeque<Message>> {
-        let nodes_msgs = self
-            .nodes
+        self.nodes
             .iter()
             .map(|(key, node_instrument)| (*key, node_instrument.msg_queue()))
-            .collect();
-        nodes_msgs
+            .collect()
     }
 
     /// Handle a message, and apply any transformations as setup in the test

--- a/tests/src/tests/consensus/helpers/fake_network.rs
+++ b/tests/src/tests/consensus/helpers/fake_network.rs
@@ -54,7 +54,9 @@ impl FakeNetwork {
             .values()
             .next()
             .expect("at least one node exists")
-            .committee()
+            .committees()
+            .get(round)
+            .unwrap()
             .leader(*round as usize)
     }
 

--- a/tests/src/tests/consensus/helpers/fake_network.rs
+++ b/tests/src/tests/consensus/helpers/fake_network.rs
@@ -126,9 +126,6 @@ impl FakeNetwork {
             Action::Gc(_) => {
                 return;
             }
-            Action::NextCommittee(..) => {
-                return;
-            }
             Action::SendNoVote(to, e) => (Some(to), Message::NoVote(e)),
             Action::SendProposal(e) => (None, Message::Vertex(e)),
             Action::SendTimeout(e) => (None, Message::Timeout(e)),

--- a/tests/src/tests/consensus/helpers/key_manager.rs
+++ b/tests/src/tests/consensus/helpers/key_manager.rs
@@ -119,12 +119,8 @@ impl KeyManager {
     }
 
     /// Setup dag for testing.
-    pub(crate) fn prepare_dag(
-        &self,
-        round: u64,
-        committee: &Committee,
-    ) -> (Dag, Evidence, Vec<PublicKey>) {
-        let mut dag = Dag::new(committee.size());
+    pub(crate) fn prepare_dag(&self, round: u64) -> (Dag, Evidence, Vec<PublicKey>) {
+        let mut dag = Dag::new();
         let edges = self
             .keys
             .values()

--- a/tests/src/tests/consensus/helpers/shaping.rs
+++ b/tests/src/tests/consensus/helpers/shaping.rs
@@ -514,6 +514,7 @@ impl Simulator {
                         .push(Event::Deliver(self.time, party, data.round(), k))
                 }
                 Action::Gc(_) => {}
+                Action::NextCommittee(..) => {}
             }
         }
     }

--- a/tests/src/tests/consensus/helpers/shaping.rs
+++ b/tests/src/tests/consensus/helpers/shaping.rs
@@ -339,7 +339,7 @@ impl Simulator {
 
         assert!(!parties.is_empty());
 
-        let dag = Dag::new(NonZeroUsize::new(parties.len()).unwrap());
+        let dag = Dag::new();
 
         let mut actions = Vec::new();
 

--- a/tests/src/tests/consensus/helpers/shaping.rs
+++ b/tests/src/tests/consensus/helpers/shaping.rs
@@ -514,7 +514,6 @@ impl Simulator {
                         .push(Event::Deliver(self.time, party, data.round(), k))
                 }
                 Action::Gc(_) => {}
-                Action::NextCommittee(..) => {}
             }
         }
     }

--- a/tests/src/tests/consensus/test_consensus_actions.rs
+++ b/tests/src/tests/consensus/test_consensus_actions.rs
@@ -34,7 +34,7 @@ async fn test_single_node_advance() {
     // Setup up consensus state
     let mut round = 7;
     let node = node_handle.node_mut();
-    let (dag, evidence, vertices_for_round) = manager.prepare_dag(round, &committee);
+    let (dag, evidence, vertices_for_round) = manager.prepare_dag(round);
     node.go(dag, evidence);
 
     // Craft messages
@@ -81,7 +81,7 @@ async fn test_single_node_timeout() {
     // Setup up consensus state
     let mut round = 4;
     let node = node_handle.node_mut();
-    let (dag, evidence, _vertices_for_round) = manager.prepare_dag(round, &committee);
+    let (dag, evidence, _vertices_for_round) = manager.prepare_dag(round);
     node.go(dag, evidence);
 
     // Craft messages
@@ -148,7 +148,7 @@ async fn test_single_node_timeout_cert() {
 
     // Setup up consensus state
     let node = node_handle.node_mut();
-    let (dag, evidence, vertices_for_round) = manager.prepare_dag(*expected_round - 1, &committee);
+    let (dag, evidence, vertices_for_round) = manager.prepare_dag(*expected_round - 1);
     node.go(dag, evidence);
 
     // Craft messages, skip leader vertex

--- a/tests/src/tests/consensus/test_consensus_fake_network.rs
+++ b/tests/src/tests/consensus/test_consensus_fake_network.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use multisig::PublicKey;
+use multisig::{Indexed, PublicKey};
 use sailfish::types::{Evidence, RoundNumber};
 use timeboost_utils::types::logging;
 use timeboost_utils::unsafe_zero_keypair;
@@ -49,7 +49,9 @@ async fn test_timeout_round_and_no_vote() {
                 if *v.data().round().data() == timeout_at_round
                     && *v.signing_key()
                         == manager
-                            .committee()
+                            .committees()
+                            .get(v.data().index())
+                            .unwrap()
                             .leader(**v.data().round().data() as usize)
                 {
                     let timeout_msgs = manager.create_timeout_msgs(timeout_at_round.into());

--- a/tests/src/tests/consensus/test_consensus_fake_network.rs
+++ b/tests/src/tests/consensus/test_consensus_fake_network.rs
@@ -243,10 +243,7 @@ fn basic_liveness() {
                         Action::SendNoVote(to, e) if n.public_key() == *to => {
                             n.handle_no_vote(e.clone())
                         }
-                        Action::SendNoVote(..)
-                        | Action::ResetTimer(..)
-                        | Action::Gc(_)
-                        | Action::NextCommittee(..) => continue,
+                        Action::SendNoVote(..) | Action::ResetTimer(..) | Action::Gc(_) => continue,
                     };
                     if !na.is_empty() {
                         next.push((n.public_key(), na))

--- a/tests/src/tests/consensus/test_consensus_fake_network.rs
+++ b/tests/src/tests/consensus/test_consensus_fake_network.rs
@@ -213,10 +213,7 @@ fn basic_liveness() {
         .iter_mut()
         .map(|(id, node_handle)| {
             let node = node_handle.node_mut();
-            (
-                *id,
-                node.go(Dag::new(node.committee_size()), Evidence::Genesis),
-            )
+            (*id, node.go(Dag::new(), Evidence::Genesis))
         })
         .collect();
 

--- a/tests/src/tests/consensus/test_consensus_fake_network.rs
+++ b/tests/src/tests/consensus/test_consensus_fake_network.rs
@@ -243,7 +243,10 @@ fn basic_liveness() {
                         Action::SendNoVote(to, e) if n.public_key() == *to => {
                             n.handle_no_vote(e.clone())
                         }
-                        Action::SendNoVote(..) | Action::ResetTimer(..) | Action::Gc(_) => continue,
+                        Action::SendNoVote(..)
+                        | Action::ResetTimer(..)
+                        | Action::Gc(_)
+                        | Action::NextCommittee(..) => continue,
                     };
                     if !na.is_empty() {
                         next.push((n.public_key(), na))

--- a/tests/src/tests/network.rs
+++ b/tests/src/tests/network.rs
@@ -119,9 +119,6 @@ pub trait TestableNetwork {
         conditions: &mut Vec<TestCondition>,
         msgs: MsgQueues<SailfishBlock>,
     ) -> TaskHandleResult {
-        for a in coordinator.init() {
-            let _ = coordinator.execute(a).await;
-        }
         loop {
             match coordinator.next().await {
                 Ok(actions) => {

--- a/tests/src/tests/network/external.rs
+++ b/tests/src/tests/network/external.rs
@@ -44,7 +44,7 @@ impl TestableNetwork for BasicNetworkTest {
     }
 
     async fn init(&mut self) -> Vec<Self::Node> {
-        let committee = self.group.committee.clone();
+        let committee = self.group.committees.clone();
         let mut nodes = Vec::new();
         for i in 0..self.group.size {
             let kpr = self.group.keypairs[i].clone();

--- a/tests/src/tests/network/internal.rs
+++ b/tests/src/tests/network/internal.rs
@@ -65,7 +65,7 @@ impl TestableNetwork for MemoryNetworkTest {
             let messages = test_net.messages();
             let kpr = self.group.keypairs[i].clone();
 
-            let cons = Consensus::new(kpr, self.group.committee.clone(), EmptyBlocks);
+            let cons = Consensus::new(kpr, self.group.committees.clone(), EmptyBlocks);
             let coor = Coordinator::new(test_net, cons);
 
             coordinators.push((coor, messages))

--- a/tests/src/tests/network/network_tests.rs
+++ b/tests/src/tests/network/network_tests.rs
@@ -108,8 +108,8 @@ where
 
     let num_nodes = 5;
     let group = Group::new(num_nodes);
-    let committee = group.committee.clone();
     let timeout_round = 3;
+    let committee = group.committees.get(timeout_round.into()).unwrap().clone();
     let interceptor = NetworkMessageInterceptor::new(move |msg, _id| {
         if let Message::Vertex(v) = msg {
             let round = msg.round();
@@ -126,7 +126,7 @@ where
         .iter()
         .map(|k| {
             // First only check if we received vertex with no vote cert from leader only
-            let committee = group.committee.clone();
+            let committee = group.committees.get(timeout_round.into()).unwrap().clone();
             let mut conditions = vec![TestCondition::new(
                 "No vote vertex from leader".to_string(),
                 move |msg, _a| {
@@ -188,8 +188,8 @@ where
 
     let num_nodes = 5;
     let group = Group::new(num_nodes);
-    let committee = group.committee.clone();
     let timeout_round = *RoundNumber::genesis();
+    let committee = group.committees.get(timeout_round.into()).unwrap().clone();
     let interceptor = NetworkMessageInterceptor::new(move |msg, _id| {
         if let Message::Vertex(v) = msg {
             let round = msg.round();
@@ -206,7 +206,7 @@ where
         .iter()
         .map(|k| {
             // First only check if we received vertex with no vote cert from leader only
-            let committee = group.committee.clone();
+            let committee = group.committees.get(timeout_round.into()).unwrap().clone();
             let mut conditions = vec![TestCondition::new(
                 "No vote vertex from leader".to_string(),
                 move |msg, _a| {
@@ -328,7 +328,11 @@ where
     let num_nodes = 5;
     let group = Group::new(num_nodes);
     let offline_at_round = 4;
-    let committee = group.committee.clone();
+    let committee = group
+        .committees
+        .get(offline_at_round.into())
+        .unwrap()
+        .clone();
     let node_id = 4;
     let interceptor = NetworkMessageInterceptor::new(move |msg, id| {
         let round = *msg.round();

--- a/tests/src/tests/rbc.rs
+++ b/tests/src/tests/rbc.rs
@@ -59,12 +59,10 @@ fn mk_host<A, const N: usize>(
             let rbc = Rbc::new(Overlay::new(comm), cfg);
             let cons = Consensus::new(k, c, EmptyBlocks);
             let mut coor = Coordinator::new(rbc, cons);
-            let mut actions = coor.init();
             loop {
-                for a in actions {
+                for a in coor.next().await? {
                     coor.execute(a).await?;
                 }
-                actions = coor.next().await?
             }
         }
     });
@@ -105,9 +103,8 @@ fn small_committee() {
         let rbc = Rbc::new(Overlay::new(comm), cfg);
         let cons = Consensus::new(k, c, EmptyBlocks);
         let mut coor = Coordinator::new(rbc, cons);
-        let mut actions = coor.init();
         loop {
-            for a in actions {
+            for a in coor.next().await? {
                 if let Action::Deliver(data) = a {
                     if data.round() >= 3.into() {
                         return Ok(());
@@ -116,7 +113,6 @@ fn small_committee() {
                     coor.execute(a).await?
                 }
             }
-            actions = coor.next().await?
         }
     });
 
@@ -162,9 +158,8 @@ fn medium_committee() {
         let rbc = Rbc::new(Overlay::new(comm), cfg);
         let cons = Consensus::new(k, c, EmptyBlocks);
         let mut coor = Coordinator::new(rbc, cons);
-        let mut actions = coor.init();
         loop {
-            for a in actions {
+            for a in coor.next().await? {
                 if let Action::Deliver(data) = a {
                     if data.round() >= 3.into() {
                         return Ok(());
@@ -173,7 +168,6 @@ fn medium_committee() {
                     coor.execute(a).await?
                 }
             }
-            actions = coor.next().await?
         }
     });
 
@@ -218,7 +212,7 @@ fn medium_committee_partition_network() {
         let rbc = Rbc::new(Overlay::new(comm), cfg);
         let cons = Consensus::new(k, c, EmptyBlocks);
         let mut coor = Coordinator::new(rbc, cons);
-        let mut actions = coor.init();
+        let mut actions = coor.next().await?;
         loop {
 
             for a in actions.clone() {

--- a/timeboost-builder/src/produce.rs
+++ b/timeboost-builder/src/produce.rs
@@ -287,7 +287,7 @@ impl Worker {
                 .trackers
                 .entry(*block_hash.data())
                 .or_insert_with(|| Tracker {
-                    votes: VoteAccumulator::new((), self.committees.current().clone()),
+                    votes: VoteAccumulator::new((), self.committees.last().clone()),
                     num: None,
                     status: CertStatus::Unknown,
                 });

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -288,11 +288,6 @@ impl Task {
         let mut pending = None;
         let mut candidates = Candidates::new();
 
-        if !self.sailfish.is_init() {
-            let actions = self.sailfish.init();
-            candidates = self.execute(actions).await?;
-        }
-
         loop {
             if pending.is_none() {
                 while let Some(ilist) = self.next_inclusion(&mut candidates) {

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -192,7 +192,7 @@ impl Sequencer {
         };
 
         let decrypter = {
-            let keyset = Keyset::new(1, committees.current().size()); // TODO
+            let keyset = Keyset::new(1, committees.last().size()); // TODO
 
             let met = NetworkMetrics::new(
                 "decrypt",

--- a/timeboost-types/src/block.rs
+++ b/timeboost-types/src/block.rs
@@ -136,9 +136,7 @@ pub struct BlockHash(B256);
 impl Indexed for BlockHash {
     type Index = ();
 
-    fn index(&self) -> Self::Index {
-        ()
-    }
+    fn index(&self) -> Self::Index {}
 }
 
 impl From<[u8; 32]> for BlockHash {

--- a/timeboost-types/src/block.rs
+++ b/timeboost-types/src/block.rs
@@ -4,7 +4,7 @@ use std::ops::{Add, Deref, Sub};
 use alloy_consensus::{Header, proofs::calculate_transaction_root};
 use alloy_primitives::{Address, B64, B256, Bloom};
 use committable::{Commitment, Committable, RawCommitmentBuilder};
-use multisig::{Certificate, Envelope};
+use multisig::{Certificate, Envelope, Indexed};
 use serde::{Deserialize, Serialize};
 
 use crate::Transaction;
@@ -131,6 +131,15 @@ impl std::ops::Deref for Block {
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, Ord, PartialOrd, PartialEq, Eq)]
 pub struct BlockHash(B256);
+
+// TODO
+impl Indexed for BlockHash {
+    type Index = ();
+
+    fn index(&self) -> Self::Index {
+        ()
+    }
+}
 
 impl From<[u8; 32]> for BlockHash {
     fn from(bytes: [u8; 32]) -> Self {

--- a/timeboost/src/api/endpoints.rs
+++ b/timeboost/src/api/endpoints.rs
@@ -1,4 +1,4 @@
-use std::io::{self, ErrorKind};
+use std::io;
 
 use anyhow::Result;
 use async_lock::RwLock;
@@ -26,8 +26,8 @@ impl TimeboostApiState {
 
     /// Run the timeboost API.
     pub async fn run(self, url: Url) -> io::Result<()> {
-        let api = define_api::<StaticVersion<0, 1>>()
-            .map_err(|e| io::Error::new(ErrorKind::Other, e.to_string()))?;
+        let api =
+            define_api::<StaticVersion<0, 1>>().map_err(|e| io::Error::other(e.to_string()))?;
         let state = RwLock::new(self);
         let mut app = App::<RwLock<TimeboostApiState>, ServerError>::with_state(state);
         app.register_module("", api)

--- a/timeboost/src/binaries/sailfish.rs
+++ b/timeboost/src/binaries/sailfish.rs
@@ -9,12 +9,12 @@ use std::{
 use anyhow::{Context, Result, bail};
 use cliquenet::{Address, Network, NetworkMetrics, Overlay};
 use committable::{Commitment, Committable, RawCommitmentBuilder};
-use multisig::{Committee, Keypair, PublicKey};
+use multisig::{Committee, CommitteeSeq, Keypair, PublicKey};
 use sailfish::{
     Coordinator,
     consensus::{Consensus, ConsensusMetrics},
     rbc::{Rbc, RbcConfig, RbcMetrics},
-    types::Action,
+    types::{Action, RoundNumber},
 };
 use serde::{Deserialize, Serialize};
 use timeboost::{metrics_api, rpc_api};
@@ -326,12 +326,15 @@ async fn main() -> Result<()> {
 
     let metrics = spawn(metrics_api(prom.clone(), cli.metrics_port));
 
-    let committee = Committee::new(
-        peer_hosts_and_keys
-            .iter()
-            .map(|b| b.0)
-            .enumerate()
-            .map(|(i, key)| (i as u8, key)),
+    let committee = CommitteeSeq::new(
+        RoundNumber::genesis()..,
+        Committee::new(
+            peer_hosts_and_keys
+                .iter()
+                .map(|b| b.0)
+                .enumerate()
+                .map(|(i, key)| (i as u8, key)),
+        ),
     );
 
     // If the stamp file exists we need to recover from a previous run.

--- a/timeboost/src/binaries/sailfish.rs
+++ b/timeboost/src/binaries/sailfish.rs
@@ -349,17 +349,10 @@ async fn main() -> Result<()> {
 
     let consensus =
         Consensus::new(keypair, committee, repeat_with(Block::random)).with_metrics(sf_metrics);
-    let mut coordinator = Coordinator::new(rbc, consensus);
+    let coordinator = Coordinator::new(rbc, consensus);
 
     // Create proof of execution.
     tokio::fs::File::create(cli.stamp).await?.sync_all().await?;
-
-    // Kickstart the network.
-    for a in coordinator.init() {
-        if let Err(e) = coordinator.execute(a).await {
-            tracing::error!("Error executing coordinator action: {}", e);
-        }
-    }
 
     let result = run(
         coordinator,


### PR DESCRIPTION
Lays the groundwork for having a sequence of `Committee`s, mostly in in the `multisig` crate. The type `CommitteeSeq<I>` represents such a sequence, consisting of non-overlapping intervals $$[i, j)$$ each mapped to one `Committee`, where $$i, j : I$$ and $$I$$ is any type that is an instance of `Indexed`. Adding a new committee from $$[k, \infty)$$, will move the current committee to the end of the previously active committees and makes $$k$$ it's exclusive upper bound.

The class of types that implement `Indexed` have a way to provide an index value which is used to select the committee that covers it. The canonical example for an index type would be `RoundNumber` and types such as `Vertex` can implement `Indexed` by returning their current round.

*Work in progress ...*