### PR TITLE
Dynamic committees for decryption phase

### DIFF
--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -543,7 +543,7 @@ impl Worker {
                 evidence = %batch.evidence.round(),
                 "invalid evidence"
             );
-            return Err(DecrypterError::NoCommittee(round.committee()));
+            return Err(DecrypterError::MissingRoundEvidence(round));
         }
 
         // This operation is doing the following: assumme local cache for this round is:
@@ -552,10 +552,7 @@ impl Worker {
         // far. with node c's batch [s1c, s2c, s3c], the new local cache is:
         // [[s1a, s1b, s1c], [s2a, s2b, s2c], [s3a, s3b, s3c]]
         let round_num = round.num();
-        let round_map = self
-            .dec_shares
-            .entry(round_num)
-            .or_insert_with(HashMap::new);
+        let round_map = self.dec_shares.entry(round_num).or_default();
         let entry = round_map
             .entry(round)
             .or_insert_with(|| vec![vec![]; batch.len()]);
@@ -837,6 +834,9 @@ pub enum DecrypterError {
 
     #[error("empty set of valid decryption shares")]
     EmptyDecShares,
+
+    #[error("missing evidence for round: {0}")]
+    MissingRoundEvidence(Round),
 
     #[error("received inclusion list is outdated (already received or hatched)")]
     OutdatedRound,

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -305,6 +305,9 @@ impl Task {
                             let acts = self.sailfish.set_next_consensus(cons);
                             candidates = self.execute(acts).await?
                         }
+                        if let Err(err) = self.decrypter.next_committee(a).await {
+                            warn!(node = %self.label, %err, "decrypt next committee error");
+                        }
                     }
                     None => {
                         return Err(TimeboostError::ChannelClosed)
@@ -355,7 +358,7 @@ impl Task {
                 match self.sailfish.execute(action).await {
                     Ok(Some(Event::Gc(r))) => {
                         if let Err(err) = self.decrypter.gc(r.num()).await {
-                            error!(node = %self.label, %err, "decrypt gc error");
+                            warn!(node = %self.label, %err, "decrypt gc error");
                         }
                     }
                     Ok(Some(Event::Catchup(_))) => {
@@ -365,6 +368,9 @@ impl Task {
                         if let Some(cons) = self.sailfish.consensus(r.committee()) {
                             let c = cons.committee().clone();
                             self.includer.set_next_committee(r.num(), c);
+                            if let Err(err) = self.decrypter.use_committee(r).await {
+                                warn!(node = %self.label, %err, "decrypt use committee error");
+                            }
                             self.output
                                 .send(Output::UseCommittee(r))
                                 .await

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -306,7 +306,7 @@ impl Task {
                             candidates = self.execute(acts).await?
                         }
                         if let Err(err) = self.decrypter.next_committee(a).await {
-                            warn!(node = %self.label, %err, "decrypt next committee error");
+                            error!(node = %self.label, %err, "decrypt next committee error");
                         }
                     }
                     None => {
@@ -369,7 +369,7 @@ impl Task {
                             let c = cons.committee().clone();
                             self.includer.set_next_committee(r.num(), c);
                             if let Err(err) = self.decrypter.use_committee(r).await {
-                                warn!(node = %self.label, %err, "decrypt use committee error");
+                                error!(node = %self.label, %err, "decrypt use committee error");
                             }
                             self.output
                                 .send(Output::UseCommittee(r))


### PR DESCRIPTION
### Context
To support dynamic committees, we need more than just the “handover” in consensus (Sailfish). Other components running on separate networks must also be made aware of committee changes so they can handle these transitions properly.

This is especially important during the decryption phase, where a committee switch should also trigger a Distributed Key Generation (DKG) event and Sailfish serves as the communication layer for this new key material.

Previous work on unifying the decryption and block building phases (Decrypter and Certifier) makes it possible to reuse the same committee switching logic across both. While further generalization of Decrypter and Certifier is desirable, some challenges remain:

1. The Decrypter uses evidence directly from Sailfish, while the Certifier must build this evidence independently. This is because multiple blocks can be produced per round, making Sailfish’s evidence model incompatible with block production.

2. Garbage collection in the Decrypter relies on a "leash" mechanism (back-pressure to Sailfish). In contrast, the Certifier lacks a direct connection between blocks and rounds, requiring the use of the lowest committed round quorum approach, similar to Sailfish.

Although these differences make complete unification challenging right now, aligning the committee change logic already improves readability and sets the stage for future convergence.

### Content
This PR finalizes support for dynamic committees in the decryption phase and prepares the groundwork for introducing DKG in the Decrypter. In particular, correctly integrating DKG is now feasible thanks to the addition of NextCommittee and UseCommittee events in the Decrypter.

Key changes:

1. Added a Round struct (comprising round_number and committee_id) to DecShareBatch. This includes the target committee_id so receivers can perform the correct threshold combination.

2. Implemented evidence checking against the correct local committee for each round.

3. Partitioned decryption shares for each round by committee_id. For hatching, we identify the first committee where threshold decryption is possible and discard shares from other committees for the same round.