### PR TITLE
fix: correct log message for NextCommittee error handling

### DIFF
--- a/timeboost-builder/src/certifier.rs
+++ b/timeboost-builder/src/certifier.rs
@@ -309,7 +309,7 @@ impl Worker {
                         match self.on_next_committee(c).await {
                             Ok(()) => {}
                             Err(CertifierError::End(end)) => return end,
-                            Err(err) => warn!(node = %self.label, %err, "error on use committee")
+                            Err(err) => warn!(node = %self.label, %err, "error on next committee")
                         }
                     Some(Command::UseCommittee(r)) =>
                         match self.on_use_committee(r).await {


### PR DESCRIPTION
Fix incorrect log message in NextCommittee command handler to properly reflect the operation being performed instead of using "use committee" message.