### PR TITLE
More block producer tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ tide-disco = "0.9.3"
 smallvec = "1.15.1"
 tokio = { version = "1", default-features = false, features = ["full"] }
 tokio-stream = "0.1.17"
+tokio-util = "0.7.15"
 toml = "0.8.19"
 tonic = "0.13.1"
 tonic-build = { version = "0.13.1", features = ["prost"] }

--- a/sailfish-types/src/lib.rs
+++ b/sailfish-types/src/lib.rs
@@ -1,6 +1,7 @@
 mod comm;
 mod committee;
 mod message;
+mod nodeinfo;
 mod payload;
 mod round;
 mod time;
@@ -13,6 +14,7 @@ pub use committee::CommitteeVec;
 pub use message::{Action, Evidence, Payload};
 pub use message::{Handover, HandoverMessage};
 pub use message::{Message, NoVote, NoVoteMessage, Timeout, TimeoutMessage};
+pub use nodeinfo::NodeInfo;
 pub use payload::DataSource;
 pub use round::{Round, RoundNumber};
 pub use time::{ConsensusTime, HasTime, Timestamp};

--- a/sailfish-types/src/nodeinfo.rs
+++ b/sailfish-types/src/nodeinfo.rs
@@ -14,6 +14,7 @@ impl<T: Default + PartialOrd + Clone> NodeInfo<T> {
         }
     }
 
