### PR TITLE
Fix race condition during committee change.

### DIFF
--- a/sailfish-consensus/benches/consensus_single.rs
+++ b/sailfish-consensus/benches/consensus_single.rs
@@ -136,7 +136,7 @@ fn action_to_msg<T: Committable>(action: Action<T>) -> Option<Message<T>> {
         Action::Deliver(..) => None,
         Action::Gc(_) => None,
         Action::Catchup(_) => None,
-        Action::UseCommittee(_) => None,
+        Action::UseCommittee(..) => None,
     }
 }
 

--- a/sailfish-rbc/src/abraham.rs
+++ b/sailfish-rbc/src/abraham.rs
@@ -68,7 +68,7 @@ enum Command<T: Committable> {
     /// Add the next committee.
     AddCommittee(AddressableCommittee),
     /// Use the given committee as specified by `Round`.
-    UseCommittee(Round),
+    UseCommittee(Round, Evidence),
 }
 
 /// RBC configuration
@@ -220,9 +220,9 @@ impl<T: Committable + Send + Serialize + Clone + 'static> Comm<T> for Rbc<T> {
             .map_err(|_| RbcError::Shutdown)
     }
 
-    async fn use_committee(&mut self, r: Round) -> Result<(), Self::Err> {
+    async fn use_committee(&mut self, r: Round, e: Evidence) -> Result<(), Self::Err> {
         self.tx
-            .send(Command::UseCommittee(r))
+            .send(Command::UseCommittee(r, e))
             .await
             .map_err(|_| RbcError::Shutdown)
     }

--- a/sailfish-types/src/comm.rs
+++ b/sailfish-types/src/comm.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use committable::Committable;
 use multisig::{PublicKey, Validated};
 
-use crate::{Message, Round, RoundNumber};
+use crate::{Evidence, Message, Round, RoundNumber};
 
 /// Types that provide broadcast and 1:1 message communication.
 #[async_trait]
@@ -32,7 +32,7 @@ pub trait Comm<T: Committable> {
     }
 
     /// Switch over to a set of peers.
-    async fn use_committee(&mut self, _: Round) -> Result<(), Self::Err> {
+    async fn use_committee(&mut self, _: Round, _: Evidence) -> Result<(), Self::Err> {
         Ok(())
     }
 }

--- a/sailfish-types/src/committee.rs
+++ b/sailfish-types/src/committee.rs
@@ -28,6 +28,14 @@ impl<const N: usize> CommitteeVec<N> {
         self.vec.iter().any(|c| c.id() == id)
     }
 
+    /// Get the index position of the given committee ID (if any).
+    ///
+    /// Committees are ordered by recency, i.e. the higher the index,
+    /// the older the committee.
+    pub fn position(&self, id: CommitteeId) -> Option<usize> {
+        self.vec.iter().position(|c| c.id() == id)
+    }
+
     /// Get the committee corresponding to the given ID (if any).
     pub fn get(&self, id: CommitteeId) -> Option<&Committee> {
         self.vec.iter().find(|c| c.id() == id)

--- a/sailfish-types/src/message.rs
+++ b/sailfish-types/src/message.rs
@@ -406,7 +406,7 @@ pub enum Action<T: Committable> {
     Gc(Round),
 
     /// Use a committee starting at the given round.
-    UseCommittee(Round),
+    UseCommittee(Round, Evidence),
 }
 
 impl<T: Committable> Action<T> {
@@ -457,7 +457,7 @@ impl<T: Committable> fmt::Display for Action<T> {
             Action::Catchup(r) => {
                 write!(f, "Catchup({r})")
             }
-            Action::UseCommittee(r) => {
+            Action::UseCommittee(r, _) => {
                 write!(f, "UseCommittee({r})")
             }
         }

--- a/tests/src/tests/consensus/helpers/fake_network.rs
+++ b/tests/src/tests/consensus/helpers/fake_network.rs
@@ -121,7 +121,7 @@ impl FakeNetwork {
             | Action::Deliver(_)
             | Action::Gc(_)
             | Action::Catchup(_)
-            | Action::UseCommittee(_) => {
+            | Action::UseCommittee(..) => {
                 return;
             }
             Action::SendNoVote(to, e) => (Some(to), Message::NoVote(e)),

--- a/tests/src/tests/consensus/helpers/shaping.rs
+++ b/tests/src/tests/consensus/helpers/shaping.rs
@@ -6,7 +6,7 @@ use std::{fmt, mem};
 
 use multisig::{Committee, Keypair, PublicKey};
 use rand::prelude::*;
-use sailfish::types::{Evidence, RoundNumber, UNKNOWN_COMMITTEE_ID};
+use sailfish::types::{Evidence, Round, RoundNumber, UNKNOWN_COMMITTEE_ID};
 use tracing::debug;
 
 use crate::prelude::*;
@@ -538,7 +538,7 @@ impl Simulator {
                     self.events
                         .push(Event::Deliver(self.time, party, data.round().num(), k))
                 }
-                Action::Gc(_) | Action::Catchup(_) | Action::UseCommittee(_) => {}
+                Action::Gc(_) | Action::Catchup(_) | Action::UseCommittee(..) => {}
             }
         }
     }
@@ -565,7 +565,8 @@ impl Simulator {
                 let l = self.resolve.get(&k).expect("known public key");
                 self.events
                     .push(Event::Timeout(self.time, name, party.timeout.1, l));
-                actions.push((*name, party.logic.timeout(party.timeout.1)))
+                let r = Round::new(party.timeout.1, self.committee.id());
+                actions.push((*name, party.logic.timeout(r)))
             }
         }
         actions

--- a/tests/src/tests/consensus/test_consensus_fake_network.rs
+++ b/tests/src/tests/consensus/test_consensus_fake_network.rs
@@ -250,7 +250,7 @@ fn basic_liveness() {
                         | Action::ResetTimer(..)
                         | Action::Gc(_)
                         | Action::Catchup(_)
-                        | Action::UseCommittee(_) => continue,
+                        | Action::UseCommittee(..) => continue,
                     };
                     if !na.is_empty() {
                         next.push((n.public_key(), na))


### PR DESCRIPTION
Consider the following sequence:

1. A `UseCommittee` action is created and the RBC layer activates a new committee in round `r`. It removes all messages of the old committee starting at `r`.
2. The node receives a proposal from another node which is in both committees for `r` + 1 but for the old committee.
3. Subsequently it receives a second proposal for `r` + 1 from the same node for the new committee.

At (3), a warning is issued that a node has made two proposal for the same round and the second proposal is rejected.

This commit adds the following constraint to `on_propose`: Proposals received for a committee older than the current one are rejected.