### PR TITLE
Add trace logs to consensus.

### DIFF
--- a/tests/src/tests/consensus/test_traffic_patterns.rs
+++ b/tests/src/tests/consensus/test_traffic_patterns.rs
@@ -188,7 +188,7 @@ fn is_valid_delivery(sim: &Simulator) -> bool {
     if m.is_empty() {
         return false;
     }
-    for r in 0 .. sim.events().len() {
+    for r in 0..sim.events().len() {
         let mut d = 0;
         for (a, b) in m.values().zip(m.values().skip(1)) {
             d += (a.get(r) != b.get(r)) as usize

--- a/tests/src/tests/consensus/test_traffic_patterns.rs
+++ b/tests/src/tests/consensus/test_traffic_patterns.rs
@@ -188,8 +188,14 @@ fn is_valid_delivery(sim: &Simulator) -> bool {
     if m.is_empty() {
         return false;
     }
-    if m.values().zip(m.values().skip(1)).any(|(a, b)| a != b) {
-        return false;
+    for r in 0 .. sim.events().len() {
+        let mut d = 0;
+        for (a, b) in m.values().zip(m.values().skip(1)) {
+            d += (a.get(r) != b.get(r)) as usize
+        }
+        if d >= sim.committee().one_honest_threshold().get() {
+            return false;
+        }
     }
     let mut s = HashSet::new();
     for e in m.values() {


### PR DESCRIPTION
Allows better analysis of consensus state machine inputs and outputs. Also addresses a test failure.