### PR TITLE
Use externally provided block numbers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11251,6 +11251,7 @@ version = "0.1.0"
 dependencies = [
  "alloy 1.0.24",
  "async-trait",
+ "blake3",
  "bytes 1.10.1",
  "cliquenet",
  "committable",
@@ -11258,6 +11259,7 @@ dependencies = [
  "futures",
  "metrics",
  "multisig",
+ "parking_lot",
  "portpicker",
  "rand 0.9.2",
  "sailfish",

--- a/sailfish-consensus/src/lib.rs
+++ b/sailfish-consensus/src/lib.rs
@@ -157,7 +157,7 @@ where
             keypair,
             state: State::Startup,
             clock: ConsensusTime(Default::default()),
-            nodes: NodeInfo::new(&committee),
+            nodes: NodeInfo::new(&committee, committee.quorum_size()),
             dag: Dag::new(committee.size()),
             round: RoundNumber::genesis(),
             committed_round: RoundNumber::genesis(),

--- a/sailfish-types/src/nodeinfo.rs
+++ b/sailfish-types/src/nodeinfo.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use multisig::{Committee, PublicKey};
 
 #[derive(Debug)]
@@ -7,10 +9,10 @@ pub struct NodeInfo<T> {
 }
 
 impl<T: Default + PartialOrd> NodeInfo<T> {
-    pub fn new(c: &Committee) -> Self {
+    pub fn new(c: &Committee, q: NonZeroUsize) -> Self {
         Self {
             nodes: c.parties().map(|k| (*k, T::default())).collect(),
-            quorum: c.quorum_size().get(),
+            quorum: q.get(),
         }
     }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 [dependencies]
 alloy = { workspace = true }
 async-trait = { workspace = true }
+blake3 = { workspace = true }
 bytes = { workspace = true }
 cliquenet = { path = "../cliquenet", features = ["turmoil"] }
 committable = { workspace = true }
@@ -15,6 +16,7 @@ crossbeam-queue = { workspace = true }
 futures = { workspace = true }
 metrics = { path = "../metrics" }
 multisig = { path = "../multisig" }
+parking_lot = { workspace = true }
 portpicker = { workspace = true }
 rand = { workspace = true }
 sailfish = { path = "../sailfish", features = ["test"] }

--- a/tests/src/tests/timeboost.rs
+++ b/tests/src/tests/timeboost.rs
@@ -118,6 +118,7 @@ where
             .sign_keypair(kpair)
             .dh_keypair(xpair)
             .address(pa)
+            .recover(recover_index.map(|r| r == i).unwrap_or(false))
             .committee(produce_committee.clone())
             .build();
         enc_keys.push(enc_key);

--- a/timeboost-builder/src/submit.rs
+++ b/timeboost-builder/src/submit.rs
@@ -241,9 +241,9 @@ mod tests {
 
     impl BlockGen {
         fn next(&mut self) -> CertifiedBlock<Validated> {
-            let b = Block::new(self.r.num(), Bytes::new());
+            let b = Block::new(self.i, self.r.num(), Bytes::new());
             let i = BlockInfo::new(self.i, self.r, b.hash());
-            self.i = self.i + 1;
+            self.i += 1;
             self.r.set_num(self.r.num() + 1);
             let mut a = VoteAccumulator::new(self.c.clone());
             for k in &self.k {

--- a/timeboost-types/src/block.rs
+++ b/timeboost-types/src/block.rs
@@ -241,7 +241,9 @@ impl CertifiedBlock<Unchecked> {
     pub fn validated(self, c: &Committee) -> Option<CertifiedBlock<Validated>> {
         if self.data.round == self.cert.data().round.num()
             && self.data.hash() == self.cert.data().hash
-            && self.cert.is_valid_par(c)
+            && self
+                .cert
+                .is_valid_with_threshold_par(c, c.one_honest_threshold())
         {
             Some(CertifiedBlock {
                 data: self.data,

--- a/timeboost-types/src/block.rs
+++ b/timeboost-types/src/block.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 use std::{
     marker::PhantomData,
-    ops::{Add, Deref, Sub},
+    ops::{Add, AddAssign, Deref, Sub},
 };
 
 use alloy::primitives::B256;
@@ -11,11 +11,10 @@ use multisig::{Certificate, Committee, CommitteeId, Unchecked, Validated};
 use sailfish_types::{Round, RoundNumber};
 use serde::{Deserialize, Serialize};
 
-/// The genesis timeboost block number.
-pub const GENESIS_BLOCK: BlockNumber = BlockNumber::new(0);
-
 /// A timeboost block number.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
 pub struct BlockNumber(u64);
 
 impl BlockNumber {
@@ -25,20 +24,6 @@ impl BlockNumber {
 
     pub fn u64(&self) -> u64 {
         self.0
-    }
-
-    pub fn genesis() -> Self {
-        GENESIS_BLOCK
-    }
-
-    pub fn is_genesis(self) -> bool {
-        self == GENESIS_BLOCK
-    }
-}
-
-impl Default for BlockNumber {
-    fn default() -> Self {
-        GENESIS_BLOCK
     }
 }
 
@@ -59,6 +44,12 @@ impl Add<u64> for BlockNumber {
 
     fn add(self, rhs: u64) -> Self::Output {
         Self(self.0 + rhs)
+    }
+}
+
+impl AddAssign<u64> for BlockNumber {
+    fn add_assign(&mut self, rhs: u64) {
+        self.0 += rhs
     }
 }
 
@@ -94,19 +85,25 @@ impl fmt::Display for BlockNumber {
 #[derive(
     Debug, Default, Clone, Copy, Serialize, Deserialize, Ord, PartialOrd, PartialEq, Eq, Hash,
 )]
-pub struct BlockHash(B256);
+pub struct BlockHash([u8; 32]);
 
 impl From<[u8; 32]> for BlockHash {
     fn from(bytes: [u8; 32]) -> Self {
-        Self(B256::from(bytes))
+        Self(bytes)
     }
 }
 
 impl Deref for BlockHash {
-    type Target = B256;
+    type Target = [u8; 32];
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl fmt::Display for BlockHash {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        B256::from(self.0).fmt(f)
     }
 }
 
@@ -120,19 +117,26 @@ impl Committable for BlockHash {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Block {
+    number: BlockNumber,
     round: RoundNumber,
     payload: Bytes,
 }
 
 impl Block {
-    pub fn new<N>(r: N, p: Bytes) -> Self
+    pub fn new<B, N>(n: B, r: N, p: Bytes) -> Self
     where
+        B: Into<BlockNumber>,
         N: Into<RoundNumber>,
     {
         Self {
+            number: n.into(),
             round: r.into(),
             payload: p,
         }
+    }
+
+    pub fn num(&self) -> BlockNumber {
+        self.number
     }
 
     pub fn round(&self) -> RoundNumber {

--- a/timeboost/src/api/internal.rs
+++ b/timeboost/src/api/internal.rs
@@ -40,7 +40,7 @@ struct InternalApiService {
 impl InternalApi for InternalApiService {
     async fn submit_block(&self, r: Request<proto::block::Block>) -> Result<Response<()>, Status> {
         let p = r.into_inner();
-        let b = Block::new(p.round, p.payload);
+        let b = Block::new(p.number, p.round, p.payload);
         if let Err(err) = self.block_handler.enqueue(b).await {
             let _: CertifierDown = err;
             return Err(Status::internal("timeboost is shutting down"));


### PR DESCRIPTION
The current way to have separate block number counters in nodes can not provide consistent block numbers. If a counter misses just a single increment, the node is permanently out of step with the others. We could potentially do away with block numbers altogether and just deliver certified blocks in the order they are given to us, however this complicates evidence handling, catch-up and GC in certifiers.

The approach taken here is to require block numbers as input, i.e. as part of the block protobuf file. The block provider needs to ensure that block numbers are consistent, consecutive and strictly monotonically increasing.

One difficulty is that with external block numbers we do not have a genesis number where we can require no evidence of a previous block. The way this is resolved here is that every node is allowed to send one message without evidence, but all subsequent messages are required to contain evidence of the previous block certificate. This can only work if at least t+1 certifiers start with the same block number, otherwise they can not form a certificate. When starting initially 2t+1 timeboost nodes have to be up to create consensus on candidate lists and eventually producing an inclusion list and a block and their certifier components should receive those in order. If individual certifiers recover from a crash they will wait for evidence before sending their first message.

Depends on: https://github.com/EspressoSystems/timeboost-proto/pull/6