### PR TITLE
Some updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11836,7 +11836,6 @@ dependencies = [
  "serde",
  "thiserror 2.0.16",
  "timeboost-crypto",
- "timeboost-types",
  "tokio",
  "toml 0.9.5",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,25 +181,25 @@ dependencies = [
 
 [[package]]
 name = "alloy"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ab534134bdf789ad5df813bd3e9fe4aec02e204d5c5b9d3be6659d8a499a3a"
+checksum = "754e8b511978ec78b3bf71140d2692fa8b67a09e44a9742487ab21dec616f953"
 dependencies = [
- "alloy-consensus 1.0.26",
- "alloy-contract 1.0.26",
+ "alloy-consensus 1.0.29",
+ "alloy-contract 1.0.29",
  "alloy-core 1.3.1",
- "alloy-eips 1.0.26",
- "alloy-genesis 1.0.26",
- "alloy-network 1.0.26",
- "alloy-node-bindings 1.0.26",
- "alloy-provider 1.0.26",
- "alloy-rpc-client 1.0.26",
- "alloy-rpc-types 1.0.26",
- "alloy-serde 1.0.26",
- "alloy-signer 1.0.26",
- "alloy-signer-local 1.0.26",
- "alloy-transport 1.0.26",
- "alloy-transport-http 1.0.26",
+ "alloy-eips 1.0.29",
+ "alloy-genesis 1.0.29",
+ "alloy-network 1.0.29",
+ "alloy-node-bindings 1.0.29",
+ "alloy-provider 1.0.29",
+ "alloy-rpc-client 1.0.29",
+ "alloy-rpc-types 1.0.29",
+ "alloy-serde 1.0.29",
+ "alloy-signer 1.0.29",
+ "alloy-signer-local 1.0.29",
+ "alloy-transport 1.0.29",
+ "alloy-transport-http 1.0.29",
  "alloy-trie 0.9.1",
 ]
 
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bf8bac84bad62b19c047ceb71af26052155b924800d1f2eb7da99022799878"
+checksum = "1816584b0c17e3ab5781d7044b07d5b884cf8fe005811b4ae2cded266e0e8c87"
 dependencies = [
- "alloy-eips 1.0.26",
+ "alloy-eips 1.0.29",
  "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-serde 1.0.26",
+ "alloy-serde 1.0.29",
  "alloy-trie 0.9.1",
  "alloy-tx-macros",
  "arbitrary",
@@ -301,15 +301,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a407a490f71974184069adabd8e7b614c5306410356d53fd6d2ab3f01b5c1e7"
+checksum = "dbb74c249b00a0e5005efc2aa3ef48c805b278cad848b544d5f53cb266f45976"
 dependencies = [
- "alloy-consensus 1.0.26",
- "alloy-eips 1.0.26",
+ "alloy-consensus 1.0.29",
+ "alloy-eips 1.0.29",
  "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-serde 1.0.26",
+ "alloy-serde 1.0.29",
  "arbitrary",
  "serde",
 ]
@@ -338,20 +338,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014ae52397b891114733f043ee49ad88c2eca03902e82e11b35ae2e559848c36"
+checksum = "b5cabcc7fdf60c92df94889d6e1b73814ecf47e99a6554f6dd7f75b45aa9d7fa"
 dependencies = [
- "alloy-consensus 1.0.26",
+ "alloy-consensus 1.0.29",
  "alloy-dyn-abi 1.3.1",
  "alloy-json-abi 1.3.1",
- "alloy-network 1.0.26",
- "alloy-network-primitives 1.0.26",
+ "alloy-network 1.0.29",
+ "alloy-network-primitives 1.0.29",
  "alloy-primitives 1.3.1",
- "alloy-provider 1.0.26",
- "alloy-rpc-types-eth 1.0.26",
+ "alloy-provider 1.0.29",
+ "alloy-rpc-types-eth 1.0.29",
  "alloy-sol-types 1.3.1",
- "alloy-transport 1.0.26",
+ "alloy-transport 1.0.29",
  "futures",
  "futures-util",
  "serde_json",
@@ -519,23 +519,25 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccab489a99806d6586118b4712506e56c2888cdf4798f29b401511bc3af13475"
+checksum = "82cee87eceefee136d68bba6d7202745c218346f28f0b96ce83b8061c991ddad"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "alloy-eip2930 0.2.1",
  "alloy-eip7702 0.6.1",
  "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-serde 1.0.26",
+ "alloy-serde 1.0.29",
  "arbitrary",
  "auto_impl",
  "c-kzg",
  "derive_more 2.0.1",
  "either",
  "serde",
+ "serde_with",
  "sha2 0.10.9",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -553,13 +555,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e61c935d77b8e95720721267db9e499411e495b11a05a28eb2a09ae350f5a4d"
+checksum = "d3da452bed368030bed0108ad208331f89ae4a7ec75b0c2935d61458a17844bc"
 dependencies = [
- "alloy-eips 1.0.26",
+ "alloy-eips 1.0.29",
  "alloy-primitives 1.3.1",
- "alloy-serde 1.0.26",
+ "alloy-serde 1.0.29",
  "alloy-trie 0.9.1",
  "serde",
  "serde_with",
@@ -631,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a16d4a9a15acf1b139b440357b4a5fb30f4386cbe0ab04385f281bb7db54b0"
+checksum = "eb4dc62df1be5c5f103f66ac8f25bf4d34e7b812e642159918466bb4c0f8e9a9"
 dependencies = [
  "alloy-primitives 1.3.1",
  "alloy-sol-types 1.3.1",
@@ -672,20 +674,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9891e40200f0819d44fd657579ea69d11097097e3ffe5a6422ffe8067763a3"
+checksum = "54e07a4331293a40c1a2fff58739c6da826cd86e3e76cd339af5d99b5e085344"
 dependencies = [
- "alloy-consensus 1.0.26",
- "alloy-consensus-any 1.0.26",
- "alloy-eips 1.0.26",
- "alloy-json-rpc 1.0.26",
- "alloy-network-primitives 1.0.26",
+ "alloy-consensus 1.0.29",
+ "alloy-consensus-any 1.0.29",
+ "alloy-eips 1.0.29",
+ "alloy-json-rpc 1.0.29",
+ "alloy-network-primitives 1.0.29",
  "alloy-primitives 1.3.1",
- "alloy-rpc-types-any 1.0.26",
- "alloy-rpc-types-eth 1.0.26",
- "alloy-serde 1.0.26",
- "alloy-signer 1.0.26",
+ "alloy-rpc-types-any 1.0.29",
+ "alloy-rpc-types-eth 1.0.29",
+ "alloy-serde 1.0.29",
+ "alloy-signer 1.0.29",
  "alloy-sol-types 1.3.1",
  "async-trait",
  "auto_impl",
@@ -711,14 +713,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d090a0ca79509160da70edddf7f7144a1eab1f45c2c9bf53695b6971b6ff890"
+checksum = "237f507e38aac68d95389fbfba451a8d18cbdb51c971bc78f643de54bb15e395"
 dependencies = [
- "alloy-consensus 1.0.26",
- "alloy-eips 1.0.26",
+ "alloy-consensus 1.0.29",
+ "alloy-eips 1.0.29",
  "alloy-primitives 1.3.1",
- "alloy-serde 1.0.26",
+ "alloy-serde 1.0.29",
  "serde",
 ]
 
@@ -745,16 +747,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4941827046d0a4fe0c46c8cb6f8ab5d5ef6519f1b8dae26cf76d6ebb1b65b310"
+checksum = "efb6429689d9b36eb8726d270dcd16f0a564355202a581f535f027eb638a3d66"
 dependencies = [
- "alloy-genesis 1.0.26",
+ "alloy-genesis 1.0.29",
  "alloy-hardforks 0.2.13",
- "alloy-network 1.0.26",
+ "alloy-network 1.0.29",
  "alloy-primitives 1.3.1",
- "alloy-signer 1.0.26",
- "alloy-signer-local 1.0.26",
+ "alloy-signer 1.0.29",
+ "alloy-signer-local 1.0.29",
  "k256",
  "rand 0.8.5",
  "serde_json",
@@ -867,25 +869,25 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618dba67b5b6e5adc10e7e84d60a5038664d1d13d4c5132c89cdc4a2990838b1"
+checksum = "040b10bb781540585e87a1e9f9a0c4f54f49674114f33aa05c9a50cf3c92e26c"
 dependencies = [
  "alloy-chains 0.2.8",
- "alloy-consensus 1.0.26",
- "alloy-eips 1.0.26",
- "alloy-json-rpc 1.0.26",
- "alloy-network 1.0.26",
- "alloy-network-primitives 1.0.26",
- "alloy-node-bindings 1.0.26",
+ "alloy-consensus 1.0.29",
+ "alloy-eips 1.0.29",
+ "alloy-json-rpc 1.0.29",
+ "alloy-network 1.0.29",
+ "alloy-network-primitives 1.0.29",
+ "alloy-node-bindings 1.0.29",
  "alloy-primitives 1.3.1",
- "alloy-rpc-client 1.0.26",
- "alloy-rpc-types-anvil 1.0.26",
- "alloy-rpc-types-eth 1.0.26",
- "alloy-signer 1.0.26",
+ "alloy-rpc-client 1.0.29",
+ "alloy-rpc-types-anvil 1.0.29",
+ "alloy-rpc-types-eth 1.0.29",
+ "alloy-signer 1.0.29",
  "alloy-sol-types 1.3.1",
- "alloy-transport 1.0.26",
- "alloy-transport-http 1.0.26",
+ "alloy-transport 1.0.29",
+ "alloy-transport-http 1.0.29",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -977,14 +979,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec13fd2abac96221eae1c92caadb72d45b3a27595ee7660399fb0a8e2d77fda5"
+checksum = "c353b166a2cfb39167ead4f8ec335acdb439ad2a436245bccc218022fe28ca65"
 dependencies = [
- "alloy-json-rpc 1.0.26",
+ "alloy-json-rpc 1.0.29",
  "alloy-primitives 1.3.1",
- "alloy-transport 1.0.26",
- "alloy-transport-http 1.0.26",
+ "alloy-transport 1.0.29",
+ "alloy-transport-http 1.0.29",
  "futures",
  "pin-project",
  "reqwest",
@@ -1012,14 +1014,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed01e563a93660b9961a7d142c66737d20acd8253d4308d7e13fef37153aab27"
+checksum = "2791cc56e1e5e7a774b172e9a926e0a8f1b0bdc25cc4d486f9672f725be31123"
 dependencies = [
  "alloy-primitives 1.3.1",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.26",
- "alloy-serde 1.0.26",
+ "alloy-rpc-types-eth 1.0.29",
+ "alloy-serde 1.0.29",
  "serde",
 ]
 
@@ -1037,13 +1039,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5dbd37963646495e32a826775447106bc2f913006eb956f70fadc23c615dece"
+checksum = "3936b18dc0ad4f6b1f3f319e518e53d94512b8fcec433b3078654c8c889c2425"
 dependencies = [
  "alloy-primitives 1.3.1",
- "alloy-rpc-types-eth 1.0.26",
- "alloy-serde 1.0.26",
+ "alloy-rpc-types-eth 1.0.29",
+ "alloy-serde 1.0.29",
  "serde",
 ]
 
@@ -1060,26 +1062,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da3ad7007cf1464cdea925cd2487a912456995272183e4fc1773858275713fd"
+checksum = "9f81c39d47eac1904e378a8079e2903bc1ddb3d9e73d5461c0db6c215d9d7ec1"
 dependencies = [
- "alloy-consensus-any 1.0.26",
- "alloy-rpc-types-eth 1.0.26",
- "alloy-serde 1.0.26",
+ "alloy-consensus-any 1.0.29",
+ "alloy-rpc-types-eth 1.0.29",
+ "alloy-serde 1.0.29",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d60a880fed667371b5cd23c49274202afa7f04a1b03ce9de72292a29621f2ae3"
+checksum = "9718f018a4e3d15e136d63ca6a646e0271a3098c5a8bf6759a0cb71d8b2ba7ce"
 dependencies = [
- "alloy-consensus 1.0.26",
- "alloy-eips 1.0.26",
+ "alloy-consensus 1.0.29",
+ "alloy-eips 1.0.29",
  "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-serde 1.0.26",
+ "alloy-serde 1.0.29",
  "arbitrary",
  "derive_more 2.0.1",
  "rand 0.8.5",
@@ -1101,7 +1103,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 0.13.0",
  "alloy-sol-types 0.8.25",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -1109,20 +1111,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd99ffe19288d462eed07f73a8960869c692b172ee74a6a57b53052cf798979"
+checksum = "b1a21e2b9b9da3f21351b9a34f820aa0580d5709aa821e8bfd26411649750f34"
 dependencies = [
- "alloy-consensus 1.0.26",
- "alloy-consensus-any 1.0.26",
- "alloy-eips 1.0.26",
- "alloy-network-primitives 1.0.26",
+ "alloy-consensus 1.0.29",
+ "alloy-consensus-any 1.0.29",
+ "alloy-eips 1.0.29",
+ "alloy-network-primitives 1.0.29",
  "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-serde 1.0.26",
+ "alloy-serde 1.0.29",
  "alloy-sol-types 1.3.1",
  "arbitrary",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1142,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93cb27da33b618fe729ab6b053275e754fbb31782caa83dfd11219d7e2e8ebf1"
+checksum = "432bbb99cfa037b8a50deb4128da7bfc3d094a6b2ac6e9220bf89b1408c5e269"
 dependencies = [
  "alloy-primitives 1.3.1",
  "arbitrary",
@@ -1169,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3fb8c9d8aa1beac2e922b5d4370217cc9dcd748af57e9ecfea5e221a2c3cb9"
+checksum = "e4b97ec9efdf375ada378d03404e8515c4e04694481fbb8c9e636313130fd734"
 dependencies = [
  "alloy-primitives 1.3.1",
  "async-trait",
@@ -1220,14 +1222,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b70d99871b4511b10d021ef945acf4d5e9dcf6afdae5797df720b80e4fddf0"
+checksum = "63e6e5b61817be1dfca20a7738eb09c9a85c333ef34ed0ae6946bdff077245fa"
 dependencies = [
- "alloy-consensus 1.0.26",
- "alloy-network 1.0.26",
+ "alloy-consensus 1.0.29",
+ "alloy-network 1.0.29",
  "alloy-primitives 1.3.1",
- "alloy-signer 1.0.26",
+ "alloy-signer 1.0.29",
  "async-trait",
  "coins-bip32",
  "coins-bip39",
@@ -1408,11 +1410,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11be38024ae4674455a3e80fcfd5956ee617710b21b4fef0add8969dda071a07"
+checksum = "7c48ab8f6beec1d32754043ad3b4da077e80ba78fd762acfb16a8460336887a2"
 dependencies = [
- "alloy-json-rpc 1.0.26",
+ "alloy-json-rpc 1.0.29",
  "alloy-primitives 1.3.1",
  "auto_impl",
  "base64 0.22.1",
@@ -1447,12 +1449,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbacef94bf7517561b8468f003985e439b6a39305aff07329333770a428b2fc1"
+checksum = "27e6b0b1188a87bbfbb5adf5ad7dcd0744e03fe3184e8ef683ec29846d884bee"
 dependencies = [
- "alloy-json-rpc 1.0.26",
- "alloy-transport 1.0.26",
+ "alloy-json-rpc 1.0.29",
+ "alloy-transport 1.0.29",
  "reqwest",
  "serde_json",
  "tower 0.5.2",
@@ -1516,12 +1518,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20401796a1205414da724f63cc4e7713d674576ee923469f07c29ccc6d382ba2"
+checksum = "81901009f4ebb0fa0d2b37328ddec6ca420ca06289dddd714bc7ee9be3c86d4b"
 dependencies = [
  "alloy-primitives 1.3.1",
- "darling 0.20.11",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -2074,7 +2076,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.9",
  "tracing",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
  "ureq",
 ]
 
@@ -3124,7 +3126,7 @@ dependencies = [
  "rkyv",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
@@ -3140,7 +3142,7 @@ dependencies = [
  "rand 0.8.5",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
@@ -3153,7 +3155,7 @@ dependencies = [
  "jf-signature",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
@@ -3290,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -3300,9 +3302,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3312,9 +3314,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3533,7 +3535,7 @@ dependencies = [
  "tonic 0.12.3",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
@@ -4008,6 +4010,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "serde",
  "strsim",
  "syn 2.0.106",
 ]
@@ -5538,7 +5541,7 @@ dependencies = [
  "time 0.3.41",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
  "url",
  "vbs",
  "workspace-hack",
@@ -5670,7 +5673,7 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
  "workspace-hack",
 ]
 
@@ -5732,7 +5735,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "tracing",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
  "trait-variant",
  "url",
  "vbs",
@@ -6123,7 +6126,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite 0.2.16",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7685,11 +7688,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -8100,12 +8103,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8391,12 +8393,6 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p3-maybe-rayon"
@@ -9013,7 +9009,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax 0.8.6",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -9056,8 +9052,8 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -9079,7 +9075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -9092,7 +9088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -9588,17 +9584,8 @@ checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.10",
- "regex-syntax 0.8.6",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -9609,14 +9596,8 @@ checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.6",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -9801,7 +9782,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite 0.27.0",
  "tracing",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
  "url",
 ]
 
@@ -10812,7 +10793,7 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5fd9e3263fc19d73abd5107dbd4d43e37949212d2b15d4d334ee5db53022b8"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -11502,7 +11483,7 @@ dependencies = [
 name = "tests"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.26",
+ "alloy 1.0.29",
  "anyhow",
  "async-trait",
  "blake3",
@@ -11659,7 +11640,7 @@ dependencies = [
  "tracing-distributed",
  "tracing-futures",
  "tracing-log",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
  "url",
  "vbs",
 ]
@@ -11755,7 +11736,7 @@ dependencies = [
 name = "timeboost"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.26",
+ "alloy 1.0.29",
  "anyhow",
  "ark-std 0.5.0",
  "axum 0.8.4",
@@ -11816,14 +11797,14 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
 name = "timeboost-config"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.26",
+ "alloy 1.0.29",
  "anyhow",
  "ark-std 0.5.0",
  "bon",
@@ -11846,7 +11827,7 @@ dependencies = [
 name = "timeboost-contract"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.26",
+ "alloy 1.0.29",
  "anyhow",
  "bincode 2.0.1",
  "clap",
@@ -11910,7 +11891,7 @@ dependencies = [
 name = "timeboost-sequencer"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.26",
+ "alloy 1.0.29",
  "ark-std 0.5.0",
  "arrayvec",
  "bimap",
@@ -11942,7 +11923,7 @@ name = "timeboost-types"
 version = "0.1.0"
 dependencies = [
  "adapters",
- "alloy 1.0.26",
+ "alloy 1.0.29",
  "alloy-rlp",
  "anyhow",
  "arbitrary",
@@ -11974,7 +11955,7 @@ dependencies = [
 name = "timeboost-utils"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.26",
+ "alloy 1.0.29",
  "anyhow",
  "arbitrary",
  "ark-std 0.5.0",
@@ -11993,7 +11974,7 @@ dependencies = [
  "timeboost-types",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
@@ -12467,7 +12448,7 @@ dependencies = [
  "itertools 0.9.0",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
@@ -12514,14 +12495,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -12540,7 +12521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
 dependencies = [
  "tracing-core",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
  "tracing-test-macro",
 ]
 
@@ -13215,7 +13196,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -13638,8 +13619,8 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "regex",
- "regex-automata 0.4.10",
- "regex-syntax 0.8.6",
+ "regex-automata",
+ "regex-syntax",
  "rustls-pki-types",
  "sha2 0.9.9",
  "sha3",
@@ -13655,7 +13636,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
  "tungstenite 0.13.0",
  "uint",
  "url",
@@ -13750,7 +13731,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 name = "yapper"
 version = "0.1.0"
 dependencies = [
- "alloy 1.0.26",
+ "alloy 1.0.29",
  "anyhow",
  "bincode 2.0.1",
  "bon",

--- a/timeboost-config/Cargo.toml
+++ b/timeboost-config/Cargo.toml
@@ -18,7 +18,6 @@ secp256k1 = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 timeboost-crypto = { path = "../timeboost-crypto" }
-timeboost-types = { path = "../timeboost-types" }
 tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }

--- a/timeboost-config/src/chain.rs
+++ b/timeboost-config/src/chain.rs
@@ -1,9 +1,7 @@
+use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::Address;
-use alloy::providers::ProviderBuilder;
-use alloy::{eips::BlockNumberOrTag, network::EthereumWallet};
 use bon::Builder;
 use serde::{Deserialize, Serialize};
-use timeboost_types::{HttpProvider, HttpProviderWithWallet};
 use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Builder)]
@@ -19,16 +17,4 @@ pub struct ParentChain {
     pub ibox_contract: Address,
     pub block_tag: BlockNumberOrTag,
     pub key_manager_contract: Address,
-}
-
-impl ParentChain {
-    pub fn provider(&self) -> HttpProvider {
-        ProviderBuilder::new().connect_http(self.rpc_url.clone())
-    }
-
-    pub fn provider_with_wallet(&self, wallet: EthereumWallet) -> HttpProviderWithWallet {
-        ProviderBuilder::new()
-            .wallet(wallet)
-            .connect_http(self.rpc_url.clone())
-    }
 }

--- a/timeboost/src/binaries/sailfish.rs
+++ b/timeboost/src/binaries/sailfish.rs
@@ -1,7 +1,7 @@
 use std::{iter::repeat_with, path::PathBuf, sync::Arc, time::Duration};
 
 use ::metrics::prometheus::PrometheusMetrics;
-use alloy::providers::Provider;
+use alloy::providers::{Provider, ProviderBuilder};
 use anyhow::{Context, Result};
 use cliquenet::{Network, NetworkMetrics, Overlay};
 use committable::{Commitment, Committable, RawCommitmentBuilder};
@@ -91,7 +91,7 @@ async fn main() -> Result<()> {
     let dh_keypair = x25519::Keypair::from(config.keys.dh.secret.clone());
 
     // syncing with contract to get peers keys and network addresses
-    let provider = config.chain.parent.provider();
+    let provider = ProviderBuilder::new().connect_http(config.chain.parent.rpc_url);
     assert_eq!(
         provider.get_chain_id().await?,
         config.chain.parent.id,

--- a/timeboost/src/binaries/timeboost.rs
+++ b/timeboost/src/binaries/timeboost.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use alloy::providers::Provider;
+use alloy::providers::{Provider, ProviderBuilder};
 use anyhow::{Context, Result, bail};
 use cliquenet::AddressableCommittee;
 use multisig::CommitteeId;
@@ -108,7 +108,7 @@ async fn main() -> Result<()> {
     let dh_keypair = x25519::Keypair::from(node_config.keys.dh.secret.clone());
 
     // syncing with contract to get peers keys and network addresses
-    let provider = node_config.chain.parent.provider();
+    let provider = ProviderBuilder::new().connect_http(node_config.chain.parent.rpc_url.clone());
     assert_eq!(
         provider.get_chain_id().await?,
         node_config.chain.parent.id,


### PR DESCRIPTION
Follow-up to https://github.com/EspressoSystems/timeboost/pull/481#discussion_r2317470048. Also updates some dependencies.

For the time being we can not update espresso-types because of https://github.com/EspressoSystems/espresso-network/pull/3553, which changes the `NsProof` encoding to use base64. Once decaf has been updated CI will fail because of `submit_random_block`.