### PR TITLE
Less noisy build.rs and selective formatting.

### DIFF
--- a/justfile
+++ b/justfile
@@ -36,8 +36,8 @@ check-individually:
     cargo check -p $pkg || exit 1; \
   done
 
-fmt:
-  cargo +nightly fmt --all
+fmt *ARGS='--all':
+  cargo +nightly fmt {{ARGS}}
 
 fmt_check:
   cargo +nightly fmt --check


### PR DESCRIPTION
Only formats the generated bindings and not the whole workspace. Also removes warnings which are merely informal messages.
