### PR TITLE
Fix typos in warnings and comments 

### DIFF
--- a/sailfish-types/src/message.rs
+++ b/sailfish-types/src/message.rs
@@ -299,7 +299,7 @@ impl<T: Committable> Message<T, Unchecked> {
 
                 // Validate the timeout certificate signatures:
                 if !crt.is_valid_par(c) {
-                    warn!("invalid timeout certiticate");
+                    warn!("invalid timeout certificate");
                     return None;
                 }
 
@@ -316,7 +316,7 @@ impl<T: Committable> Message<T, Unchecked> {
 
                 // Validate the handover certificate signatures:
                 if !crt.is_valid_par(c) {
-                    warn!("invalid handover certiticate");
+                    warn!("invalid handover certificate");
                     return None;
                 }
 

--- a/timeboost-crypto/src/feldman.rs
+++ b/timeboost-crypto/src/feldman.rs
@@ -147,7 +147,7 @@ impl<C: CurveGroup> FeldmanVss<C> {
         .take(t)
         .collect::<Vec<_>>();
 
-        // infalliable
+        // infallible
         C::msm(commitment, &powers).expect("bases and scalars shouuld have the same length")
     }
 }


### PR DESCRIPTION


Description
- Correct spelling in `timeboost-crypto/src/feldman.rs` comment: “infallible”.
- Normalize warning messages in `sailfish-types/src/message.rs` for timeout and handover certificates.

