### PR TITLE
feat: add VSS trait

### DIFF
--- a/timeboost-crypto/src/traits.rs
+++ b/timeboost-crypto/src/traits.rs
@@ -1,2 +1,3 @@
+pub mod dkg;
 pub mod dleq_proof;
 pub mod threshold_enc;


### PR DESCRIPTION
Closes https://app.asana.com/1/1208976916964769/project/1209394409339229/task/1210580323499315

### This PR:

- Add a trait for local VSS 


### This PR does not:

I was originally thinking about adding a trait for DKG, but after thinking about it. it makes more sense to just abstract the VSS component. (and later the local resharing APIs) 
The networked DKG can be just methods on timeboost structs. I think we can generically implement something like this later:

```rust
impl Consensus {
    async fn dkg<R: Rng, VSS, ACS, VESS>(&mut self, rng: &mut R) -> Result<SecretKey, PublicKey, CombinerKey>;
}
```
