### PR TITLE
Convert DKG output to Threshold DecryptionKey

### DIFF
--- a/timeboost-crypto/Cargo.toml
+++ b/timeboost-crypto/Cargo.toml
@@ -19,8 +19,8 @@ bincode = { workspace = true }
 bs58 = { workspace = true }
 bytes = { workspace = true }
 committable = { workspace = true }
-digest = { workspace = true }
 derive_more = { workspace = true }
+digest = { workspace = true }
 generic-array = { workspace = true }
 multisig = { path = "../multisig" }
 num-integer = "0.1"

--- a/timeboost-crypto/src/feldman.rs
+++ b/timeboost-crypto/src/feldman.rs
@@ -5,7 +5,7 @@ use ark_poly::{DenseUVPolynomial, Polynomial, univariate::DensePolynomial};
 use ark_serialize::{CanonicalSerialize, SerializationError, serialize_to_vec};
 use ark_std::marker::PhantomData;
 use ark_std::rand::Rng;
-use derive_more::{Deref, From};
+use derive_more::{Deref, From, IntoIterator};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::{iter::successors, num::NonZeroU32};
@@ -179,7 +179,18 @@ impl<C: CurveGroup> VerifiableSecretSharing for FeldmanVss<C> {
 
 /// Commitment of a dealing in Feldman VSS
 #[serde_as]
-#[derive(Clone, Debug, PartialEq, Eq, From, Deref, Serialize, Deserialize, CanonicalSerialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    From,
+    Deref,
+    Serialize,
+    Deserialize,
+    CanonicalSerialize,
+    IntoIterator,
+)]
 pub struct FeldmanCommitment<C: CurveGroup> {
     #[serde_as(as = "crate::SerdeAs")]
     comm: Vec<C::Affine>,

--- a/timeboost-crypto/src/lib.rs
+++ b/timeboost-crypto/src/lib.rs
@@ -14,6 +14,7 @@ use ark_ff::field_hashers::DefaultFieldHasher;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use committable::{Commitment, Committable, RawCommitmentBuilder};
 use cp_proof::Proof;
+use derive_more::From;
 use digest::{generic_array::GenericArray, typenum};
 use multisig::Committee;
 use serde::de::DeserializeOwned;
@@ -112,21 +113,21 @@ impl Keyset {
 }
 
 #[serde_as]
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, From)]
 pub struct CombKey<C: CurveGroup> {
     #[serde_as(as = "Vec<crate::SerdeAs>")]
     pub key: Vec<C>,
 }
 
 #[serde_as]
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, From)]
 pub struct PublicKey<C: CurveGroup> {
     #[serde_as(as = "crate::SerdeAs")]
     key: C,
 }
 
 #[serde_as]
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Zeroize, ZeroizeOnDrop, From)]
 pub struct KeyShare<C: CurveGroup> {
     #[serde_as(as = "crate::SerdeAs")]
     share: C::ScalarField,

--- a/timeboost-types/Cargo.toml
+++ b/timeboost-types/Cargo.toml
@@ -17,6 +17,7 @@ alloy-signer = { workspace = true }
 alloy-signer-local = { workspace = true }
 anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true }
+ark-ec = { workspace = true }
 ark-std = { workspace = true }
 async-trait = { workspace = true }
 bincode = { workspace = true }
@@ -25,6 +26,7 @@ bytes = { workspace = true }
 committable = { workspace = true }
 ethereum_ssz = { workspace = true }
 multisig = { path = "../multisig" }
+rayon = { workspace = true }
 sailfish-types = { path = "../sailfish-types" }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/timeboost-types/src/decryption.rs
+++ b/timeboost-types/src/decryption.rs
@@ -1,8 +1,13 @@
 use std::collections::BTreeMap;
 
+use anyhow::anyhow;
+use ark_ec::AffineRepr;
 use multisig::{Committee, KeyId};
+use rayon::prelude::*;
 use timeboost_crypto::{
-    DecryptionScheme, prelude::DkgEncKey, traits::threshold_enc::ThresholdEncScheme,
+    DecryptionScheme,
+    prelude::{DkgEncKey, Vss},
+    traits::{dkg::VerifiableSecretSharing, threshold_enc::ThresholdEncScheme},
 };
 
 type KeyShare = <DecryptionScheme as ThresholdEncScheme>::KeyShare;
@@ -26,6 +31,38 @@ impl DecryptionKey {
             combkey,
             privkey,
         }
+    }
+
+    /// Construct all key material for threshold decryption from DKG/resharing outputs.
+    ///
+    /// # Parameters
+    /// - `committee_size`: size of the threshold committee
+    /// - `node_idx`: in 0..committee_size, currently same as KeyId
+    /// - `commitment`: the Feldman Commitment (see output of `ShoupVess::encrypted_shares()` and
+    ///   `FeldmanVss::share()`)
+    /// - `key_share`: the decrypted secret share from `ShoupVess::decrypt_share()`
+    pub fn from_dkg(
+        committee_size: usize,
+        node_idx: usize,
+        commitment: &<Vss as VerifiableSecretSharing>::Commitment,
+        key_share: <Vss as VerifiableSecretSharing>::SecretShare,
+    ) -> anyhow::Result<Self> {
+        // note: all .into() are made available via derive_more::From on those structs
+        let pk: PublicKey = commitment
+            .first()
+            .ok_or_else(|| anyhow!("feldman commitment can't be empty"))?
+            .into_group()
+            .into();
+
+        let combkey: CombKey = (0..committee_size)
+            .into_par_iter()
+            .map(|idx| Vss::derive_public_share_unchecked(idx, commitment))
+            .collect::<Vec<_>>()
+            .into();
+
+        let prikey: KeyShare = (key_share, node_idx as u32).into();
+
+        Ok(Self::new(pk, combkey, prikey))
     }
 
     pub fn pubkey(&self) -> &PublicKey {


### PR DESCRIPTION
Address the missing TODO in #417 

### This PR:

add the missing conversion after VESS is done at the end of the DKG procedure into the DecryptionKey required for the threshold scheme.