### PR TITLE
Removes `unsafe_zero_keypair` and others.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8093,6 +8093,7 @@ dependencies = [
  "ed25519-compact",
  "either",
  "minicbor",
+ "rand 0.9.2",
  "rayon",
  "secp256k1 0.31.1",
  "serde",

--- a/multisig/Cargo.toml
+++ b/multisig/Cargo.toml
@@ -18,6 +18,7 @@ constant_time_eq = { workspace = true }
 ed25519-compact = { workspace = true }
 either = { workspace = true }
 minicbor = { workspace = true }
+rand = { workspace = true }
 rayon = { workspace = true }
 secp256k1 = { workspace = true }
 serde = { workspace = true }

--- a/multisig/src/lib.rs
+++ b/multisig/src/lib.rs
@@ -11,8 +11,10 @@ use std::fmt;
 
 use committable::{Commitment, Committable, RawCommitmentBuilder};
 use minicbor::{CborLen, Decode, Encode};
-use secp256k1::rand::Rng;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
+
+pub use rand;
 
 pub use cert::Certificate;
 pub use committee::{Committee, CommitteeId};
@@ -135,19 +137,6 @@ impl Keypair {
         Self {
             sk: SecretKey { key: sk },
             pk: PublicKey { key: pk },
-        }
-    }
-
-    /// Generate keypair from a seed.
-    pub fn from_seed(seed: [u8; 32]) -> Self {
-        loop {
-            if let Ok(sk) = secp256k1::SecretKey::from_byte_array(seed) {
-                let pk = sk.public_key(secp256k1::SECP256K1);
-                return Self {
-                    sk: SecretKey { key: sk },
-                    pk: PublicKey { key: pk },
-                };
-            }
         }
     }
 

--- a/multisig/src/x25519.rs
+++ b/multisig/src/x25519.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::fmt;
 
 use ed25519_compact::x25519;
-use secp256k1::rand::Rng;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 use super::{InvalidKeypair, InvalidPublicKey, InvalidSecretKey};
@@ -42,14 +42,8 @@ impl Keypair {
         Ok(Self { pair })
     }
 
-    // note: `ed25519_compat` crate doesn't offer or re-export anything from `rand`,
-    // thus we use `Rng` re-exported from `secp256k1` instead for convenience
     pub fn generate_with_rng<R: Rng>(rng: &mut R) -> Result<Self, InvalidKeypair> {
         let seed: [u8; 32] = rng.random();
-        Self::from_seed(seed)
-    }
-
-    pub fn from_seed(seed: [u8; 32]) -> Result<Self, InvalidKeypair> {
         let sk = x25519::SecretKey::new(seed);
         let Ok(pk) = sk.recover_public_key() else {
             return Err(InvalidKeypair(()));

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,9 +1,9 @@
 use std::net::{Ipv4Addr, SocketAddr};
 
 use multisig::{Committee, Keypair, PublicKey, x25519};
+use rand::{SeedableRng, rngs::StdRng};
 use sailfish_types::UNKNOWN_COMMITTEE_ID;
 use test_utils::ports::alloc_port;
-use timeboost_utils::{unsafe_zero_dh_keypair, unsafe_zero_keypair};
 
 #[cfg(test)]
 mod tests;
@@ -61,10 +61,16 @@ pub struct Group {
 impl Group {
     pub async fn new(size: usize) -> Self {
         let sign_keypairs = (0..size as u64)
-            .map(unsafe_zero_keypair)
+            .map(|i| {
+                let mut g = StdRng::seed_from_u64(i);
+                Keypair::generate_with_rng(&mut g)
+            })
             .collect::<Vec<_>>();
         let dh_keypairs = (0..size as u64)
-            .map(unsafe_zero_dh_keypair)
+            .map(|i| {
+                let mut g = StdRng::seed_from_u64(i);
+                x25519::Keypair::generate_with_rng(&mut g).unwrap()
+            })
             .collect::<Vec<_>>();
         let mut addrs = vec![];
         let mut pubks = vec![];

--- a/tests/src/tests/consensus/helpers/shaping.rs
+++ b/tests/src/tests/consensus/helpers/shaping.rs
@@ -308,7 +308,8 @@ impl Simulator {
                 for (b, s) in name.as_bytes().iter().zip(seed.iter_mut()) {
                     *s = *b
                 }
-                (name, Keypair::from_seed(seed))
+                let mut g = rand::rngs::StdRng::from_seed(seed);
+                (name, Keypair::generate_with_rng(&mut g))
             })
             .collect();
 

--- a/tests/src/tests/consensus/test_consensus_actions.rs
+++ b/tests/src/tests/consensus/test_consensus_actions.rs
@@ -108,7 +108,7 @@ async fn test_single_node_timeout_cert() {
     let committee = node_handle.committee().clone();
 
     // Setup expectations
-    let expected_round = RoundNumber::new(4);
+    let expected_round = RoundNumber::new(2);
     let timeout = node_handle.expected_timeout(expected_round);
     let no_vote = node_handle.expected_no_vote(expected_round);
 

--- a/tests/src/tests/consensus/test_consensus_fake_network.rs
+++ b/tests/src/tests/consensus/test_consensus_fake_network.rs
@@ -1,9 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use multisig::PublicKey;
+use multisig::{Keypair, PublicKey};
 use sailfish::types::{Evidence, RoundNumber};
 use timeboost_utils::types::logging;
-use timeboost_utils::unsafe_zero_keypair;
 
 use crate::prelude::*;
 use crate::tests::consensus::helpers::node_instrument::TestNodeInstrument;
@@ -163,7 +162,6 @@ async fn test_invalid_vertex_signatures() {
     logging::init_logging();
 
     let num_nodes = 5;
-    let invalid_node_id = num_nodes + 1;
 
     let (nodes, manager) = make_consensus_nodes(num_nodes);
 
@@ -173,7 +171,7 @@ async fn test_invalid_vertex_signatures() {
         move |msg: &Message, _node_handle: &mut TestNodeInstrument| {
             if let Message::Vertex(_e) = msg {
                 // generate keys for invalid node for a node one not in stake table
-                let invalid_kpair = unsafe_zero_keypair(invalid_node_id);
+                let invalid_kpair = Keypair::generate();
                 // modify current network message with this invalid one
                 return vec![manager.create_vertex_proposal_msg(msg.round().num(), &invalid_kpair)];
             }

--- a/tests/src/tests/consensus/test_traffic_patterns.rs
+++ b/tests/src/tests/consensus/test_traffic_patterns.rs
@@ -139,18 +139,18 @@ fn delay_vertices_to_leader() {
             .with(edges("E", all)),
         Rule::new("trigger timeout of leader vertex")
             .precondition(|sim| {
-                sim.round() == Some(1) && sim.leader(1) == Some("E") && sim.leader(2) == Some("B")
+                sim.round() == Some(1) && sim.leader(1) == Some("B") && sim.leader(2) == Some("D")
             })
             .plus(edge("A", "A"))
             .plus(edge("A", "B").delay_fn(|m| if m.is_vertex() { 15 } else { 0 }))
             .plus(edge("A", "C"))
             .plus(edge("A", "D"))
             .plus(edge("A", "E"))
-            .plus(edge("B", "A"))
-            .plus(edge("B", "B").delay_fn(|m| if m.is_vertex() { 15 } else { 0 }))
-            .plus(edge("B", "C"))
-            .plus(edge("B", "D"))
-            .plus(edge("B", "E"))
+            .plus(edge("B", "A").delay(15))
+            .plus(edge("B", "B").delay(15))
+            .plus(edge("B", "C").delay(15))
+            .plus(edge("B", "D").delay(15))
+            .plus(edge("B", "E").delay(15))
             .plus(edge("C", "A"))
             .plus(edge("C", "B").delay_fn(|m| if m.is_vertex() { 15 } else { 0 }))
             .plus(edge("C", "C"))
@@ -161,11 +161,11 @@ fn delay_vertices_to_leader() {
             .plus(edge("D", "C"))
             .plus(edge("D", "D"))
             .plus(edge("D", "E"))
-            .plus(edge("E", "A").delay(15))
-            .plus(edge("E", "B").delay(15))
-            .plus(edge("E", "C").delay(15))
-            .plus(edge("E", "D").delay(15))
-            .plus(edge("E", "E").delay(15)),
+            .plus(edge("E", "A").delay_fn(|m| if m.is_vertex() { 15 } else { 0 }))
+            .plus(edge("E", "B"))
+            .plus(edge("E", "C"))
+            .plus(edge("E", "D"))
+            .plus(edge("E", "E")),
     ]);
     sim.goto(50);
 

--- a/tests/src/tests/network/network_tests.rs
+++ b/tests/src/tests/network/network_tests.rs
@@ -292,7 +292,7 @@ where
                     TestCondition::new(format!("Vertex from {}", k.public_key()), move |msg, _a| {
                         if let Some(Message::Vertex(v)) = msg {
                             let r = *v.data().round().data().num();
-                            if v.data().evidence().is_timeout() && r != 6 {
+                            if v.data().evidence().is_timeout() && r != 5 {
                                 return TestOutcome::Failed(
                                     "We should only timeout when node 4 is leader the first time",
                                 );

--- a/timeboost-utils/src/lib.rs
+++ b/timeboost-utils/src/lib.rs
@@ -6,37 +6,8 @@ pub mod until;
 use std::time::Duration;
 
 use cliquenet::Address;
-use multisig::x25519;
 use tokio::time::sleep;
 use tracing::{error, info};
-
-pub fn unsafe_zero_keypair<N: Into<u64>>(i: N) -> multisig::Keypair {
-    sig_keypair_from_seed_indexed([0u8; 32], i.into())
-}
-
-pub fn unsafe_zero_dh_keypair<N: Into<u64>>(i: N) -> x25519::Keypair {
-    dh_keypair_from_seed_indexed([0u8; 32], i.into())
-}
-
-pub fn sig_keypair_from_seed_indexed(seed: [u8; 32], index: u64) -> multisig::Keypair {
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(&seed);
-    hasher.update(&index.to_le_bytes());
-    let new_seed = *hasher.finalize().as_bytes();
-    multisig::Keypair::from_seed(new_seed)
-}
-
-pub fn dh_keypair_from_seed_indexed(seed: [u8; 32], index: u64) -> x25519::Keypair {
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(&seed);
-    hasher.update(&index.to_le_bytes());
-    let new_seed = *hasher.finalize().as_bytes();
-    x25519::Keypair::from_seed(new_seed).unwrap()
-}
-
-pub fn bs58_encode(b: &[u8]) -> String {
-    bs58::encode(b).into_string()
-}
 
 /// NON PRODUCTION
 /// This function takes the provided host and hits the health endpoint. This to ensure that when


### PR DESCRIPTION
Deterministic keypair generation can be achieved by passing in a suitably prepared `Rng` impl, as is done here for tests.