### PR TITLE
feat: Feldman VSS implementation

### DIFF
--- a/timeboost-crypto/src/feldman.rs
+++ b/timeboost-crypto/src/feldman.rs
@@ -1,0 +1,216 @@
+//! Implementation of Feldman VSS
+
+use ark_ec::CurveGroup;
+use ark_poly::{DenseUVPolynomial, Polynomial, univariate::DensePolynomial};
+use ark_std::marker::PhantomData;
+use ark_std::rand::Rng;
+use std::{iter::successors, num::NonZeroU32};
+
+use crate::{
+    interpolation::interpolate,
+    traits::dkg::{VerifiableSecretSharing, VssError},
+};
+
+/// Feldman VSS: <https://www.cs.umd.edu/~gasarch/TOPICS/secretsharing/feldmanVSS.pdf>
+#[derive(Debug, Clone)]
+pub struct FeldmanVSS<C: CurveGroup>(PhantomData<C>);
+
+#[derive(Debug, Clone, Copy)]
+pub struct FeldmanVSSPublicParam {
+    // reconstruction threshold t
+    pub(crate) t: NonZeroU32,
+    // total number of nodes
+    pub(crate) n: NonZeroU32,
+}
+
+impl FeldmanVSSPublicParam {
+    pub fn new(t: NonZeroU32, n: NonZeroU32) -> Self {
+        Self { t, n }
+    }
+}
+
+impl<C: CurveGroup> VerifiableSecretSharing for FeldmanVSS<C> {
+    type PublicParam = FeldmanVSSPublicParam;
+    type Secret = C::ScalarField;
+    type SecretShare = C::ScalarField;
+    type Commitment = Vec<C::Affine>;
+    type ShareProof = (); // unused
+
+    fn share<R: Rng>(
+        pp: &Self::PublicParam,
+        rng: &mut R,
+        secret: Self::Secret,
+    ) -> (
+        Vec<Self::SecretShare>,
+        Self::Commitment,
+        Vec<Self::ShareProof>,
+    ) {
+        // sample random polynomial of degree t-1 (s.t. any t evaluations can interpolate this poly)
+        // f(X) = Sum a_i * X^i
+        let mut poly = DensePolynomial::<Self::Secret>::rand(pp.t.get() as usize - 1, rng);
+        // f(0) = a_0 set to the secret, this index access will never panic since t>0
+        poly.coeffs[0] = secret;
+
+        // prepare shares, node i \in {0,.. ,n-1} get f(i+1)
+        let shares: Vec<Self::SecretShare> = (0..pp.n.get())
+            .map(|node_idx| poly.evaluate(&(node_idx + 1).into()))
+            .collect();
+
+        // prepare commitment, u = (g^a_0, g^a_1, ..., g^a_t-1)
+        let commitment = C::generator().batch_mul(&poly.coeffs);
+
+        (shares, commitment, vec![])
+    }
+
+    fn verify(
+        pp: &Self::PublicParam,
+        node_idx: usize,
+        share: &Self::SecretShare,
+        commitment: &Self::Commitment,
+        _share_proof: &Self::ShareProof,
+    ) -> Result<bool, VssError> {
+        let n = pp.n.get() as usize;
+        let t = pp.t.get() as usize;
+
+        // input validation
+        if node_idx >= n {
+            return Err(VssError::IndexOutOfBound(n - 1, node_idx));
+        }
+        if commitment.len() != t {
+            return Err(VssError::InvalidCommitment);
+        }
+
+        // i-th node computes g^f(i+1), namely poly eval in the exponent
+        // g^f(x) = Prod_{j \in [0, t-1]} u_j ^ {x^j}
+        let eval_point = C::ScalarField::from(node_idx as u64 + 1);
+        let powers = successors(Some(C::ScalarField::from(1u64)), |prev| {
+            Some(*prev * eval_point)
+        })
+        .take(t)
+        .collect::<Vec<_>>();
+        let eval_in_exp = C::msm(commitment, &powers).map_err(|_| {
+            VssError::InternalError("commitments and powers mismatched length".to_string())
+        })?;
+
+        Ok(C::generator().mul(share) == eval_in_exp)
+    }
+
+    fn reconstruct(
+        pp: &Self::PublicParam,
+        shares: impl Iterator<Item = (usize, Self::SecretShare)>,
+    ) -> Result<Self::Secret, VssError> {
+        let shares = shares.collect::<Vec<_>>();
+        let n = pp.n.get() as usize;
+        let t = pp.t.get() as usize;
+        // input validation
+        if shares.len() != t {
+            return Err(VssError::InsufficientShares(t, shares.len()));
+        }
+        for (idx, _) in shares.iter() {
+            if *idx >= n {
+                return Err(VssError::IndexOutOfBound(n - 1, *idx));
+            }
+        }
+
+        // Lagrange interpolate to get back the secret
+        let eval_points: Vec<_> = shares
+            .iter()
+            .map(|&(idx, _)| C::ScalarField::from(idx as u64 + 1))
+            .collect();
+        let evals: Vec<_> = shares.iter().map(|&(_, share)| share).collect();
+        interpolate::<C>(&eval_points, &evals)
+            .map_err(|e| VssError::FailedReconstruction(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_bls12_381::G1Projective;
+    use ark_std::{UniformRand, rand::seq::SliceRandom, test_rng};
+
+    use super::*;
+
+    fn test_feldman_vss_helper<C: CurveGroup>() {
+        let rng = &mut test_rng();
+        for _ in 0..10 {
+            let secret = C::ScalarField::rand(rng);
+            let n = rng.gen_range(5..20);
+            let t = rng.gen_range(2..n);
+            let n_usize = n as usize;
+            let t_usize = t as usize;
+
+            let n = NonZeroU32::new(n).unwrap();
+            let t = NonZeroU32::new(t).unwrap();
+            let pp = FeldmanVSSPublicParam::new(t, n);
+
+            let (shares, commitment, _proofs) = FeldmanVSS::<C>::share(&pp, rng, secret);
+            let proof = (); // not used
+            for (node_idx, s) in shares.iter().enumerate() {
+                // happy path
+                assert!(FeldmanVSS::<C>::verify(&pp, node_idx, s, &commitment, &proof).unwrap());
+
+                // sad path
+                // wrong node_idx should fail
+                assert!(
+                    !FeldmanVSS::<C>::verify(&pp, node_idx + 1, s, &commitment, &proof)
+                        .unwrap_or(false)
+                );
+
+                // wrong secret share should fail
+                assert!(
+                    !FeldmanVSS::<C>::verify(
+                        &pp,
+                        node_idx,
+                        &C::ScalarField::rand(rng),
+                        &commitment,
+                        &proof
+                    )
+                    .unwrap()
+                );
+
+                // wrong commitment should fail
+                let mut bad_comm = commitment.clone();
+                bad_comm[1] = C::Affine::default();
+                assert!(!FeldmanVSS::<C>::verify(&pp, node_idx, s, &bad_comm, &proof).unwrap());
+
+                // incomplete/dropped commitment should fail
+                bad_comm.pop();
+                assert!(FeldmanVSS::<C>::verify(&pp, node_idx, s, &bad_comm, &proof).is_err());
+            }
+
+            // 1. Randomly select t-share subset and reconstruct (should succeed)
+            let mut indices: Vec<_> = (0..n_usize).collect();
+            indices.shuffle(rng);
+            let t_indices = &indices[..t_usize];
+            let rec = FeldmanVSS::<C>::reconstruct(&pp, t_indices.iter().map(|&i| (i, shares[i])))
+                .unwrap();
+            assert_eq!(rec, secret);
+
+            // 2. Remove one from t-share subset (t-1 shares, should fail)
+            assert!(
+                FeldmanVSS::<C>::reconstruct(
+                    &pp,
+                    t_indices[..t_usize - 1].iter().map(|&i| (i, shares[i]))
+                )
+                .is_err()
+            );
+
+            // 3. Replace one share in t-size subset with a random (invalid) share (should fail)
+            let mut bad_shares = t_indices
+                .iter()
+                .map(|&i| (i, shares[i]))
+                .collect::<Vec<_>>();
+            // Replace the first share with a random value
+            bad_shares[0] = (bad_shares[0].0, C::ScalarField::rand(rng));
+            assert_ne!(
+                FeldmanVSS::<C>::reconstruct(&pp, bad_shares.into_iter()).unwrap(),
+                secret
+            );
+        }
+    }
+
+    #[test]
+    fn test_feldman_vss() {
+        test_feldman_vss_helper::<G1Projective>();
+    }
+}

--- a/timeboost-crypto/src/interpolation.rs
+++ b/timeboost-crypto/src/interpolation.rs
@@ -1,0 +1,116 @@
+//! General Lagrange interpolation in base field or in the exponent, see BonehShoup Sec 22.1.1
+//!
+//! For FFT evaluation domain (aka roots of unity), directly use:
+//! <https://docs.rs/ark-poly/latest/ark_poly/domain/trait.EvaluationDomain.html#method.ifft>
+
+use ark_ec::CurveGroup;
+use ark_ff::{Field, batch_inversion};
+
+/// Lagrange interpolation: given the evaluated points {x_i}, evaluations: {y_i=f(x_i)}, return f(0)
+/// polynomial degree = eval_points.len() - 1
+pub(crate) fn interpolate<C: CurveGroup>(
+    eval_points: &[C::ScalarField],
+    evals: &[C::ScalarField],
+) -> anyhow::Result<C::ScalarField> {
+    let n = eval_points.len();
+    anyhow::ensure!(
+        n == evals.len(),
+        "eval_points and evals must have same length"
+    );
+    anyhow::ensure!(n > 0, "need at least one point");
+
+    let lagrange_coeffs = lagrange_coeffs_at_zero(eval_points);
+    let result = lagrange_coeffs
+        .iter()
+        .zip(evals)
+        .map(|(l, y)| *l * *y)
+        .sum();
+    Ok(result)
+}
+
+/// Given evaluated points {x_i}, evaluations in the exponents: {g^y_i}, returns g^f(0)
+/// polynomial degree = eval_points.len() - 1
+/// Corollary 22.2 of BonehShoup book
+pub(crate) fn interpolate_in_exponent<C: CurveGroup>(
+    eval_points: &[C::ScalarField],
+    evals_in_exp: &[C::Affine],
+) -> anyhow::Result<C> {
+    let n = eval_points.len();
+    anyhow::ensure!(
+        n == evals_in_exp.len(),
+        "eval_points and evals_in_exp must have same length"
+    );
+    anyhow::ensure!(n > 0, "need at least one point");
+
+    let lagrange_coeffs = lagrange_coeffs_at_zero(eval_points);
+    C::msm(evals_in_exp, &lagrange_coeffs)
+        .map_err(|e| anyhow::anyhow!("Interpolate in exponent failed: {:?}", e))
+}
+
+/// Compute barycentric Lagrange coefficients at 0 for given eval points
+fn lagrange_coeffs_at_zero<F: Field>(eval_points: &[F]) -> Vec<F> {
+    let n = eval_points.len();
+    let mut w = vec![F::one(); n];
+    for i in 0..n {
+        for j in 0..n {
+            if i != j {
+                w[i] *= eval_points[i] - eval_points[j];
+            }
+        }
+    }
+    batch_inversion(&mut w);
+    let l0 = eval_points.iter().fold(F::one(), |acc, x_i| acc * (-*x_i));
+    eval_points
+        .iter()
+        .zip(w.iter())
+        .map(|(x_i, w_i)| l0 * w_i / (-*x_i))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_bls12_381::{Fr, G1Affine, G1Projective};
+    use ark_ec::{CurveGroup, PrimeGroup};
+    use ark_ff::{UniformRand, Zero};
+    use ark_std::rand::thread_rng;
+
+    #[test]
+    fn test_interpolate_basic() {
+        // f(x) = 3x^2 + 2x + 1
+        let f = |x: Fr| Fr::from(3u32) * x * x + Fr::from(2u32) * x + Fr::from(1u32);
+        let xs: Vec<Fr> = (1u64..=3).map(Fr::from).collect();
+        let ys: Vec<Fr> = xs.iter().map(|&x| f(x)).collect();
+        let interp = interpolate::<G1Projective>(&xs, &ys).unwrap();
+        let f0 = f(Fr::zero());
+        assert_eq!(interp, f0);
+    }
+
+    #[test]
+    fn test_interpolate_random() {
+        let mut rng = thread_rng();
+        // Random quadratic
+        let a = Fr::rand(&mut rng);
+        let b = Fr::rand(&mut rng);
+        let c = Fr::rand(&mut rng);
+        let f = |x: Fr| a * x * x + b * x + c;
+        let xs: Vec<Fr> = (1u64..=3).map(Fr::from).collect();
+        let ys: Vec<Fr> = xs.iter().map(|&x| f(x)).collect();
+        assert_eq!(interpolate::<G1Projective>(&xs, &ys).unwrap(), c);
+    }
+
+    #[test]
+    fn test_interpolate_in_exponent() {
+        // f(x) = 5x + 7
+        let a = Fr::from(5u32);
+        let b = Fr::from(7u32);
+        let f = |x: Fr| a * x + b;
+        let xs: Vec<Fr> = (1u64..=2).map(Fr::from).collect();
+        let ys: Vec<Fr> = xs.iter().map(|&x| f(x)).collect();
+        let g = G1Projective::generator();
+        let gs_y: Vec<G1Affine> = ys.iter().map(|y| (g * *y).into_affine()).collect();
+        let interp_exp = interpolate_in_exponent::<G1Projective>(&xs, &gs_y).unwrap();
+        let expected = g * b;
+        assert_eq!(interp_exp, expected);
+    }
+}

--- a/timeboost-crypto/src/lib.rs
+++ b/timeboost-crypto/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cp_proof;
+mod interpolation;
 pub mod sg_encryption;
 pub mod traits;
 

--- a/timeboost-crypto/src/lib.rs
+++ b/timeboost-crypto/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cp_proof;
+pub mod feldman;
 mod interpolation;
 pub mod sg_encryption;
 pub mod traits;

--- a/timeboost-crypto/src/traits/dkg.rs
+++ b/timeboost-crypto/src/traits/dkg.rs
@@ -71,4 +71,10 @@ pub enum VssError {
     IndexOutOfBound(usize, usize),
     #[error("invalid secret share at index {0}: {1}")]
     InvalidShare(usize, String),
+    #[error("invalid VSS commitment")]
+    InvalidCommitment,
+    #[error("failed to reconstruct: {0}")]
+    FailedReconstruction(String),
+    #[error("internal err: {0}")]
+    InternalError(String),
 }

--- a/timeboost-crypto/src/traits/dkg.rs
+++ b/timeboost-crypto/src/traits/dkg.rs
@@ -15,7 +15,6 @@ pub trait VerifiableSecretSharing {
     type Secret;
     type SecretShare;
     type Commitment;
-    type ShareProof;
 
     /// Generates a (t, n)-secret sharing of the given `secret`.
     ///
@@ -24,23 +23,17 @@ pub trait VerifiableSecretSharing {
     /// Returns a tuple of:
     ///   - a vector of `n` secret shares,
     ///   - a global proof/commitment (e.g., Feldman commitments; may be unused in some schemes),
-    ///   - a vector of `n` per-share proofs/openings (e.g., Pedersen openings).
     fn share<R: Rng>(
         pp: &Self::PublicParam,
         rng: &mut R,
         secret: Self::Secret,
-    ) -> (
-        Vec<Self::SecretShare>,
-        Self::Commitment,
-        Vec<Self::ShareProof>,
-    );
+    ) -> (Vec<Self::SecretShare>, Self::Commitment);
 
     /// Verifies a secret share against the global and per-share proofs.
     ///
     /// - `node_idx`: index of the share to verify
     /// - `share`: the secret share to verify
     /// - `commitment`: the global commitment (if any)
-    /// - `share_proof`: the per-share proof/opening (if any)
     ///
     /// Returns Ok(true) if valid, Ok(false) if invalid, or an appropriate `VssError` otherwise.
     fn verify(
@@ -48,7 +41,6 @@ pub trait VerifiableSecretSharing {
         node_idx: usize,
         share: &Self::SecretShare,
         commitment: &Self::Commitment,
-        share_proof: &Self::ShareProof,
     ) -> Result<bool, VssError>;
 
     /// Reconstructs the original secret from a set of (index, share) pairs.
@@ -65,8 +57,8 @@ pub trait VerifiableSecretSharing {
 /// Error types for [`VerifiableSecretSharing`]
 #[derive(Error, Debug, Clone)]
 pub enum VssError {
-    #[error("insufficient secret shares, expected: {0}, got: {1}")]
-    InsufficientShares(usize, usize),
+    #[error("mismatched number of secret shares, expected: {0}, got: {1}")]
+    MismatchedSharesCount(usize, usize),
     #[error("share index out of bound, max: {0}, got: {1}")]
     IndexOutOfBound(usize, usize),
     #[error("invalid secret share at index {0}: {1}")]


### PR DESCRIPTION
Blocked by #374 
Closes https://app.asana.com/1/1208976916964769/project/1209394409339229/task/1210580323499323?focus=true

### This PR:

- Extrapolate previous Lagrange interpolation logic into its own files, into two functions: one for normal `interpolate()` which is used in VSS reconstruction, the other is `interpolate_in_exponent()` which is used in threshold decryption. (and later in resharing)
- Implement Feldman VSS and added unit tests.
