### PR TITLE
Remove `run_dkg_handover_decryption_phase_e2e`.

### DIFF
--- a/timeboost-sequencer/src/decrypt.rs
+++ b/timeboost-sequencer/src/decrypt.rs
@@ -427,15 +427,15 @@ impl Drop for Decrypter {
 enum WorkerState {
     /// Obtains the threshold decryption key from DKG bundles.
     ///
-    /// A node can recover its threshold decryption key in two ways:  
+    /// A node can recover its threshold decryption key in two ways:
     /// 1. **Consensus**: by combining DKG bundles extracted directly from candidate lists produced
     ///    by peers.
     /// 2. **Network**: by receiving and combining an agreed-upon subset of DKG bundles from a
     ///    designated set of peers.
     ///
-    /// For the initial DKG, method (1) is used.  
-    /// For resharing, method (2) is used, with the source peers being the previous committee.  
-    /// When catching up—whether during the initial DKG or after resharing—the node also uses  
+    /// For the initial DKG, method (1) is used.
+    /// For resharing, method (2) is used, with the source peers being the previous committee.
+    /// When catching up—whether during the initial DKG or after resharing—the node also uses
     /// method (2), but obtains the bundles from the current committee.
     DkgPending(HashMap<PublicKey, DkgSubset>),
     /// Active mode with decryption key ready.
@@ -448,7 +448,7 @@ impl Default for WorkerState {
     }
 }
 
-/// A `Worker` handles the production, exchange, and combination of decryption shares  
+/// A `Worker` handles the production, exchange, and combination of decryption shares
 /// in coordination with other peers. See [`Decrypter`] for details.
 #[derive(Builder)]
 struct Worker {
@@ -1546,7 +1546,6 @@ mod tests {
         time::Instant,
     };
     use test_utils::ports::alloc_port;
-    use timeboost_config::DECRYPTER_PORT_OFFSET;
     use timeboost_utils::types::logging;
 
     use cliquenet::AddressableCommittee;
@@ -1573,7 +1572,6 @@ mod tests {
     const TEST_SEQNO: u64 = 10;
     const RETAIN_ROUNDS: usize = 100;
     const COM1: u64 = 1;
-    const COM2: u64 = 2;
 
     // Pre-generated deterministic keys for consistent testing
     // Generated via: `just mkconfig_local 5 --seed 42`
@@ -1585,28 +1583,12 @@ mod tests {
         "6LMMEuoPRCkpDsnxnANCRCBC6JagdCHs2pjNicdmQpQE",
     ];
 
-    const COM2_SIGNATURE_PRIVATE_KEY_STRINGS: [&str; COMMITTEE_SIZE] = [
-        "6YJc9asDJQsFFHHg8iX23oL1sySx2EgTGM8CqDd71WMa",
-        "6NZdk8EGRSVS7sSjcjMiC8vL4KcSY41ELU6HaKyk1Drk",
-        "AMJEYXVhS4FfoqfD6VL5nZTNbzJQdtgdxBcVEAwZnLJ3",
-        "5mLCMSVT4f8HPqCqdKChxugpMcQ3x1C7hwfEnsTApFfp",
-        "4yhZYmNvAouKFpiYomrV9aH8kUZTLRH2hiCZtJzcAASa",
-    ];
-
     const COM1_DH_PRIVATE_KEY_STRINGS: [&str; COMMITTEE_SIZE] = [
         "BB3zUfFQGfw3sL6bpp1JH1HozK6ehEDmRGoiCpQH62rZ",
         "4hjtciEvuoFVT55nAzvdP9E76r18QwntWwFoeginCGnP",
         "Fo2nYV4gE9VfoVW9bSySAJ1ZuKT461x6ovZnr3EecCZg",
         "5KpixkV7czZTDVh7nV7VL1vGk4uf4kjKidDWq34CJx1T",
         "39wAn3bQzpn19oa8CiaNUFd8GekQAJMMuzrbp8Jt3FKz",
-    ];
-
-    const COM2_DH_PRIVATE_KEY_STRINGS: [&str; COMMITTEE_SIZE] = [
-        "Ho9ZZCkP1i6f12fkWGUZucJxX2qbv9L3UbB56sqwjvkw",
-        "F5E9cp5qUe4z2wdaRYvEhFMYXaLy4sEX1rwCWRcTH69i",
-        "5zhwDWJ1ut6q871aHCHmH7QRCHDykXjUSEriGTLkwezL",
-        "2PojAT3g5iqGTrgLhTRKKHqwbeoFhRkzkYLM9AttFoKK",
-        "Bk2wY7o2YE9gpu6jxiRSbWiMU88H8s9D9MQGMaF2LJ7h",
     ];
 
     const COM1_DKG_PRIVATE_KEY_STRINGS: [&str; COMMITTEE_SIZE] = [
@@ -1617,18 +1599,10 @@ mod tests {
         "GFvv2wcQmiGpk5rFp1FGpeUjnVUyZmGM9k8VHb1Jn7EG",
     ];
 
-    const COM2_DKG_PRIVATE_KEY_STRINGS: [&str; COMMITTEE_SIZE] = [
-        "GLNPt6EYeFQbq8cCX5nKMA4LbCKdrUN5o5hmWTPJbkJZ",
-        "2n3Pz5NeUAVu5YaWgXN9CCrS6rC7NZwVZ48AG8m7JRqF",
-        "AGxRDhGvgovb1DZMjL3Y6Q4hF6UUpFCtpPD6sTJd827U",
-        "A3GUHxG3cPKvCch6XowztrHrrvaGS5JH3CuXQKCxQEnv",
-        "216zC1MgfV54cJJtt3AKdjJHhqfgZLZCmEyCkFN1bPoF",
-    ];
-
-    #[test]
     /// Tests the local DKG (Distributed Key Generation) end-to-end flow without networking.
     /// Verifies that committee members can generate threshold decryption keys and perform
     /// threshold encryption/decryption operations.
+    #[test]
     fn test_local_dkg_e2e() {
         logging::init_logging();
         let mut rng = thread_rng();
@@ -1949,9 +1923,9 @@ mod tests {
         );
     }
 
-    #[tokio::test]
     /// Tests integrated DKG to ensure it terminates with consistent public encryption keys
     /// across all committee members in a networked environment.
+    #[tokio::test]
     async fn test_dkg_termination() {
         logging::init_logging();
         let (mut decrypters, setup) = setup(
@@ -1985,172 +1959,20 @@ mod tests {
         }
     }
 
-    #[tokio::test]
     /// Tests the complete DKG and decryption phase end-to-end flow in a networked environment.
     /// Verifies that encrypted transactions can be properly decrypted after DKG completion.
+    #[tokio::test]
     async fn test_dkg_and_decryption_phase_e2e() {
         run_dkg_and_decryption_phase_e2e(false).await;
     }
 
-    #[tokio::test]
     /// Tests the complete DKG and decryption phase end-to-end flow in a networked environment.
     /// Verifies that encrypted transactions can be properly decrypted after DKG completion.
     /// The node that is catching up will not have the dealings locally enqueued but will instead
     /// fetch the dealings from other nodes to obtain the DKG key material.
+    #[tokio::test]
     async fn test_dkg_and_decryption_phase_e2e_with_catchup() {
         run_dkg_and_decryption_phase_e2e(true).await;
-    }
-
-    #[tokio::test]
-    /// Tests the full spectrum of Decrypter states:
-    /// 1. Initial committee completes dkg and decrypts transactions.
-    /// 2. NextCommittee and UseCommittee events are triggered adding nodes to the network.
-    /// 3. Resharing is done in the background among new/old committee members.
-    /// 4. Old committee decrypts its last inclusion list triggering committee switch.
-    /// 5. New committee decrypts its first inclusion list using key from resharing.
-    async fn run_dkg_handover_decryption_phase_e2e() {
-        logging::init_logging();
-
-        let (mut com1_decrypters, com1_setup) = setup(
-            COM1,
-            &COM1_SIGNATURE_PRIVATE_KEY_STRINGS,
-            &COM1_DH_PRIVATE_KEY_STRINGS,
-            &COM1_DKG_PRIVATE_KEY_STRINGS,
-            None,
-        )
-        .await;
-        tracing::info!("COM1 decrypters and setup initialized");
-
-        let com1_round = RoundNumber::new(DECRYPTION_ROUND);
-
-        enqueue_all_dkg_bundles(&mut com1_decrypters, None).await;
-        tracing::info!("All DKG bundles enqueued for COM1");
-
-        for cell in com1_setup.dec_keys() {
-            cell.read().await;
-        }
-        tracing::info!("COM1 DKG keys generated and available");
-
-        let encryption_key = com1_setup.dec_keys()[0]
-            .get()
-            .expect("encryption key should be generated after DKG");
-
-        let com2_round = RoundNumber::new(DECRYPTION_ROUND + 1);
-        let (mut com2_decrypters, com2_setup) = setup(
-            COM2,
-            &COM2_SIGNATURE_PRIVATE_KEY_STRINGS,
-            &COM2_DH_PRIVATE_KEY_STRINGS,
-            &COM2_DKG_PRIVATE_KEY_STRINGS,
-            Some(com1_setup.clone()),
-        )
-        .await;
-        tracing::info!("COM2 decrypters and setup initialized with previous committee");
-
-        // trigger NextCommittee event at each decrypter in COM1
-        for decrypter in com1_decrypters.iter_mut() {
-            let mut sf_addr = com2_setup.addr_comm().clone();
-            sf_addr.update_addresses(|a| a.clone().with_port(a.port() - DECRYPTER_PORT_OFFSET));
-            decrypter
-                .next_committee(sf_addr, com2_setup.key_store().clone())
-                .await
-                .expect("next committee event succeeds");
-        }
-        tracing::info!("NextCommittee event triggered for all COM1 decrypters");
-
-        let priority_tx_message = b"Priority message for old committee";
-        let regular_tx_message = b"Non-priority message for old committee";
-
-        let encrypted_inclusion_list = create_encrypted_inclusion_list(
-            com1_round,
-            com1_setup.addr_comm().committee().clone(),
-            com1_setup.sig_keys(),
-            encryption_key.pubkey(),
-            priority_tx_message,
-            regular_tx_message,
-        );
-        tracing::info!("Encrypted inclusion list created for COM1 round");
-
-        // enqueues the same inclusion list to all nodes in COM1
-        for decrypter in com1_decrypters.iter_mut() {
-            decrypter
-                .enqueue(encrypted_inclusion_list.clone())
-                .await
-                .expect("Inclusion list should be enqueued successfully");
-        }
-        tracing::info!("Encrypted inclusion list enqueued to all COM1 decrypters");
-
-        let _ = collect_inclusion_lists(&mut com1_decrypters).await;
-        tracing::info!("Decrypted inclusion lists collected from COM1 decrypters");
-
-        // enqueue resharing bundles (for COM2) at each decrypter in COM1
-        enqueue_all_dkg_bundles(&mut com1_decrypters, Some(com2_setup.key_store().clone())).await;
-        tracing::info!("Resharing bundles enqueued for COM2 at all COM1 decrypters");
-
-        // trigger UseCommittee event for COM2
-        for decrypter in com2_decrypters.iter_mut() {
-            decrypter
-                .use_committee(Round::new(com2_round, COM2))
-                .await
-                .expect("use committee event succeeds");
-        }
-        tracing::info!("UseCommittee event triggered for COM2 decrypters");
-
-        let priority_tx_message = b"Priority message for new committee";
-        let regular_tx_message = b"Non-priority message for new committee";
-
-        let encrypted_inclusion_list = create_encrypted_inclusion_list(
-            com2_round,
-            com2_setup.addr_comm().committee().clone(),
-            com2_setup.sig_keys(),
-            encryption_key.pubkey(), // same encryption key
-            priority_tx_message,
-            regular_tx_message,
-        );
-        tracing::info!("Encrypted inclusion list created for COM2 round");
-
-        for new_decrypter in com2_decrypters.iter_mut() {
-            new_decrypter
-                .enqueue(encrypted_inclusion_list.clone())
-                .await
-                .expect("Inclusion list should be enqueued successfully");
-        }
-        tracing::info!("Encrypted inclusion list enqueued to all COM2 decrypters");
-
-        let decrypted_inclusion_lists = collect_inclusion_lists(&mut com2_decrypters).await;
-        tracing::info!("Decrypted inclusion lists collected from COM2 decrypters");
-
-        // Verify that all decrypted inclusion lists are correct
-        for decrypted_list in decrypted_inclusion_lists {
-            assert_eq!(
-                decrypted_list.round(),
-                com2_round,
-                "Decrypted list should have the expected round number"
-            );
-            assert_eq!(
-                decrypted_list.priority_bundles().len(),
-                1,
-                "Should have exactly one priority bundle"
-            );
-            assert_eq!(
-                decrypted_list.regular_bundles().len(),
-                1,
-                "Should have exactly one regular bundle"
-            );
-
-            let decrypted_priority_data = decrypted_list.priority_bundles()[0].bundle().data();
-            let decrypted_regular_data = decrypted_list.regular_bundles()[0].data();
-
-            assert_eq!(
-                decrypted_priority_data.to_vec(),
-                priority_tx_message.to_vec(),
-                "Decrypted priority transaction should match original"
-            );
-            assert_eq!(
-                decrypted_regular_data.to_vec(),
-                regular_tx_message.to_vec(),
-                "Decrypted regular transaction should match original"
-            );
-        }
     }
 
     /// Helper to run DKG and decryption phase E2E test.


### PR DESCRIPTION
This test is redundant since [PR #502][1] was merged and is often failing on CI. The reason for its failure is a race condition: sometimes not all nodes finish the resharing because of all the DKG requests they send, less than t + 1 are answered because peers are themselves in an incomplete DKG state or they are not in a running state. In any case they are not replying. The test is then ultimately hanging and timing out because it attempts to subsequently collect the inclusion list from all decrypters and some can not provide it.

The test would need to be fixed by allowing enough time for the decrypters of committee 1 to have their local DKG state ready before the members of committee 2 send their DKG requests. For production it is assumed that between scheduling the next committee and activating it, sufficient time is given.

Rather than fixing the test this PR removes it because -- as mentioned above -- it is redundant with another test.

<details>

<summary>Log excerpt from a failed test run</summary>

#### Node `hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh` receives only 1 DKG response

The committee consists of 5 members, so at least 2 responses are required, however every other node is either not in a running state or has an unfinished local DKG state.

```
2025-09-29T16:07:07.402479Z DEBUG timeboost_sequencer::decrypt: use committee node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh round=43@2
2025-09-29T16:07:07.414734Z DEBUG timeboost_sequencer::decrypt: enqueuing inclusion list node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh round=43 is_encrypted=true
2025-09-29T16:07:07.416425Z  INFO timeboost_sequencer::decrypt: use committee node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh round=43@2
2025-09-29T16:07:07.416443Z TRACE timeboost_sequencer::decrypt: requested DKG subset from current node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh round=43@2
2025-09-29T16:07:07.416455Z TRACE timeboost_sequencer::decrypt: received decrypt request node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh round=43
2025-09-29T16:07:07.911553Z TRACE timeboost_sequencer::decrypt: inbound message node=eiwaGN1NNaQdbnR9FsjKzUeLghQZsTLPjiL4RcQgfLoX from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh buf=2
2025-09-29T16:07:07.911584Z TRACE timeboost_sequencer::decrypt: received dkg request node=eiwaGN1NNaQdbnR9FsjKzUeLghQZsTLPjiL4RcQgfLoX from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:07.911594Z TRACE timeboost_sequencer::decrypt: local dkg incomplete node=eiwaGN1NNaQdbnR9FsjKzUeLghQZsTLPjiL4RcQgfLoX from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:07.913869Z TRACE timeboost_sequencer::decrypt: inbound message node=264jMLf85hfufg4ck97Hw2jiL6i1PHNoGUqxUqfhtssaE from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh buf=2
2025-09-29T16:07:07.913889Z TRACE timeboost_sequencer::decrypt: received dkg request node=264jMLf85hfufg4ck97Hw2jiL6i1PHNoGUqxUqfhtssaE from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:07.913897Z TRACE timeboost_sequencer::decrypt: local dkg incomplete node=264jMLf85hfufg4ck97Hw2jiL6i1PHNoGUqxUqfhtssaE from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:07.929523Z TRACE timeboost_sequencer::decrypt: inbound message node=vGKKAxVNfkSCdn8qh36nXdSZqyhPq644sQBoeZtcEUCR from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh buf=2
2025-09-29T16:07:07.929544Z TRACE timeboost_sequencer::decrypt: received dkg request node=vGKKAxVNfkSCdn8qh36nXdSZqyhPq644sQBoeZtcEUCR from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:07.929552Z TRACE timeboost_sequencer::decrypt: local dkg incomplete node=vGKKAxVNfkSCdn8qh36nXdSZqyhPq644sQBoeZtcEUCR from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:08.172512Z TRACE timeboost_sequencer::decrypt: inbound message node=tV66KknkDH47hRSNzwJtt7Q7EZtxVxQsNnUGoAJdDn6J from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh buf=2
2025-09-29T16:07:08.172532Z TRACE timeboost_sequencer::decrypt: received dkg request node=tV66KknkDH47hRSNzwJtt7Q7EZtxVxQsNnUGoAJdDn6J from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:08.172540Z TRACE timeboost_sequencer::decrypt: local dkg incomplete node=tV66KknkDH47hRSNzwJtt7Q7EZtxVxQsNnUGoAJdDn6J from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:08.249198Z TRACE timeboost_sequencer::decrypt: inbound message node=28NkSnRnefwgwoP5Xj1Xo21bAHpVQcYEYouTNyjyjH5V3 from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh buf=2
2025-09-29T16:07:08.249222Z TRACE timeboost_sequencer::decrypt: received dkg request node=28NkSnRnefwgwoP5Xj1Xo21bAHpVQcYEYouTNyjyjH5V3 from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:08.249335Z TRACE timeboost_sequencer::decrypt: inbound message node=fkTFXcMaEEzutGCreYpDb1B2h8hNMf6UMNRbt8dnhi2v from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh buf=2
2025-09-29T16:07:08.249346Z TRACE timeboost_sequencer::decrypt: received dkg request node=fkTFXcMaEEzutGCreYpDb1B2h8hNMf6UMNRbt8dnhi2v from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:08.249477Z TRACE timeboost_sequencer::decrypt: inbound message node=24hzR236zciuEFgtq7n2uHhoJBYkHDtd2s8LCCURLRfvU from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh buf=2
2025-09-29T16:07:08.249489Z TRACE timeboost_sequencer::decrypt: received dkg request node=24hzR236zciuEFgtq7n2uHhoJBYkHDtd2s8LCCURLRfvU from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:08.249601Z TRACE timeboost_sequencer::decrypt: inbound message node=ufyeJDrHnH7BuuBvwaonu86YYZKYW47VedCdZ2yqAanm from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh buf=2
2025-09-29T16:07:08.249611Z TRACE timeboost_sequencer::decrypt: received dkg request node=ufyeJDrHnH7BuuBvwaonu86YYZKYW47VedCdZ2yqAanm from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:08.249723Z TRACE timeboost_sequencer::decrypt: inbound message node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=ufyeJDrHnH7BuuBvwaonu86YYZKYW47VedCdZ2yqAanm buf=2
2025-09-29T16:07:08.249735Z TRACE timeboost_sequencer::decrypt: received dkg request node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=ufyeJDrHnH7BuuBvwaonu86YYZKYW47VedCdZ2yqAanm committee_id=2
2025-09-29T16:07:08.249748Z TRACE timeboost_sequencer::decrypt: not in a running state node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:08.249754Z TRACE timeboost_sequencer::decrypt: inbound message node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=24hzR236zciuEFgtq7n2uHhoJBYkHDtd2s8LCCURLRfvU buf=2
2025-09-29T16:07:08.249766Z TRACE timeboost_sequencer::decrypt: received dkg request node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=24hzR236zciuEFgtq7n2uHhoJBYkHDtd2s8LCCURLRfvU committee_id=2
2025-09-29T16:07:08.249779Z TRACE timeboost_sequencer::decrypt: not in a running state node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:08.249784Z TRACE timeboost_sequencer::decrypt: inbound message node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=fkTFXcMaEEzutGCreYpDb1B2h8hNMf6UMNRbt8dnhi2v buf=2
2025-09-29T16:07:08.249796Z TRACE timeboost_sequencer::decrypt: received dkg request node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=fkTFXcMaEEzutGCreYpDb1B2h8hNMf6UMNRbt8dnhi2v committee_id=2
2025-09-29T16:07:08.249810Z TRACE timeboost_sequencer::decrypt: not in a running state node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:08.249815Z TRACE timeboost_sequencer::decrypt: inbound message node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=28NkSnRnefwgwoP5Xj1Xo21bAHpVQcYEYouTNyjyjH5V3 buf=2
2025-09-29T16:07:08.249826Z TRACE timeboost_sequencer::decrypt: received dkg request node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=28NkSnRnefwgwoP5Xj1Xo21bAHpVQcYEYouTNyjyjH5V3 committee_id=2
2025-09-29T16:07:08.249840Z TRACE timeboost_sequencer::decrypt: not in a running state node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:08.448509Z TRACE timeboost_sequencer::decrypt: inbound message node=v6UBdLT5BvMhLW7iKv7M2xYeaW2SCAsnZ5PiSg6AaKfA from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh buf=2
2025-09-29T16:07:08.448526Z TRACE timeboost_sequencer::decrypt: received dkg request node=v6UBdLT5BvMhLW7iKv7M2xYeaW2SCAsnZ5PiSg6AaKfA from=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh committee_id=2
2025-09-29T16:07:08.463561Z TRACE timeboost_sequencer::decrypt: inbound message node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=v6UBdLT5BvMhLW7iKv7M2xYeaW2SCAsnZ5PiSg6AaKfA buf=38139
2025-09-29T16:07:08.544537Z TRACE timeboost_sequencer::decrypt: received dkg response node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=v6UBdLT5BvMhLW7iKv7M2xYeaW2SCAsnZ5PiSg6AaKfA committee=2
2025-09-29T16:07:08.818860Z TRACE timeboost_sequencer::decrypt: inbound message node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=ufyeJDrHnH7BuuBvwaonu86YYZKYW47VedCdZ2yqAanm buf=788
2025-09-29T16:07:08.819214Z TRACE timeboost_sequencer::decrypt: received batch message node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=ufyeJDrHnH7BuuBvwaonu86YYZKYW47VedCdZ2yqAanm round=43@2
2025-09-29T16:07:08.834439Z TRACE timeboost_sequencer::decrypt: inbound message node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=24hzR236zciuEFgtq7n2uHhoJBYkHDtd2s8LCCURLRfvU buf=788
2025-09-29T16:07:08.834750Z TRACE timeboost_sequencer::decrypt: received batch message node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=24hzR236zciuEFgtq7n2uHhoJBYkHDtd2s8LCCURLRfvU round=43@2
2025-09-29T16:07:08.836212Z TRACE timeboost_sequencer::decrypt: inbound message node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=fkTFXcMaEEzutGCreYpDb1B2h8hNMf6UMNRbt8dnhi2v buf=788
2025-09-29T16:07:08.836582Z TRACE timeboost_sequencer::decrypt: received batch message node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=fkTFXcMaEEzutGCreYpDb1B2h8hNMf6UMNRbt8dnhi2v round=43@2
2025-09-29T16:07:08.842125Z TRACE timeboost_sequencer::decrypt: inbound message node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=28NkSnRnefwgwoP5Xj1Xo21bAHpVQcYEYouTNyjyjH5V3 buf=788
2025-09-29T16:07:08.842501Z TRACE timeboost_sequencer::decrypt: received batch message node=hcUWjmK8pTz5AY39CDh1gVnVbaF4nNuEf2dQ5SWXZQyh from=28NkSnRnefwgwoP5Xj1Xo21bAHpVQcYEYouTNyjyjH5V3 round=43@2
```

</details>


[1]: https://github.com/EspressoSystems/timeboost/pull/502

CC: @akonring, @alxiong 