### PR TITLE
Lookup handover evidence.

### DIFF
--- a/sailfish-consensus/src/lib.rs
+++ b/sailfish-consensus/src/lib.rs
@@ -1035,6 +1035,11 @@ where
         if let Some(cert) = self.timeouts.get(&r).and_then(|a| a.certificate()) {
             return Some(Evidence::Timeout(cert.clone()));
         }
+        if let Some(cert) = self.handovers.as_ref().and_then(|a| a.certificate()) {
+            if cert.data().round().num() == r {
+                return Some(Evidence::Handover(cert.clone()));
+            }
+        }
         None
     }
 


### PR DESCRIPTION
In case the first round after handover times out, the only possible evidence is the handover certificate which is not currently considered when looking up evidence of the previous round.