### PR TITLE
fix: add missing committee ID parameter to Committee::new calls in multisig benchmarks

### DIFF
--- a/multisig/tests/bench.rs
+++ b/multisig/tests/bench.rs
@@ -31,6 +31,7 @@ fn bench_vote_accumulator() {
     for n in SIZES {
         let mut keys = (0..n).map(|_| Keypair::generate()).collect::<Vec<_>>();
         let comm = Committee::new(
+            0u64,
             keys.iter()
                 .enumerate()
                 .map(|(i, kp)| (i as u8, kp.public_key())),
@@ -59,6 +60,7 @@ fn bench_certificate_is_valid() {
     for n in SIZES {
         let mut keys = (0..n).map(|_| Keypair::generate()).collect::<Vec<_>>();
         let comm = Committee::new(
+            0u64,
             keys.iter()
                 .enumerate()
                 .map(|(i, kp)| (i as u8, kp.public_key())),
@@ -74,6 +76,7 @@ fn bench_certificate_is_valid_par() {
     for n in SIZES {
         let mut keys = (0..n).map(|_| Keypair::generate()).collect::<Vec<_>>();
         let comm = Committee::new(
+            0u64,
             keys.iter()
                 .enumerate()
                 .map(|(i, kp)| (i as u8, kp.public_key())),
@@ -89,6 +92,7 @@ fn certificate_sizes() {
     for n in SIZES {
         let mut keys = (0..n).map(|_| Keypair::generate()).collect::<Vec<_>>();
         let comm = Committee::new(
+            0u64,
             keys.iter()
                 .enumerate()
                 .map(|(i, kp)| (i as u8, kp.public_key())),


### PR DESCRIPTION
The Committee::new function requires two parameters (committee ID and iterator), but the benchmark tests were only passing the iterator parameter. This caused compilation failures with E0061 and E0277 errors.

Added the missing committee ID parameter (0u64) to all Committee::new calls in the benchmark tests to fix the compilation errors.