+    /// Store a value of a party.
     pub fn record(&mut self, k: &PublicKey, new: T) -> bool {
         let Some(i) = self.nodes.iter().position(|(p, _)| p == k) else {
             return false;
@@ -41,7 +42,7 @@ impl<T: Default + PartialOrd + Clone> NodeInfo<T> {
         true
     }
 
-    /// Gets the smallest round number the quorum of nodes has committed.
+    /// Gets the lower bound of the highest quorum interval.
     pub fn quorum(&self) -> T {
         debug_assert!(self.quorum <= self.nodes.len());
         self.nodes[self.quorum - 1].1.clone()

--- a/sailfish-types/src/nodeinfo.rs
+++ b/sailfish-types/src/nodeinfo.rs
@@ -1,25 +1,20 @@
 use multisig::{Committee, PublicKey};
-use sailfish_types::RoundNumber;
 
-/// Information about nodes.
 #[derive(Debug)]
-pub struct NodeInfo {
-    /// Associative list of public key to committed round number.
-    nodes: Vec<(PublicKey, RoundNumber)>,
-    /// The quorum size of the nodes.
+pub struct NodeInfo<T> {
+    nodes: Vec<(PublicKey, T)>,
     quorum: usize,
 }
 
-impl NodeInfo {
+impl<T: Default + PartialOrd + Clone> NodeInfo<T> {
     pub fn new(c: &Committee) -> Self {
         Self {
-            nodes: c.parties().map(|k| (*k, RoundNumber::genesis())).collect(),
+            nodes: c.parties().map(|k| (*k, T::default())).collect(),
             quorum: c.quorum_size().get(),
         }
     }
 
-    /// Sets the committed round of a committee member.
-    pub fn set_committed_round(&mut self, k: &PublicKey, new: RoundNumber) -> bool {
+    pub fn record(&mut self, k: &PublicKey, new: T) -> bool {
         let Some(i) = self.nodes.iter().position(|(p, _)| p == k) else {
             return false;
         };
@@ -39,7 +34,7 @@ impl NodeInfo {
         self.nodes.insert(i, (*k, new));
 
         debug_assert!({
-            let it = self.nodes.iter().map(|(_, r)| *r);
+            let it = self.nodes.iter().map(|(_, r)| r);
             it.clone().zip(it.skip(1)).all(|(a, b)| a >= b)
         });
 
@@ -47,8 +42,8 @@ impl NodeInfo {
     }
 
     /// Gets the smallest round number the quorum of nodes has committed.
-    pub fn committed_round_quorum(&self) -> RoundNumber {
+    pub fn quorum(&self) -> T {
         debug_assert!(self.quorum <= self.nodes.len());
-        self.nodes[self.quorum - 1].1
+        self.nodes[self.quorum - 1].1.clone()
     }
 }

--- a/sailfish-types/src/round.rs
+++ b/sailfish-types/src/round.rs
@@ -30,6 +30,12 @@ impl RoundNumber {
     }
 }
 
+impl Default for RoundNumber {
+    fn default() -> Self {
+        GENESIS_ROUND
+    }
+}
+
 impl From<u64> for RoundNumber {
     fn from(val: u64) -> Self {
         Self(val)

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,5 +27,6 @@ timeboost-types = { path = "../timeboost-types" }
 timeboost-utils = { path = "../timeboost-utils", features = ["test"] }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 turmoil = { workspace = true }
 tracing = { workspace = true }

--- a/tests/src/tests/timeboost.rs
+++ b/tests/src/tests/timeboost.rs
@@ -100,7 +100,6 @@ where
             .dh_keypair(xpair)
             .address(pa)
             .committee(produce_committee.clone())
-            .retain(100)
             .build();
         cfgs.push((conf, pcf));
     }

--- a/timeboost-builder/Cargo.toml
+++ b/timeboost-builder/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-arrayvec = { workspace = true }
 bincode = { workspace = true }
 committable = { workspace = true }
 bon = { workspace = true }

--- a/timeboost-builder/src/config.rs
+++ b/timeboost-builder/src/config.rs
@@ -8,7 +8,6 @@ pub struct BlockProducerConfig {
     pub(crate) dh_keypair: x25519::Keypair,
     pub(crate) committee: AddressableCommittee,
     pub(crate) address: Address,
-    pub(crate) retain: usize,
     #[builder(default = true)]
     pub(crate) recover: bool,
 }

--- a/timeboost-builder/src/produce.rs
+++ b/timeboost-builder/src/produce.rs
@@ -225,7 +225,7 @@ struct Worker {
     #[builder(default = RoundNumber::genesis())]
     clock: RoundNumber,
 
-    /// Quorum of block numbers to use with garbale collection.
+    /// Quorum of block numbers to use with garbage collection.
     info: NodeInfo<BlockNumber>,
 }
 

--- a/timeboost-types/src/block.rs
+++ b/timeboost-types/src/block.rs
@@ -34,6 +34,12 @@ impl BlockNumber {
     }
 }
 
+impl Default for BlockNumber {
+    fn default() -> Self {
+        GENESIS_BLOCK
+    }
+}
+
 impl From<u64> for BlockNumber {
     fn from(val: u64) -> Self {
         Self(val)
@@ -245,5 +251,17 @@ impl CertifiedBlock {
 
     pub fn data(&self) -> &Block {
         &self.data
+    }
+}
+
+impl From<CertifiedBlock> for Certificate<BlockInfo> {
+    fn from(block: CertifiedBlock) -> Self {
+        block.cert
+    }
+}
+
+impl From<CertifiedBlock> for Block {
+    fn from(block: CertifiedBlock) -> Self {
+        block.data
     }
 }

--- a/timeboost-types/src/block.rs
+++ b/timeboost-types/src/block.rs
@@ -4,7 +4,7 @@ use std::ops::{Add, Deref, Sub};
 use alloy_primitives::B256;
 use bytes::Bytes;
 use committable::{Commitment, Committable, RawCommitmentBuilder};
-use multisig::{Certificate, CommitteeId};
+use multisig::Certificate;
 use sailfish_types::RoundNumber;
 use serde::{Deserialize, Serialize};
 use timeboost_proto::block as proto;
@@ -189,20 +189,20 @@ impl TryFrom<proto::Block> for Block {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct BlockInfo {
     num: BlockNumber,
+    round: RoundNumber,
     hash: BlockHash,
-    committee: CommitteeId,
 }
 
 impl BlockInfo {
-    pub fn new<B, C>(num: B, hash: BlockHash, committee: C) -> Self
+    pub fn new<B, R>(num: B, r: R, hash: BlockHash) -> Self
     where
         B: Into<BlockNumber>,
-        C: Into<CommitteeId>,
+        R: Into<RoundNumber>,
     {
         Self {
             num: num.into(),
+            round: r.into(),
             hash,
-            committee: committee.into(),
         }
     }
 
@@ -210,12 +210,12 @@ impl BlockInfo {
         self.num
     }
 
-    pub fn hash(&self) -> &BlockHash {
-        &self.hash
+    pub fn round(&self) -> RoundNumber {
+        self.round
     }
 
-    pub fn committee(&self) -> CommitteeId {
-        self.committee
+    pub fn hash(&self) -> &BlockHash {
+        &self.hash
     }
 }
 
@@ -223,8 +223,8 @@ impl Committable for BlockInfo {
     fn commit(&self) -> Commitment<Self> {
         RawCommitmentBuilder::new("BlockInfo")
             .field("num", self.num.commit())
+            .field("round", self.round.commit())
             .field("hash", self.hash.commit())
-            .field("committee", self.committee.commit())
             .finalize()
     }
 }

--- a/timeboost-types/src/block.rs
+++ b/timeboost-types/src/block.rs
@@ -5,7 +5,7 @@ use alloy_primitives::B256;
 use bytes::Bytes;
 use committable::{Commitment, Committable, RawCommitmentBuilder};
 use multisig::Certificate;
-use sailfish_types::RoundNumber;
+use sailfish_types::{Round, RoundNumber};
 use serde::{Deserialize, Serialize};
 use timeboost_proto::block as proto;
 
@@ -195,19 +195,18 @@ impl TryFrom<proto::Block> for Block {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct BlockInfo {
     num: BlockNumber,
-    round: RoundNumber,
+    round: Round,
     hash: BlockHash,
 }
 
 impl BlockInfo {
-    pub fn new<B, R>(num: B, r: R, hash: BlockHash) -> Self
+    pub fn new<B>(num: B, r: Round, hash: BlockHash) -> Self
     where
         B: Into<BlockNumber>,
-        R: Into<RoundNumber>,
     {
         Self {
             num: num.into(),
-            round: r.into(),
+            round: r,
             hash,
         }
     }
@@ -216,8 +215,8 @@ impl BlockInfo {
         self.num
     }
 
-    pub fn round(&self) -> RoundNumber {
-        self.round
+    pub fn round(&self) -> &Round {
+        &self.round
     }
 
     pub fn hash(&self) -> &BlockHash {

--- a/timeboost/src/config.rs
+++ b/timeboost/src/config.rs
@@ -73,7 +73,6 @@ impl TimeboostConfig {
             .dh_keypair(self.dh_keypair.clone())
             .address(self.producer_addr.clone())
             .committee(self.producer_committee.clone())
-            .retain(self.leash_len)
             .recover(self.recover)
             .build()
     }


### PR DESCRIPTION
1. Move `NodeInfo` from `sailfish-consensus` to `sailfish-types` and use it in `Producer` to determine the lower bound for garbage collection.
2. Use `CommitteeVec` in `Producer` and always determine committee by ID.