### PR TITLE
append round evidence to decrypter worker payload

### DIFF
--- a/sailfish-consensus/src/lib.rs
+++ b/sailfish-consensus/src/lib.rs
@@ -714,8 +714,9 @@ where
                     continue;
                 }
                 let b = to_deliver.payload().clone();
+                let e = to_deliver.evidence().clone();
                 info!(node = %self.public_key(), vertex = %to_deliver, "deliver");
-                actions.push(Action::Deliver(Payload::new(r, s, b)));
+                actions.push(Action::Deliver(Payload::new(r, s, b, e)));
                 self.delivered.insert((r, s));
             }
         }

--- a/sailfish-types/src/message.rs
+++ b/sailfish-types/src/message.rs
@@ -220,14 +220,18 @@ pub struct Payload<T: Committable> {
     round: RoundNumber,
     source: PublicKey,
     data: T,
+    /// when sailfish delivers to timeboost, round evidence prevents malicious timeboost nodes
+    /// placing messages arbitrarily far into the future, causing unbounded buffer grow.
+    evidence: Evidence,
 }
 
 impl<T: Committable> Payload<T> {
-    pub fn new(round: RoundNumber, source: PublicKey, data: T) -> Self {
+    pub fn new(round: RoundNumber, source: PublicKey, data: T, evidence: Evidence) -> Self {
         Self {
             round,
             source,
             data,
+            evidence,
         }
     }
 
@@ -245,6 +249,10 @@ impl<T: Committable> Payload<T> {
 
     pub fn into_data(self) -> T {
         self.data
+    }
+
+    pub fn evidence(&self) -> &Evidence {
+        &self.evidence
     }
 
     pub fn into_parts(self) -> (RoundNumber, PublicKey, T) {

--- a/sailfish-types/src/message.rs
+++ b/sailfish-types/src/message.rs
@@ -220,8 +220,6 @@ pub struct Payload<T: Committable> {
     round: RoundNumber,
     source: PublicKey,
     data: T,
-    /// when sailfish delivers to timeboost, round evidence prevents malicious timeboost nodes
-    /// placing messages arbitrarily far into the future, causing unbounded buffer grow.
     evidence: Evidence,
 }
 
@@ -255,8 +253,12 @@ impl<T: Committable> Payload<T> {
         &self.evidence
     }
 
-    pub fn into_parts(self) -> (RoundNumber, PublicKey, T) {
-        (self.round, self.source, self.data)
+    pub fn into_evidence(self) -> Evidence {
+        self.evidence
+    }
+
+    pub fn into_parts(self) -> (RoundNumber, PublicKey, T, Evidence) {
+        (self.round, self.source, self.data, self.evidence)
     }
 }
 

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -355,10 +355,6 @@ impl Worker {
 
     /// logic to process a `WorkerRequest::Decrypt` request from the decrypter
     async fn on_decrypt_request(&mut self, round: RoundNumber, incl: InclusionList) -> Result<()> {
-        // reject requests too far into the future without proper round evidence
-        if !incl.evidence().is_valid(round, &self.committee) {
-            return Err(DecryptError::MissingRoundEvidence(round));
-        }
         let dec_shares = self.decrypt(round, &incl);
         if dec_shares.is_empty() {
             return Err(DecryptError::EmptyDecShares);

--- a/timeboost-sequencer/src/include.rs
+++ b/timeboost-sequencer/src/include.rs
@@ -24,8 +24,6 @@ pub struct Includer {
     committee: Committee,
     /// Consensus round.
     round: RoundNumber,
-    /// Round evidence
-    evidence: Evidence,
     /// Consensus timestamp.
     time: Timestamp,
     /// Epoch of timestamp.
@@ -43,7 +41,6 @@ impl Includer {
         Self {
             committee: c,
             round: RoundNumber::genesis(),
-            evidence: Evidence::Genesis,
             time: Timestamp::default(),
             epoch: Timestamp::default().epoch(),
             seqno: SeqNo::zero(),
@@ -61,7 +58,6 @@ impl Includer {
         debug_assert!(lists.len() >= self.committee.quorum_size().get());
 
         self.round = round;
-        self.evidence = evidence;
 
         while self.cache.len() > CACHE_SIZE {
             self.cache.pop_first();
@@ -150,8 +146,7 @@ impl Includer {
             }
         }
 
-        let mut ilist =
-            InclusionList::new(self.round, self.time, self.index, self.evidence.clone());
+        let mut ilist = InclusionList::new(self.round, self.time, self.index, evidence);
         ilist
             .set_priority_bundles(bundles)
             .set_regular_bundles(include);

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -362,11 +362,13 @@ impl Task {
                 match action {
                     Action::Deliver(payload) => {
                         round = payload.round();
-                        if payload.evidence().round() > evidence.round() {
-                            evidence = payload.evidence().clone()
-                        }
                         match payload.data().decode::<MAX_MESSAGE_SIZE>() {
-                            Ok(data) => lists.push(data),
+                            Ok(data) => {
+                                if payload.evidence().round() > evidence.round() {
+                                    evidence = payload.into_evidence()
+                                }
+                                lists.push(data)
+                            }
                             Err(err) => {
                                 warn!(
                                     node = %self.label,

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -360,25 +360,23 @@ impl Task {
             let mut lists = Vec::new();
             while let Some(action) = actions.pop_front() {
                 match action {
-                    Action::Deliver(payload) => {
-                        round = payload.round();
-                        match payload.data().decode::<MAX_MESSAGE_SIZE>() {
-                            Ok(data) => {
-                                if payload.evidence().round() > evidence.round() {
-                                    evidence = payload.into_evidence()
-                                }
-                                lists.push(data)
+                    Action::Deliver(payload) => match payload.data().decode::<MAX_MESSAGE_SIZE>() {
+                        Ok(data) => {
+                            round = payload.round();
+                            if payload.evidence().round() > evidence.round() {
+                                evidence = payload.into_evidence()
                             }
-                            Err(err) => {
-                                warn!(
-                                    node = %self.label,
-                                    err  = %err,
-                                    src  = %payload.source(),
-                                    "failed to deserialize candidate list"
-                                );
-                            }
+                            lists.push(data)
                         }
-                    }
+                        Err(err) => {
+                            warn!(
+                                node = %self.label,
+                                err  = %err,
+                                src  = %payload.source(),
+                                "failed to deserialize candidate list"
+                            );
+                        }
+                    },
                     Action::Gc(r) => {
                         self.decrypter.gc(r).await?;
                         actions.push_front(action);

--- a/timeboost-types/src/inclusion_list.rs
+++ b/timeboost-types/src/inclusion_list.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use crate::{Bundle, Bytes, DelayedInboxIndex, Epoch, Timestamp, bundle::SignedPriorityBundle};
-use sailfish_types::RoundNumber;
+use sailfish_types::{Evidence, RoundNumber};
 use timeboost_crypto::KeysetId;
 
 /// List of bundles to be included, selected from `CandidateList`.
@@ -12,16 +12,18 @@ pub struct InclusionList {
     round: RoundNumber,
     time: Timestamp,
     index: DelayedInboxIndex,
+    evidence: Evidence,
     priority: Vec<SignedPriorityBundle>,
     regular: Vec<Bundle>,
 }
 
 impl InclusionList {
-    pub fn new(r: RoundNumber, t: Timestamp, i: DelayedInboxIndex) -> Self {
+    pub fn new(r: RoundNumber, t: Timestamp, i: DelayedInboxIndex, e: Evidence) -> Self {
         Self {
             round: r,
             time: t,
             index: i,
+            evidence: e,
             priority: Vec::new(),
             regular: Vec::new(),
         }
@@ -88,6 +90,10 @@ impl InclusionList {
 
     pub fn timestamp(&self) -> Timestamp {
         self.time
+    }
+
+    pub fn evidence(&self) -> &Evidence {
+        &self.evidence
     }
 
     pub fn round(&self) -> RoundNumber {


### PR DESCRIPTION
Closes  https://app.asana.com/1/1208976916964769/project/1209394409339229/task/1210279951025506


### This PR:

- add `Payload.evidence` field
  - during `order_vertices()`, data: payload + evidence 
- add `evidence` to `Includer::inclusion_list(&mut self, round, evidence, lists: Vec<CandidateList>) -> Outcome`
- add `InclusionList.evidence` field
- add evidence check during `insert_shares`,
  - during decrypter's worker construction, we pass in `Committee` info for the evidence check later, this committee will be updated via Decrypter's request when we have dynamic committee (future PR) 
