### PR TITLE
Use network name in Noise prologue.

### DIFF
--- a/cliquenet/src/net.rs
+++ b/cliquenet/src/net.rs
@@ -872,6 +872,8 @@ where
         let h = Builder::new(NOISE_PARAMS.parse().expect("valid noise params"))
             .local_private_key(&self.keypair.secret_key().as_bytes())
             .expect("valid private key")
+            .prologue(self.name.as_bytes())
+            .expect("1st time we set the prologue")
             .build_responder()
             .expect("valid noise params yield valid handshake state");
         self.handshake_tasks.spawn(async move {
@@ -967,6 +969,8 @@ async fn connect<T: tcp::Stream + Unpin>(
             .expect("valid private key")
             .remote_public_key(to.1.as_slice())
             .expect("valid remote pub key")
+            .prologue(name.as_bytes())
+            .expect("1st time we set the prologue")
             .build_initiator()
             .expect("valid noise params yield valid handshake state")
     };

--- a/cliquenet/tests/frame-handling.rs
+++ b/cliquenet/tests/frame-handling.rs
@@ -31,7 +31,7 @@ async fn multiple_frames() {
 
     let mut net_a = Overlay::new(
         Network::create(
-            "f1",
+            "frames",
             all_parties[0].2,
             party_a_sign.public_key(),
             party_a_dh,
@@ -43,7 +43,7 @@ async fn multiple_frames() {
     );
     let mut net_b = Overlay::new(
         Network::create(
-            "f2",
+            "frames",
             all_parties[1].2,
             party_b_sign.public_key(),
             party_b_dh,

--- a/tests/src/tests/rbc.rs
+++ b/tests/src/tests/rbc.rs
@@ -60,7 +60,7 @@ fn mk_host<A, const N: usize>(
         let p = peers.clone();
         async move {
             let comm = Network::create_turmoil(
-                "test",
+                "rbc",
                 a,
                 k.public_key(),
                 x.clone(),
@@ -114,7 +114,7 @@ fn small_committee() {
 
     sim.client("C", async move {
         let addr = (UNSPECIFIED, ports[2]);
-        let comm = Network::create_turmoil("C", addr, k.public_key(), x, peers, NetworkMetrics::default()).await?;
+        let comm = Network::create_turmoil("rbc", addr, k.public_key(), x, peers, NetworkMetrics::default()).await?;
         let cfg = RbcConfig::new(k.clone(), c.id(), c.clone()).recover(false);
         let rbc = Rbc::new(10, Overlay::new(comm), cfg);
         let cons = Consensus::new(k, c, EmptyBlocks);
@@ -172,7 +172,7 @@ fn medium_committee() {
 
     sim.client("E", async move {
         let addr = (UNSPECIFIED, ports[4]);
-        let comm = Network::create_turmoil("E", addr, k.public_key(), x, peers, NetworkMetrics::default()).await?;
+        let comm = Network::create_turmoil("rbc", addr, k.public_key(), x, peers, NetworkMetrics::default()).await?;
         let cfg = RbcConfig::new(k.clone(), c.id(), c.clone()).recover(false);
         let rbc = Rbc::new(10, Overlay::new(comm), cfg);
         let cons = Consensus::new(k, c, EmptyBlocks);
@@ -229,7 +229,7 @@ fn medium_committee_partition_network() {
 
     sim.client("E", async move {
         let addr = (UNSPECIFIED, ports[4]);
-        let comm = Network::create_turmoil("E", addr, k.public_key(), x, peers, NetworkMetrics::default()).await?;
+        let comm = Network::create_turmoil("rbc", addr, k.public_key(), x, peers, NetworkMetrics::default()).await?;
         let cfg = RbcConfig::new(k.clone(), c.id(), c.clone()).recover(false);
         let rbc = Rbc::new(10, Overlay::new(comm), cfg);
         let cons = Consensus::new(k, c, EmptyBlocks);


### PR DESCRIPTION
To avoid accidentally connecting peers of different networks we now include the network name (e.g. "sailfish") in the Noise prologue. The handshake will fail if differently named network peers try to connect.