### PR TITLE
ci: update apt to fix protobuf not found

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,9 @@ jobs:
         tar -vxf just-1.14.0-x86_64-unknown-linux-musl.tar.gz just
         sudo cp just /usr/bin/just
     - name: Install protobuf compiler
-      run: sudo apt-get install -y protobuf-compiler
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y protobuf-compiler
     - name: Build
       run: just build_release
     - name: Upload binaries
@@ -44,7 +46,9 @@ jobs:
     - uses: actions/checkout@v4
     - uses: taiki-e/install-action@nextest
     - name: Install protobuf compiler
-      run: sudo apt-get install -y protobuf-compiler
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y protobuf-compiler
     - name: Install Just
       run: |
         wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz
@@ -58,7 +62,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install protobuf compiler
-      run: sudo apt-get install -y protobuf-compiler
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y protobuf-compiler
     - name: Install Just
       run: |
         wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz
@@ -89,7 +95,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install protobuf compiler
-      run: sudo apt-get install -y protobuf-compiler
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y protobuf-compiler
     - name: Install Just
       run: |
         wget https://github.com/casey/just/releases/download/1.14.0/just-1.14.0-x86_64-unknown-linux-musl.tar.gz


### PR DESCRIPTION
Closes #<ISSUE_NUMBER>

currently in `main`, CI failed due to `protobuf` download in ubuntu failed with 404 not found