### PR TITLE
Correct cache validity comment in Includer

### DIFF
--- a/timeboost-sequencer/src/include.rs
+++ b/timeboost-sequencer/src/include.rs
@@ -227,7 +227,7 @@ impl Includer {
             .0)
     }
 
-    /// Check if the cache is valid, i.e. ends with at least 8 consecutive rounds.
+    /// Check if the cache is valid, i.e. contains at least 8 recent rounds (not necessarily consecutive).
     fn is_valid_cache(&self) -> bool {
         self.cache.len() >= CACHE_SIZE
     }

--- a/timeboost-sequencer/src/include.rs
+++ b/timeboost-sequencer/src/include.rs
@@ -227,7 +227,8 @@ impl Includer {
             .0)
     }
 
-    /// Check if the cache is valid, i.e. contains at least 8 recent rounds (not necessarily consecutive).
+    /// Check if the cache is valid, i.e. contains at least 8 recent rounds (not necessarily
+    /// consecutive).
     fn is_valid_cache(&self) -> bool {
         self.cache.len() >= CACHE_SIZE
     }


### PR DESCRIPTION
The previous comment claimed the cache “ends with at least 8 consecutive rounds,” but the implementation only checks the number of cached rounds (self.cache.len() >= CACHE_SIZE). Rounds can legitimately be skipped when collecting Deliver actions (only the latest round in a batch is used), and is_unknown only needs a horizon of recent processed rounds, not strict numeric consecutiveness. This change aligns the comment with the actual and intended behavior, preventing confusion and avoiding pressure to implement an unnecessary “consecutive rounds” check.