### PR TITLE
Ensure inclusion list round is monotonic.

### DIFF
--- a/timeboost-sequencer/src/include.rs
+++ b/timeboost-sequencer/src/include.rs
@@ -63,9 +63,7 @@ impl Includer {
             self.clear_cache()
         }
 
-        debug_assert!(lists.len() >= self.committee.quorum_size().get());
-
-        self.round = round;
+        self.round = max(self.round, round);
 
         while self.cache.len() > CACHE_SIZE {
             self.cache.pop_first();


### PR DESCRIPTION
After candidate lists of round `r` formed an inclusion list, a delayed candidate list for `r - 1` may be delivered by Sailfish. The debug assertion --- while mostly true --- is not correct, because the delayed candidate list might be the only delivery. This commit therefore removes the assertion but also ensures that the round counter is monotonic.