### PR TITLE
Update test and yapper logic to get encryption key after DKG

### DIFF
--- a/tests/src/tests/timeboost.rs
+++ b/tests/src/tests/timeboost.rs
@@ -115,10 +115,10 @@ async fn gen_bundles(
 ) {
     let mut enc_key = None;
     loop {
-        match enc_key_rx.try_recv() {
-            Ok(k) => enc_key = Some(k),
-            _ => {}
-        };
+        if let Ok(k) = enc_key_rx.try_recv() {
+            enc_key = Some(k);
+        }
+
         let Ok(b) = make_bundle(enc_key.as_ref()) else {
             warn!("Failed to generate bundle");
             continue;

--- a/tests/src/tests/timeboost/block_order.rs
+++ b/tests/src/tests/timeboost/block_order.rs
@@ -33,18 +33,18 @@ async fn block_order() {
     let mut tasks = JoinSet::new();
     let (bcast, _) = broadcast::channel(3);
     let finish = CancellationToken::new();
-    
+
     let mut chosen_enc_key_rx = None;
 
     for (c, b) in cfg {
         let (tx, rx) = mpsc::unbounded_channel();
         let (enc_key_tx, enc_key_rx) = oneshot::channel();
-        
+
         // Use the first receiver for gen_bundles
         if chosen_enc_key_rx.is_none() {
             chosen_enc_key_rx = Some(enc_key_rx);
         }
-        
+
         let mut brx = bcast.subscribe();
         let finish = finish.clone();
         tasks.spawn(async move {

--- a/tests/src/tests/timeboost/handover.rs
+++ b/tests/src/tests/timeboost/handover.rs
@@ -113,10 +113,15 @@ where
             .map(|((k, x), a)| (k.public_key(), x.public_key(), a.clone())),
     );
 
-    let dkg_keys = (0..sign_keys.len()).map(|_| DkgDecKey::generate()).collect::<Vec<_>>();
+    let dkg_keys = (0..sign_keys.len())
+        .map(|_| DkgDecKey::generate())
+        .collect::<Vec<_>>();
     let dkg_keystore = DkgKeyStore::new(
         committee.clone(),
-        dkg_keys.iter().enumerate().map(|(i, sk)| (i as u8, sk.into())),
+        dkg_keys
+            .iter()
+            .enumerate()
+            .map(|(i, sk)| (i as u8, sk.into())),
     );
 
     sign_keys

--- a/timeboost-crypto/src/prelude.rs
+++ b/timeboost-crypto/src/prelude.rs
@@ -34,8 +34,9 @@ use ark_bls12_381::G1Projective;
 
 pub use crate::mre;
 use crate::{
+    DecryptionScheme,
     feldman::FeldmanVss,
-    traits::dkg::VerifiableSecretSharing,
+    traits::{dkg::VerifiableSecretSharing, threshold_enc::ThresholdEncScheme},
     vess::{self, ShoupVess},
 };
 pub use vess::VessCiphertext;
@@ -63,3 +64,10 @@ pub type Vss = FeldmanVss<G1Projective>;
 
 /// Commitment to a Shamir secret dealing
 pub type VssCommitment = <FeldmanVss<G1Projective> as VerifiableSecretSharing>::Commitment;
+
+/// Public encryption key in the threshold decryption scheme
+pub type ThresholdEncKey = <DecryptionScheme as ThresholdEncScheme>::PublicKey;
+/// Combiner key in the threshold decryption scheme
+pub type ThresholdCombKey = <DecryptionScheme as ThresholdEncScheme>::CombKey;
+/// Decryption key share in the threshold decryption scheme
+pub type ThresholdDecKeyShare = <DecryptionScheme as ThresholdEncScheme>::KeyShare;

--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -301,6 +301,7 @@ struct Worker {
 
     /// channel for sending the encryption key after DKG/resharing is done
     // TODO(alex): after ACS, remember to update self.dec_sk and send enc_key over this channel
+    #[allow(dead_code)]
     enc_key_tx: oneshot::Sender<ThresholdEncKey>,
 
     /// round number of the first decrypter request, used to ignore received decryption shares for

--- a/timeboost-sequencer/src/lib.rs
+++ b/timeboost-sequencer/src/lib.rs
@@ -19,13 +19,14 @@ use sailfish::consensus::{Consensus, ConsensusMetrics};
 use sailfish::rbc::{Rbc, RbcError, RbcMetrics};
 use sailfish::types::{Action, ConsensusTime, Evidence, Round, RoundNumber};
 use sailfish::{Coordinator, Event};
-use timeboost_crypto::prelude::{Vess, Vss};
+use timeboost_crypto::prelude::{ThresholdEncKey, Vess, Vss};
 use timeboost_crypto::traits::dkg::VerifiableSecretSharing;
 use timeboost_crypto::vess::VessError;
 use timeboost_types::{BundleVariant, DkgBundle, DkgKeyStore, Timestamp, Transaction};
 use timeboost_types::{CandidateList, CandidateListBytes, InclusionList};
 use tokio::select;
 use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::sync::oneshot;
 use tokio::task::{JoinHandle, spawn};
 use tracing::{error, info, warn};
 
@@ -98,7 +99,11 @@ impl Mode {
 }
 
 impl Sequencer {
-    pub async fn new<M>(cfg: SequencerConfig, metrics: &M) -> Result<Self>
+    pub async fn new<M>(
+        cfg: SequencerConfig,
+        metrics: &M,
+        enc_key_tx: oneshot::Sender<ThresholdEncKey>,
+    ) -> Result<Self>
     where
         M: ::metrics::Metrics,
     {
@@ -162,7 +167,7 @@ impl Sequencer {
             Coordinator::new(rbc, cons, cfg.previous_sailfish_committee.is_some())
         };
 
-        let decrypter = Decrypter::new(cfg.decrypter_config(), metrics).await?;
+        let decrypter = Decrypter::new(cfg.decrypter_config(), metrics, enc_key_tx).await?;
 
         let (tx, rx) = mpsc::channel(1024);
         let (cx, cr) = mpsc::channel(4);

--- a/timeboost-utils/src/load_generation.rs
+++ b/timeboost-utils/src/load_generation.rs
@@ -3,29 +3,32 @@ use ark_std::rand::{self, Rng};
 use bincode::error::EncodeError;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::Serialize;
-use timeboost_crypto::{DecryptionScheme, traits::threshold_enc::ThresholdEncScheme};
+use timeboost_crypto::{
+    DecryptionScheme, Plaintext, prelude::ThresholdEncKey,
+    traits::threshold_enc::ThresholdEncScheme,
+};
 use timeboost_types::{Address, Bundle, BundleVariant, PriorityBundle, SeqNo, Signer};
 
 pub type EncKey = <DecryptionScheme as ThresholdEncScheme>::PublicKey;
 
-pub fn make_bundle() -> anyhow::Result<BundleVariant> {
+pub fn make_bundle(pubkey: Option<&ThresholdEncKey>) -> anyhow::Result<BundleVariant> {
     let mut rng = rand::thread_rng();
     let mut v = [0; 256];
     rng.fill(&mut v);
     let mut u = Unstructured::new(&v);
 
     let max_seqno = 10;
-    let bundle = Bundle::arbitrary(&mut u)?;
+    let mut bundle = Bundle::arbitrary(&mut u)?;
 
-    // FIXME(alex): fix this
-    // if rng.gen_bool(0.5) {
-    //     // encrypt bundle
-    //     let data = bundle.data();
-    //     let plaintext = Plaintext::new(data.to_vec());
-    //     let ciphertext = DecryptionScheme::encrypt(&mut rng, pubkey, &plaintext, &vec![])?;
-    //     let encoded = serialize(&ciphertext)?;
-    //     bundle.set_encrypted_data(encoded.into());
-    // }
+    if pubkey.is_some() && rng.gen_bool(0.5) {
+        // encrypt bundle
+        let data = bundle.data();
+        let plaintext = Plaintext::new(data.to_vec());
+        let ciphertext = DecryptionScheme::encrypt(&mut rng, pubkey.unwrap(), &plaintext, &vec![])?;
+        let encoded = serialize(&ciphertext)?;
+        bundle.set_encrypted_data(encoded.into());
+    }
+
     if rng.gen_bool(0.5) {
         // priority
         let auction = Address::default();
@@ -45,8 +48,6 @@ pub fn tps_to_millis<N: Into<u64>>(tps: N) -> u64 {
     1000 / tps.into()
 }
 
-// TODO(alex): remove this
-#[allow(dead_code)]
 fn serialize<T: Serialize>(d: &T) -> Result<Bytes, EncodeError> {
     let mut b = BytesMut::new().writer();
     bincode::serde::encode_into_std_write(d, &mut b, bincode::config::standard())?;

--- a/timeboost/api/endpoints.toml
+++ b/timeboost/api/endpoints.toml
@@ -13,6 +13,12 @@ PATH = ["/submit-regular"]
 METHOD = "POST"
 DOC = "Submit regular bundle to Timeboost"
 
+# Returns Some(None) if not ready, Some(key) when ready
+[route.enckey]
+PATH = ["/enckey"]
+METHOD = "POST"
+DOC = "Encryption key for threshold decryptable bundle"
+
 [route.healthz]
 PATH = ["/healthz"]
 METHOD = "GET"

--- a/timeboost/src/lib.rs
+++ b/timeboost/src/lib.rs
@@ -10,6 +10,7 @@ use metrics::TimeboostMetrics;
 use multisig::PublicKey;
 use reqwest::Url;
 use timeboost_builder::{Certifier, CertifierDown};
+use timeboost_crypto::prelude::ThresholdEncKey;
 use timeboost_proto::internal::internal_api_server::InternalApiServer;
 use timeboost_sequencer::{Output, Sequencer};
 use timeboost_types::BundleVariant;
@@ -17,6 +18,7 @@ use timeboost_utils::types::prometheus::PrometheusMetrics;
 use tokio::net::lookup_host;
 use tokio::select;
 use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio::task::spawn;
 use tracing::{error, info, instrument, warn};
@@ -55,10 +57,14 @@ impl Drop for Timeboost {
 }
 
 impl Timeboost {
-    pub async fn new(cfg: TimeboostConfig, rx: Receiver<BundleVariant>) -> Result<Self> {
+    pub async fn new(
+        cfg: TimeboostConfig,
+        rx: Receiver<BundleVariant>,
+        enc_key_tx: oneshot::Sender<ThresholdEncKey>,
+    ) -> Result<Self> {
         let pro = Arc::new(PrometheusMetrics::default());
         let met = Arc::new(TimeboostMetrics::new(&*pro));
-        let seq = Sequencer::new(cfg.sequencer_config(), &*pro).await?;
+        let seq = Sequencer::new(cfg.sequencer_config(), &*pro, enc_key_tx).await?;
         let blk = Certifier::new(cfg.certifier_config(), &*pro).await?;
 
         // TODO: Once we have e2e listener this check wont be needed
@@ -162,8 +168,12 @@ pub async fn metrics_api(metrics: Arc<PrometheusMetrics>, metrics_port: u16) {
     serve_metrics_api::<StaticVersion<0, 1>>(metrics_port, metrics).await
 }
 
-pub async fn rpc_api(sender: Sender<BundleVariant>, rpc_port: u16) {
-    if let Err(e) = api::endpoints::TimeboostApiState::new(sender)
+pub async fn rpc_api(
+    sender: Sender<BundleVariant>,
+    enc_key_rx: oneshot::Receiver<ThresholdEncKey>,
+    rpc_port: u16,
+) {
+    if let Err(e) = api::endpoints::TimeboostApiState::new(sender, enc_key_rx)
         .run(Url::parse(&format!("http://0.0.0.0:{rpc_port}")).unwrap())
         .await
     {

--- a/yapper/src/tx.rs
+++ b/yapper/src/tx.rs
@@ -2,6 +2,7 @@ use futures::future::join_all;
 use reqwest::{Client, Url};
 use std::time::Duration;
 use timeboost::types::BundleVariant;
+use timeboost_crypto::prelude::ThresholdEncKey;
 use timeboost_utils::load_generation::{make_bundle, tps_to_millis};
 use tokio::time::interval;
 
@@ -9,7 +10,7 @@ use anyhow::{Context, Result};
 use cliquenet::Address;
 use tracing::warn;
 
-fn setup_urls(all_hosts_as_addresses: &[Address]) -> Result<Vec<(Url, Url)>> {
+fn setup_urls(all_hosts_as_addresses: &[Address]) -> Result<Vec<(Url, Url, Url)>> {
     let mut urls = Vec::new();
 
     for addr in all_hosts_as_addresses {
@@ -17,8 +18,10 @@ fn setup_urls(all_hosts_as_addresses: &[Address]) -> Result<Vec<(Url, Url)>> {
             .with_context(|| format!("parsing {addr} into a url"))?;
         let priority_url = Url::parse(&format!("http://{addr}/v0/submit-priority"))
             .with_context(|| format!("parsing {addr} into a url"))?;
+        let enckey_url = Url::parse(&format!("http://{addr}/v0/enckey"))
+            .with_context(|| format!("parsing {addr} into a url"))?;
 
-        urls.push((regular_url, priority_url));
+        urls.push((regular_url, priority_url, enckey_url));
     }
 
     Ok(urls)
@@ -59,6 +62,29 @@ async fn send_bundle_to_node(
     }
 }
 
+async fn fetch_encryption_key(client: &Client, enckey_url: &Url) -> Option<ThresholdEncKey> {
+    let response = match client.post(enckey_url.clone()).send().await {
+        Ok(response) => response,
+        Err(err) => {
+            warn!(%err, "failed to request encryption key");
+            return None;
+        }
+    };
+
+    if !response.status().is_success() {
+        warn!("enckey request failed with status: {}", response.status());
+        return None;
+    }
+
+    match response.json::<Option<ThresholdEncKey>>().await {
+        Ok(enc_key) => enc_key,
+        Err(err) => {
+            warn!(%err, "failed to parse encryption key response");
+            None
+        }
+    }
+}
+
 pub async fn yap(addresses: &[Address], tps: u32) -> Result<()> {
     let c = Client::builder().timeout(Duration::from_secs(1)).build()?;
     let urls = setup_urls(addresses)?;
@@ -67,15 +93,22 @@ pub async fn yap(addresses: &[Address], tps: u32) -> Result<()> {
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
+        // Try to fetch encryption key from the first node
+        let enc_key = if let Some((_, _, enckey_url)) = urls.first() {
+            fetch_encryption_key(&c, enckey_url).await
+        } else {
+            None
+        };
+
         // create a bundle for next `interval.tick()`, then send this bundle to each node
-        let Ok(b) = make_bundle() else {
+        let Ok(b) = make_bundle(enc_key.as_ref()) else {
             warn!("failed to generate bundle");
             continue;
         };
 
         interval.tick().await;
 
-        join_all(urls.iter().map(|(regular_url, priority_url)| async {
+        join_all(urls.iter().map(|(regular_url, priority_url, _)| async {
             send_bundle_to_node(&b, &c, regular_url, priority_url).await
         }))
         .await;


### PR DESCRIPTION
As mentioned on Slack, we need to update yapper and load_generation logic since the encryption key not available at startup, and only available through asking Decrypter who's running DKG/resharing.

My final implementation is as follows:
- Decrypter hold a `oneshot::Sender` that will send over the encryption key once the DKG/resharing is done
- TimeboostApiState will hold the receiving end
- TimeboostApi expose a new endpoint `/enckey` for any client to get the encryption key once available
- any tests that will only spawn `Sequencer`, the oneshot channel is created locally, and the receiver end is no longer TimeboostApi server, but rather the `async gen_bundles()`
- `async gen_bundles()` will periodically check if Decrypter has put the enc_key in the channel, if so pass on to `make_bundle(Option<&ThreholdEncKey>)` which will produce encrypted bundle probabilistically, else `make_bundle(None)` will simply produce unencrypted bundles.


Since this is part of our DKG work, I'm targeting our WIP branch