### PR TITLE
fix: Replace r#gen with gen in MRE test code

### DIFF
--- a/timeboost-crypto/src/mre.rs
+++ b/timeboost-crypto/src/mre.rs
@@ -278,7 +278,7 @@ mod tests {
             .enumerate()
             .map(|(i, sk)| sk.label(i))
             .collect();
-        let msgs = repeat_with(|| rng.r#gen::<[u8; 32]>().to_vec())
+        let msgs = repeat_with(|| rng.gen::<[u8; 32]>().to_vec())
             .take(n)
             .collect::<Vec<_>>();
         let aad = b"Alice";


### PR DESCRIPTION
This change fixes an incorrect use of r#gen in the test code, replacing it with the standard gen method. The r# prefix is only needed when using reserved keywords as identifiers, but "gen" is not a reserved keyword in Rust.