### PR TITLE
chore: use DKG_AAD constant in DkgAccumulator::try_add

### DIFF
--- a/timeboost-types/src/decryption.rs
+++ b/timeboost-types/src/decryption.rs
@@ -403,7 +403,6 @@ impl DkgAccumulator {
             return Ok(());
         }
 
-        let aad: &[u8; 3] = b"dkg";
         let vess = Vess::new_fast();
         let store = self.store.clone();
         let mode = self.mode.clone();
@@ -417,7 +416,7 @@ impl DkgAccumulator {
                         store.sorted_keys(),
                         bundle.vess_ct(),
                         bundle.comm(),
-                        aad,
+                        DKG_AAD,
                     )?;
                 }
                 AccumulatorMode::Resharing(combkey) => {
@@ -429,7 +428,7 @@ impl DkgAccumulator {
                         store.sorted_keys(),
                         bundle.vess_ct(),
                         bundle.comm(),
-                        aad,
+                        DKG_AAD,
                         *pub_share,
                     )?;
                 }


### PR DESCRIPTION
Replace the local AAD literal with the file-level DKG_AAD constant in DkgAccumulator::try_add. This ensures a single source of truth for the DKG domain separator and prevents accidental drift from other code paths (encryption/decryption and verification) that already rely on DKG_AAD.